### PR TITLE
[Owner] Feat: 점주 로그인 API 구현

### DIFF
--- a/deal-api-owner/src/main/kotlin/com/chaltteok/owner/auth/controller/AuthController.kt
+++ b/deal-api-owner/src/main/kotlin/com/chaltteok/owner/auth/controller/AuthController.kt
@@ -1,0 +1,43 @@
+package com.chaltteok.owner.auth.controller
+
+import com.chaltteok.common.dto.ResponseDTO
+import com.chaltteok.common.exception.BusinessException
+import com.chaltteok.common.security.dto.LoginRequest
+import com.chaltteok.common.security.dto.ReissueRequest
+import com.chaltteok.common.security.dto.TokenDto
+import com.chaltteok.common.security.enums.AuthErrorCode
+import com.chaltteok.common.security.jwt.JwtTokenProvider
+import com.chaltteok.owner.auth.service.OwnerAuthService
+import jakarta.validation.Valid
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/v1/owner/auth")
+class AuthController(
+    private val ownerAuthService: OwnerAuthService,
+    private val jwtTokenProvider: JwtTokenProvider,
+) {
+    @PostMapping("/login")
+    fun login(@Valid @RequestBody request: LoginRequest): ResponseDTO<TokenDto> =
+        ResponseDTO.success(ownerAuthService.login(request.username, request.password))
+
+    @PostMapping("/reissue")
+    fun reissue(@Valid @RequestBody request: ReissueRequest): ResponseDTO<TokenDto> {
+        val token = request.refreshToken
+        if (!jwtTokenProvider.validateToken(token)) throw BusinessException(AuthErrorCode.INVALID_TOKEN)
+
+        val userId = jwtTokenProvider.getIdFromToken(token)
+        val role = jwtTokenProvider.getRoleFromToken(token)
+        val stored = jwtTokenProvider.getStoredRefreshToken(userId, role)
+            ?: throw BusinessException(AuthErrorCode.INVALID_TOKEN)
+
+        if (stored != token) throw BusinessException(AuthErrorCode.TOKEN_MISMATCH)
+
+        val newAccess = jwtTokenProvider.generateAccessToken(userId, role)
+        val newRefresh = jwtTokenProvider.generateRefreshToken(userId, role)
+        return ResponseDTO.success(TokenDto(newAccess, newRefresh, userId))
+    }
+}

--- a/deal-api-owner/src/main/kotlin/com/chaltteok/owner/auth/service/OwnerAuthService.kt
+++ b/deal-api-owner/src/main/kotlin/com/chaltteok/owner/auth/service/OwnerAuthService.kt
@@ -1,0 +1,7 @@
+package com.chaltteok.owner.auth.service
+
+import com.chaltteok.common.security.dto.TokenDto
+
+interface OwnerAuthService {
+    fun login(username: String, password: String): TokenDto
+}

--- a/deal-api-owner/src/main/kotlin/com/chaltteok/owner/auth/service/OwnerAuthServiceImpl.kt
+++ b/deal-api-owner/src/main/kotlin/com/chaltteok/owner/auth/service/OwnerAuthServiceImpl.kt
@@ -1,0 +1,37 @@
+package com.chaltteok.owner.auth.service
+
+import com.chaltteok.common.exception.BusinessException
+import com.chaltteok.common.security.dto.TokenDto
+import com.chaltteok.common.security.enums.AuthErrorCode
+import com.chaltteok.common.security.jwt.JwtTokenProvider
+import com.chaltteok.core.repository.owner.OwnerRepository
+import org.springframework.security.crypto.password.PasswordEncoder
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class OwnerAuthServiceImpl(
+    private val ownerRepository: OwnerRepository,
+    private val passwordEncoder: PasswordEncoder,
+    private val jwtTokenProvider: JwtTokenProvider,
+) : OwnerAuthService {
+
+    companion object {
+        private const val ROLE = "ROLE_OWNER"
+    }
+
+    @Transactional(readOnly = true)
+    override fun login(username: String, password: String): TokenDto {
+        val owner = ownerRepository.findByUsername(username)
+            .orElseThrow { BusinessException(AuthErrorCode.INVALID_CREDENTIALS) }
+
+        if (!passwordEncoder.matches(password, owner.password)) {
+            throw BusinessException(AuthErrorCode.INVALID_CREDENTIALS)
+        }
+
+        val userId = owner.id ?: throw BusinessException(AuthErrorCode.INVALID_CREDENTIALS)
+        val accessToken = jwtTokenProvider.generateAccessToken(userId, ROLE)
+        val refreshToken = jwtTokenProvider.generateRefreshToken(userId, ROLE)
+        return TokenDto(accessToken, refreshToken, userId)
+    }
+}

