### PR TITLE
Release: v1.1.0 - 일별 재고 관리 기능 오픈 및 도메인 구조 리팩토링

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/feature_request.md
+++ b/.github/PULL_REQUEST_TEMPLATE/feature_request.md
@@ -1,0 +1,27 @@
+---
+name: ✨ Feature Request (개발용)
+about: 새로운 기능 개발 또는 버그 수정 시 사용합니다.
+title: "[모듈명] Feat: 작업 내용 요약"
+labels: feature, backend
+assignees: ''
+---
+
+## 📄 개요
+- ex: 점주 상품 등록 API 구현
+- ex: 파일 업로드 유틸리티 추가
+
+## ✅ 작업 내용
+- [ ] 기능 개발 (API 구현)
+- [ ] 테스트 코드 작성 (Unit/Integration)
+- [ ] 리팩토링
+- [ ] 문서화 (Swagger 등)
+
+## 🔗 관련 이슈
+Closes #
+
+## 🧪 테스트 방법
+1. Postman Body 설정: ...
+2. 실행 결과 확인: ...
+
+## 📸 스크린샷 (선택)
+## ⚠️ 특이사항

--- a/.github/PULL_REQUEST_TEMPLATE/release_request.md
+++ b/.github/PULL_REQUEST_TEMPLATE/release_request.md
@@ -1,0 +1,29 @@
+---
+name: 🚀 Release Request (배포용)
+about: develop 내용을 main으로 배포할 때 사용합니다.
+title: "Release: v1.0.0 - 이번 배포의 핵심 주제"
+labels: release
+assignees: ''
+---
+
+## 📅 배포 개요
+- 버전: v1.0.0
+- 주요 내용: 점주 상품 등록 기능 오픈
+
+## 📦 변경 사항 (Changelog)
+
+### ✨ 신규 기능 (Features)
+-
+-
+
+### 🐛 버그 수정 (Fixes)
+-
+
+## ⚠️ 배포 전 체크리스트 (Operations)
+- [ ] DB 마이그레이션 (DDL) 실행이 필요한가요?
+- [ ] 환경변수(application.yml) 변경이 필요한가요?
+- [ ] 특정 디렉토리 권한 설정이 필요한가요?
+
+## 🔙 롤백 계획
+- ex: 이전 버전의 JAR로 재실행
+- ex: DB 트랜잭션 롤백

--- a/deal-api-owner/src/main/kotlin/com/chaltteok/owner/dailystock/controller/DailyStocksController.kt
+++ b/deal-api-owner/src/main/kotlin/com/chaltteok/owner/dailystock/controller/DailyStocksController.kt
@@ -1,0 +1,25 @@
+package com.chaltteok.owner.dailystock.controller
+
+import com.chaltteok.common.dto.ResponseDTO
+import com.chaltteok.owner.dailystock.dto.DailyStocksRegisterRequest
+import com.chaltteok.owner.dailystock.service.DailyStockService
+import jakarta.validation.Valid
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/v1/owner/daily-stocks")
+class DailyStocksController(
+    private val dailyStockService: DailyStockService
+) {
+    @PostMapping
+    fun createDailyStock(@Valid @RequestBody dailyStocksRegisterRequest: DailyStocksRegisterRequest)
+            : ResponseEntity<ResponseDTO<Any>> {
+        dailyStockService.registerDailyStock(dailyStocksRegisterRequest)
+        return ResponseEntity.status(HttpStatus.CREATED).body(ResponseDTO.success());
+    }
+}

--- a/deal-api-owner/src/main/kotlin/com/chaltteok/owner/dailystock/dto/DailyStocksRegisterRequest.kt
+++ b/deal-api-owner/src/main/kotlin/com/chaltteok/owner/dailystock/dto/DailyStocksRegisterRequest.kt
@@ -1,0 +1,38 @@
+package com.chaltteok.owner.dailystock.dto
+
+import com.chaltteok.core.domain.DailyStock
+import com.chaltteok.core.domain.ProductOption
+import com.chaltteok.owner.dailystock.enums.DailyStockStatusType
+import com.chaltteok.owner.dailystock.enums.DailyStockType
+import jakarta.validation.constraints.NotNull
+import java.time.LocalDate
+
+data class DailyStocksRegisterRequest(
+    @field:NotNull(message = "option id must not be null")
+    val optionId: String,
+
+    @field:NotNull(message = "sale date must not be null")
+    val saleDate: LocalDate,
+
+    val stockType: DailyStockType? = DailyStockType.NORMAL,
+
+    val salePrice: Int?,
+
+    @field:NotNull(message = "sale amount must not be null")
+    val totalQty: Int,
+
+    val status: String? = DailyStockStatusType.OPEN.name
+) {
+    fun toDailyStockEntity(productOption: ProductOption, salePrice: Int): DailyStock {
+        val finalStockType = (this.stockType ?: DailyStockType.NORMAL).name
+
+        return DailyStock(
+            optionId = productOption.id as Long,
+            saleDate = saleDate,
+            stockType = finalStockType,
+            salePrice = salePrice,
+            totalQty = totalQty,
+            currentQty = totalQty,
+        )
+    }
+}