--- a/deal-api-owner/src/main/kotlin/com/chaltteok/owner/config/WebConfig.kt
+++ b/deal-api-owner/src/main/kotlin/com/chaltteok/owner/config/WebConfig.kt
@@ -1,0 +1,16 @@
+package com.chaltteok.owner.config
+
+import org.springframework.context.annotation.Configuration
+import org.springframework.web.servlet.config.annotation.CorsRegistry
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer
+
+@Configuration
+class WebConfig : WebMvcConfigurer {
+    override fun addCorsMappings(registry: CorsRegistry) {
+        registry.addMapping("/api/**")
+            .allowedOriginPatterns("*")
+            .allowedMethods("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS")
+            .allowedHeaders("*")
+            .allowCredentials(true)
+    }
+}

--- a/deal-common-api/build.gradle.kts
+++ b/deal-common-api/build.gradle.kts
@@ -14,6 +14,9 @@ tasks.getByName<Jar>("jar") {
 dependencies {
     api(project(":deal-core"))
     api("org.springframework.boot:spring-boot-starter-web")
-//    api("org.springframework.boot:spring-boot-starter-validation")
-//    api("org.springframework.boot:spring-boot-starter-security") // 인증/인가 공통
+    api("org.springframework.boot:spring-boot-starter-validation")
+    api("org.springframework.boot:spring-boot-starter-security")
+    api("io.jsonwebtoken:jjwt-api:0.12.6")
+    runtimeOnly("io.jsonwebtoken:jjwt-impl:0.12.6")
+    runtimeOnly("io.jsonwebtoken:jjwt-jackson:0.12.6")
 }

--- a/deal-common-api/src/main/kotlin/com/chaltteok/common/security/config/SecurityConfig.kt
+++ b/deal-common-api/src/main/kotlin/com/chaltteok/common/security/config/SecurityConfig.kt
@@ -1,0 +1,55 @@
+package com.chaltteok.common.security.config
+
+import com.chaltteok.common.security.jwt.JwtAuthenticationFilter
+import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.http.HttpMethod
+import org.springframework.security.config.Customizer.withDefaults
+import org.springframework.security.config.annotation.web.builders.HttpSecurity
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity
+import org.springframework.security.config.http.SessionCreationPolicy
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder
+import org.springframework.security.crypto.password.PasswordEncoder
+import org.springframework.security.web.SecurityFilterChain
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter
+
+@Configuration
+@EnableWebSecurity
+@ConditionalOnWebApplication(type = ConditionalOnWebApplication.Type.SERVLET)
+class SecurityConfig(
+    private val jwtAuthenticationFilter: JwtAuthenticationFilter,
+) {
+    @Bean
+    fun securityFilterChain(http: HttpSecurity): SecurityFilterChain {
+        http
+            .cors(withDefaults())
+            .csrf { it.disable() }
+            .sessionManagement { it.sessionCreationPolicy(SessionCreationPolicy.STATELESS) }
+            .authorizeHttpRequests { auth ->
+                auth
+                    .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
+                    .requestMatchers("/api/v1/owner/auth/**").permitAll()
+                    .requestMatchers("/api/v1/owner/**").hasAuthority("ROLE_OWNER")
+                    .anyRequest().authenticated()
+            }
+            .exceptionHandling { ex ->
+                ex.authenticationEntryPoint { _, response, _ ->
+                    response.status = 401
+                    response.contentType = "application/json;charset=UTF-8"
+                    response.writer.write("""{"result":"ERROR","errorCode":"A002","errorMessage":"유효하지 않은 토큰입니다."}""")
+                }
+                ex.accessDeniedHandler { _, response, _ ->
+                    response.status = 403
+                    response.contentType = "application/json;charset=UTF-8"
+                    response.writer.write("""{"result":"ERROR","errorCode":"A005","errorMessage":"접근 권한이 없습니다."}""")
+                }
+            }
+            .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter::class.java)
+
+        return http.build()
+    }
+
+    @Bean
+    fun passwordEncoder(): PasswordEncoder = BCryptPasswordEncoder()
+}