--- a/deal-api-owner/src/main/kotlin/com/chaltteok/owner/dailystock/enums/DailyStockErrorCode.kt
+++ b/deal-api-owner/src/main/kotlin/com/chaltteok/owner/dailystock/enums/DailyStockErrorCode.kt
@@ -1,0 +1,13 @@
+package com.chaltteok.owner.dailystock.enums
+
+import com.chaltteok.common.enums.ErrorCode
+import org.springframework.http.HttpStatus
+
+enum class DailyStockErrorCode (
+    override val message: String,
+    override val status: HttpStatus
+):ErrorCode{
+    INVALID_ID("Invalid id",HttpStatus.BAD_REQUEST),
+    EVENT_PRICE_REQUIRED("I don't have a price",HttpStatus.BAD_REQUEST),
+    DUPLICATE_STOCK("It's already registered in stock",HttpStatus.BAD_REQUEST),
+}

--- a/deal-api-owner/src/main/kotlin/com/chaltteok/owner/dailystock/enums/DailyStockStatusType.kt
+++ b/deal-api-owner/src/main/kotlin/com/chaltteok/owner/dailystock/enums/DailyStockStatusType.kt
@@ -1,0 +1,5 @@
+package com.chaltteok.owner.dailystock.enums
+
+enum class DailyStockStatusType {
+    OPEN,CLOSE
+}

--- a/deal-api-owner/src/main/kotlin/com/chaltteok/owner/dailystock/enums/DailyStockType.kt
+++ b/deal-api-owner/src/main/kotlin/com/chaltteok/owner/dailystock/enums/DailyStockType.kt
@@ -1,0 +1,6 @@
+package com.chaltteok.owner.dailystock.enums
+
+enum class DailyStockType {
+    NORMAL,
+    EVENT
+}

--- a/deal-api-owner/src/main/kotlin/com/chaltteok/owner/dailystock/service/DailyStockService.kt
+++ b/deal-api-owner/src/main/kotlin/com/chaltteok/owner/dailystock/service/DailyStockService.kt
@@ -1,0 +1,7 @@
+package com.chaltteok.owner.dailystock.service
+
+import com.chaltteok.owner.dailystock.dto.DailyStocksRegisterRequest
+
+interface DailyStockService {
+    fun registerDailyStock(dailyStocksRegisterRequest: DailyStocksRegisterRequest)
+}

--- a/deal-api-owner/src/main/kotlin/com/chaltteok/owner/dailystock/service/DailyStockServiceImpl.kt
+++ b/deal-api-owner/src/main/kotlin/com/chaltteok/owner/dailystock/service/DailyStockServiceImpl.kt
@@ -1,0 +1,43 @@
+package com.chaltteok.owner.dailystock.service
+
+import com.chaltteok.common.exception.BusinessException
+import com.chaltteok.core.repository.dailystock.DailyStockRepository
+import com.chaltteok.core.repository.productoption.ProductOptionRepository
+import com.chaltteok.owner.dailystock.dto.DailyStocksRegisterRequest
+import com.chaltteok.owner.dailystock.enums.DailyStockErrorCode
+import com.chaltteok.owner.dailystock.enums.DailyStockType
+import io.github.oshai.kotlinlogging.KotlinLogging
+import org.springframework.dao.DataIntegrityViolationException
+import org.springframework.stereotype.Service
+
+private val logger = KotlinLogging.logger {}
+
+@Service
+class DailyStockServiceImpl(
+    private val dailyStockRepository: DailyStockRepository,
+    private val productOptionRepository: ProductOptionRepository,
+) : DailyStockService {
+    override fun registerDailyStock(dailyStocksRegisterRequest: DailyStocksRegisterRequest) {
+        val productOption =
+            productOptionRepository.findProductOptionByOptionUuid(dailyStocksRegisterRequest.optionId)
+                .orElseThrow { BusinessException(DailyStockErrorCode.INVALID_ID) }
+        logger.info { "product option select success" }
+
+        val finalPrice = dailyStocksRegisterRequest.salePrice ?: productOption.price
+        val stockType = dailyStocksRegisterRequest.stockType ?: DailyStockType.NORMAL
+        if (stockType == DailyStockType.EVENT && finalPrice == 0) {
+            logger.warn { "Event stock must have price > 0" }
+            throw BusinessException(DailyStockErrorCode.EVENT_PRICE_REQUIRED)
+        }
+
+        val stock = dailyStocksRegisterRequest.toDailyStockEntity(productOption, finalPrice)
+
+        try {
+            dailyStockRepository.save(stock)
+            logger.info { "daily stock registered successfully" }
+        } catch (e: DataIntegrityViolationException) {
+            logger.warn { "Duplicate stock registration attempt" }
+            throw BusinessException(DailyStockErrorCode.DUPLICATE_STOCK)
+        }
+    }
+}

--- a/deal-api-owner/src/main/kotlin/com/chaltteok/owner/product/controller/ProductController.kt
+++ b/deal-api-owner/src/main/kotlin/com/chaltteok/owner/product/controller/ProductController.kt
@@ -1,8 +1,8 @@
-package com.chaltteok.owner.controller
+package com.chaltteok.owner.product.controller
 
 import com.chaltteok.common.dto.ResponseDTO
-import com.chaltteok.owner.dto.ProductRegisterRequest
-import com.chaltteok.owner.service.ProductService
+import com.chaltteok.owner.product.dto.ProductRegisterRequest
+import com.chaltteok.owner.product.service.ProductService
 import jakarta.validation.Valid
 import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType

--- a/deal-api-owner/src/main/kotlin/com/chaltteok/owner/product/dto/ProductRegisterRequest.kt
+++ b/deal-api-owner/src/main/kotlin/com/chaltteok/owner/product/dto/ProductRegisterRequest.kt
@@ -1,7 +1,8 @@
-package com.chaltteok.owner.dto
+package com.chaltteok.owner.product.dto
 
 import com.chaltteok.core.domain.Product
 import com.chaltteok.core.domain.ProductOption
+import com.chaltteok.owner.product.enums.StockType
 import jakarta.validation.constraints.Min
 import jakarta.validation.constraints.NotNull
 