--- a/deal-common-api/src/main/kotlin/com/chaltteok/common/security/dto/LoginRequest.kt
+++ b/deal-common-api/src/main/kotlin/com/chaltteok/common/security/dto/LoginRequest.kt
@@ -1,0 +1,8 @@
+package com.chaltteok.common.security.dto
+
+import jakarta.validation.constraints.NotBlank
+
+data class LoginRequest(
+    @field:NotBlank val username: String,
+    @field:NotBlank val password: String,
+)

--- a/deal-common-api/src/main/kotlin/com/chaltteok/common/security/dto/ReissueRequest.kt
+++ b/deal-common-api/src/main/kotlin/com/chaltteok/common/security/dto/ReissueRequest.kt
@@ -1,0 +1,7 @@
+package com.chaltteok.common.security.dto
+
+import jakarta.validation.constraints.NotBlank
+
+data class ReissueRequest(
+    @field:NotBlank val refreshToken: String,
+)

--- a/deal-common-api/src/main/kotlin/com/chaltteok/common/security/dto/TokenDto.kt
+++ b/deal-common-api/src/main/kotlin/com/chaltteok/common/security/dto/TokenDto.kt
@@ -1,0 +1,7 @@
+package com.chaltteok.common.security.dto
+
+data class TokenDto(
+    val accessToken: String,
+    val refreshToken: String,
+    val userId: Long,
+)

--- a/deal-common-api/src/main/kotlin/com/chaltteok/common/security/enums/AuthErrorCode.kt
+++ b/deal-common-api/src/main/kotlin/com/chaltteok/common/security/enums/AuthErrorCode.kt
@@ -1,0 +1,14 @@
+package com.chaltteok.common.security.enums
+
+import com.chaltteok.common.enums.ErrorCode
+import org.springframework.http.HttpStatus
+
+enum class AuthErrorCode(
+    override val status: HttpStatus,
+    override val message: String,
+) : ErrorCode {
+    INVALID_CREDENTIALS(HttpStatus.UNAUTHORIZED, "아이디 또는 비밀번호가 올바르지 않습니다."),
+    INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰입니다."),
+    TOKEN_MISMATCH(HttpStatus.UNAUTHORIZED, "토큰 정보가 일치하지 않습니다."),
+    EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "만료된 토큰입니다."),
+}

--- a/deal-common-api/src/main/kotlin/com/chaltteok/common/security/jwt/JwtAuthenticationFilter.kt
+++ b/deal-common-api/src/main/kotlin/com/chaltteok/common/security/jwt/JwtAuthenticationFilter.kt
@@ -1,0 +1,39 @@
+package com.chaltteok.common.security.jwt
+
+import jakarta.servlet.FilterChain
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
+import org.springframework.security.core.authority.SimpleGrantedAuthority
+import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.stereotype.Component
+import org.springframework.web.filter.OncePerRequestFilter
+
+@Component
+class JwtAuthenticationFilter(
+    private val jwtTokenProvider: JwtTokenProvider,
+) : OncePerRequestFilter() {
+
+    override fun doFilterInternal(
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+        filterChain: FilterChain,
+    ) {
+        val token = resolveToken(request)
+        if (token != null && jwtTokenProvider.validateToken(token)) {
+            val userId = jwtTokenProvider.getIdFromToken(token)
+            val role = jwtTokenProvider.getRoleFromToken(token)
+            val auth = UsernamePasswordAuthenticationToken(
+                userId, null, listOf(SimpleGrantedAuthority(role))
+            )
+            SecurityContextHolder.getContext().authentication = auth
+            request.setAttribute("X-User-Id", userId)
+        }
+        filterChain.doFilter(request, response)
+    }
+
+    private fun resolveToken(request: HttpServletRequest): String? {
+        val bearer = request.getHeader("Authorization") ?: return null
+        return if (bearer.startsWith("Bearer ")) bearer.substring(7) else null
+    }
+}