@@ -26,7 +27,7 @@ data class ProductRegisterRequest(
 
     fun toProductOption(product: Product): ProductOption {
         return ProductOption(
-            optionName = "기본옵션",
+            optionName = StockType.NORMAL.name,
             product = product,
             price = price,
         )

--- a/deal-api-owner/src/main/kotlin/com/chaltteok/owner/product/enums/ProductErrorCode.kt
+++ b/deal-api-owner/src/main/kotlin/com/chaltteok/owner/product/enums/ProductErrorCode.kt
@@ -1,9 +1,9 @@
-package com.chaltteok.owner.enums
+package com.chaltteok.owner.product.enums
 
 import com.chaltteok.common.enums.ErrorCode
 import org.springframework.http.HttpStatus
 
-enum class OwnerErrorCode(
+enum class ProductErrorCode(
     override val message: String,
     override val status: HttpStatus
 ): ErrorCode {

--- a/deal-api-owner/src/main/kotlin/com/chaltteok/owner/product/enums/StockType.kt
+++ b/deal-api-owner/src/main/kotlin/com/chaltteok/owner/product/enums/StockType.kt
@@ -1,0 +1,6 @@
+package com.chaltteok.owner.product.enums
+
+enum class StockType(name: String) {
+    EVENT("EVENT"),
+    NORMAL("NORMAL")
+}

--- a/deal-api-owner/src/main/kotlin/com/chaltteok/owner/product/service/ProductService.kt
+++ b/deal-api-owner/src/main/kotlin/com/chaltteok/owner/product/service/ProductService.kt
@@ -1,0 +1,8 @@
+package com.chaltteok.owner.product.service
+
+import com.chaltteok.owner.product.dto.ProductRegisterRequest
+import org.springframework.web.multipart.MultipartFile
+
+interface ProductService {
+    fun registerProduct(productRegisterRequest: ProductRegisterRequest, image: MultipartFile?)
+}

--- a/deal-api-owner/src/main/kotlin/com/chaltteok/owner/product/service/ProductServiceImpl.kt
+++ b/deal-api-owner/src/main/kotlin/com/chaltteok/owner/product/service/ProductServiceImpl.kt
@@ -1,10 +1,10 @@
-package com.chaltteok.owner.service
+package com.chaltteok.owner.product.service
 
 
 import com.chaltteok.core.repository.product.ProductRepository
 import com.chaltteok.core.repository.productoption.ProductOptionRepository
-import com.chaltteok.owner.dto.ProductRegisterRequest
-import com.chaltteok.owner.util.LocalFileUploader
+import com.chaltteok.owner.product.dto.ProductRegisterRequest
+import com.chaltteok.owner.product.util.LocalFileUploader
 import io.github.oshai.kotlinlogging.KotlinLogging
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional

--- a/deal-api-owner/src/main/kotlin/com/chaltteok/owner/product/util/LocalFileUploader.kt
+++ b/deal-api-owner/src/main/kotlin/com/chaltteok/owner/product/util/LocalFileUploader.kt
@@ -1,7 +1,7 @@
-package com.chaltteok.owner.util
+package com.chaltteok.owner.product.util
 
 import com.chaltteok.common.exception.BusinessException
-import com.chaltteok.owner.enums.OwnerErrorCode
+import com.chaltteok.owner.product.enums.ProductErrorCode
 import org.apache.tika.Tika
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Component
@@ -21,7 +21,7 @@ class LocalFileUploader(
 
         // 파일 존재 여부 확인
         if (file.isEmpty) {
-            throw BusinessException(OwnerErrorCode.FILE_EMPTY)
+            throw BusinessException(ProductErrorCode.FILE_EMPTY)
         }
 
         // mime type check
@@ -30,7 +30,7 @@ class LocalFileUploader(
                 tika.detect(inputStream)
             }
         } catch (e: Exception) {
-            throw BusinessException(OwnerErrorCode.FILE_UPLOAD_ERROR)
+            throw BusinessException(ProductErrorCode.FILE_UPLOAD_ERROR)
         }
 
 
@@ -38,7 +38,7 @@ class LocalFileUploader(
         val allowedMimeTypes = listOf("image/jpeg", "image/png")
 
         if (mimeType !in allowedMimeTypes) {
-            throw BusinessException(OwnerErrorCode.INVALID_FILE_TYPE)
+            throw BusinessException(ProductErrorCode.INVALID_FILE_TYPE)
         }
 
         val directory = Paths.get(uploadDir).toAbsolutePath().normalize()

--- a/deal-api-owner/src/main/kotlin/com/chaltteok/owner/service/ProductService.kt
+++ b/deal-api-owner/src/main/kotlin/com/chaltteok/owner/service/ProductService.kt
@@ -1,8 +1,0 @@
-package com.chaltteok.owner.service
-
-import com.chaltteok.owner.dto.ProductRegisterRequest
-import org.springframework.web.multipart.MultipartFile
-
-interface ProductService {
-    fun registerProduct(productRegisterRequest: ProductRegisterRequest,image: MultipartFile?)
-}

--- a/deal-core/src/main/kotlin/com/chaltteok/core/repository/productoption/ProductOptionRepository.kt
+++ b/deal-core/src/main/kotlin/com/chaltteok/core/repository/productoption/ProductOptionRepository.kt
@@ -2,7 +2,9 @@ package com.chaltteok.core.repository.productoption
 
 import com.chaltteok.core.domain.ProductOption
 import org.springframework.data.jpa.repository.JpaRepository
+import java.util.*
 
 
-interface ProductOptionRepository : JpaRepository<ProductOption, Long>,ProductOptionRepositoryCustom {
+interface ProductOptionRepository : JpaRepository<ProductOption, Long>, ProductOptionRepositoryCustom {
+    fun findProductOptionByOptionUuid(uuid: String): Optional<ProductOption>
 }


### PR DESCRIPTION
# 🚀 Release Note v1.1.0

## 📅 배포 개요
점주 서비스의 일별 재고(Daily Stock) 생성 및 관리 기능이 추가되었습니다.
또한, 프로젝트의 장기적인 유지보수를 위해 도메인 중심의 패키지 구조 리팩토링이 적용되었습니다.

## 📦 변경 사항 (Changelog)

### ✨ 신규 기능 (Features)
- 일별 재고 생성 API 오픈 (`POST /api/v1/owner/daily-stocks`)
    - 상품 옵션별 날짜 지정 재고 등록 기능
    - 가격 정책 적용: 판매가 미입력 시 원가 자동 적용, 이벤트 상품 0원 등록 방지
    - 안정성 강화: DB Unique Key(`uk_option_date_type`)를 활용한 중복 등록 방어 로직 적용

### 🛠 기술적 변경 사항 (Technical & Refactor)
- 디렉토리 구조 전면 개편:
    - 기존: 기능 중심 (`controller`, `service` 패키지에 모든 도메인이 섞임)
    - 변경: 도메인 중심 (`product`, `dailystock` 패키지 하위에 각 계층 위치)
- 동시성 처리 최적화: 애플리케이션 레벨의 `exists` 조회 쿼리를 제거하고 예외 처리 방식으로 변경하여 DB 부하 감소

## ⚠️ 배포 및 운영 체크리스트 (Operations)
1. 빌드 주의: 패키지 경로가 대거 변경되었습니다. CI/CD 파이프라인이나 로컬 환경에서 **Clean Build**가 권장됩니다.
2. DB 스키마: `daily_stock` 테이블 및 유니크 인덱스(`uk_option_date_type`)가 생성되어 있어야 합니다.
3. 권한 확인: 재고 생성 API는 `OWNER` 권한을 가진 토큰으로만 호출 가능합니다. (Security 설정 확인)

## 🔗 포함된 주요 PR
- #7 [Stock] Feat: 일별 재고 생성 기능 구현 및 디렉토리 구조 리팩토링 #3 