--- a/deal-common-api/src/main/kotlin/com/chaltteok/common/security/jwt/JwtTokenProvider.kt
+++ b/deal-common-api/src/main/kotlin/com/chaltteok/common/security/jwt/JwtTokenProvider.kt
@@ -1,0 +1,69 @@
+package com.chaltteok.common.security.jwt
+
+import io.jsonwebtoken.Claims
+import io.jsonwebtoken.JwtException
+import io.jsonwebtoken.Jwts
+import io.jsonwebtoken.security.Keys
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.data.redis.core.StringRedisTemplate
+import org.springframework.stereotype.Component
+import java.util.Date
+import java.util.concurrent.TimeUnit
+import javax.crypto.SecretKey
+
+@Component
+class JwtTokenProvider(
+    @Value("\${jwt.secret}") private val secret: String,
+    private val redisTemplate: StringRedisTemplate,
+) {
+    private val key: SecretKey by lazy {
+        Keys.hmacShaKeyFor(secret.toByteArray(Charsets.UTF_8))
+    }
+
+    companion object {
+        private const val ACCESS_TOKEN_VALIDITY_MS = 30 * 60 * 1000L       // 30분
+        private const val REFRESH_TOKEN_VALIDITY_MS = 7 * 24 * 60 * 60 * 1000L // 7일
+        private const val ROLE_CLAIM = "role"
+    }
+
+    fun generateAccessToken(userId: Long, role: String): String {
+        val now = Date()
+        return Jwts.builder()
+            .subject(userId.toString())
+            .claim(ROLE_CLAIM, role)
+            .issuedAt(now)
+            .expiration(Date(now.time + ACCESS_TOKEN_VALIDITY_MS))
+            .signWith(key)
+            .compact()
+    }
+
+    fun generateRefreshToken(userId: Long, role: String): String {
+        val now = Date()
+        val token = Jwts.builder()
+            .subject(userId.toString())
+            .claim(ROLE_CLAIM, role)
+            .issuedAt(now)
+            .expiration(Date(now.time + REFRESH_TOKEN_VALIDITY_MS))
+            .signWith(key)
+            .compact()
+        redisTemplate.opsForValue().set(
+            refreshKey(userId, role), token,
+            REFRESH_TOKEN_VALIDITY_MS, TimeUnit.MILLISECONDS
+        )
+        return token
+    }
+
+    fun validateToken(token: String): Boolean = runCatching { parseClaims(token) }.isSuccess
+
+    fun getIdFromToken(token: String): Long = parseClaims(token).subject.toLong()
+
+    fun getRoleFromToken(token: String): String = parseClaims(token)[ROLE_CLAIM, String::class.java]
+
+    fun getStoredRefreshToken(userId: Long, role: String): String? =
+        redisTemplate.opsForValue().get(refreshKey(userId, role))
+
+    private fun refreshKey(userId: Long, role: String) = "refresh:$role:$userId"
+
+    private fun parseClaims(token: String): Claims =
+        Jwts.parser().verifyWith(key).build().parseSignedClaims(token).payload
+}

--- a/deal-core/src/main/kotlin/com/chaltteok/core/repository/owner/OwnerRepository.kt
+++ b/deal-core/src/main/kotlin/com/chaltteok/core/repository/owner/OwnerRepository.kt
@@ -2,6 +2,8 @@ package com.chaltteok.core.repository.owner
 
 import com.chaltteok.core.domain.Owner
 import org.springframework.data.jpa.repository.JpaRepository
+import java.util.Optional
 
 interface OwnerRepository : JpaRepository<Owner, Long>, OwnerRepositoryCustom {
+    fun findByUsername(username: String): Optional<Owner>
 }


### PR DESCRIPTION
## 📄 개요
- 점주 로그인/토큰 재발급 API 구현
- JWT 인증 인프라(Spring Security + jjwt + Redis) 공통 모듈 구축

## ✅ 작업 내용
- [x] 기능 개발 (API 구현)
- [ ] 테스트 코드 작성 (Unit/Integration)
- [ ] 리팩토링
- [ ] 문서화 (Swagger 등)

## 🔗 관련 이슈
Closes #

## 🧪 테스트 방법
```
POST /api/v1/owner/auth/login
Content-Type: application/json

{ "username": "owner01", "password": "password123" }
```
응답: `{ "accessToken": "...", "refreshToken": "...", "userId": 1 }`

```
POST /api/v1/owner/auth/reissue
Content-Type: application/json

{ "refreshToken": "..." }
```

## 📸 스크린샷 (선택)

## ⚠️ 특이사항
- `deal-common-api`에 Spring Security + jjwt 의존성 추가 (하위 모듈에 자동 전파)
- Redis에 refresh token 저장 (`refresh:ROLE_OWNER:{userId}` 키)
- Access token 유효기간: 30분 / Refresh token: 7일
- SecurityConfig: `/api/v1/owner/auth/**` permitAll, 그 외 `/api/v1/owner/**`는 `ROLE_OWNER` 필요