### PR TITLE
feat: 도메인 엔티티를 deal-consumer 기대 구조로 정렬

### DIFF
--- a/deal-api-owner/src/main/kotlin/com/chaltteok/owner/dailystock/dto/DailyStocksRegisterRequest.kt
+++ b/deal-api-owner/src/main/kotlin/com/chaltteok/owner/dailystock/dto/DailyStocksRegisterRequest.kt
@@ -1,8 +1,7 @@
 package com.chaltteok.owner.dailystock.dto
 
 import com.chaltteok.core.domain.DailyStock
-import com.chaltteok.core.domain.ProductOption
-import com.chaltteok.owner.dailystock.enums.DailyStockStatusType
+import com.chaltteok.core.domain.Product
 import com.chaltteok.owner.dailystock.enums.DailyStockType
 import jakarta.validation.constraints.NotNull
 import java.time.LocalDate
@@ -20,19 +19,17 @@ data class DailyStocksRegisterRequest(
 
     @field:NotNull(message = "sale amount must not be null")
     val totalQty: Int,
-
-    val status: String? = DailyStockStatusType.OPEN.name
 ) {
-    fun toDailyStockEntity(productOption: ProductOption, salePrice: Int): DailyStock {
+    fun toDailyStockEntity(product: Product, salePrice: Int): DailyStock {
         val finalStockType = (this.stockType ?: DailyStockType.NORMAL).name
 
         return DailyStock(
-            optionId = productOption.id as Long,
+            product = product,
             saleDate = saleDate,
             stockType = finalStockType,
             salePrice = salePrice,
             totalQty = totalQty,
-            currentQty = totalQty,
+            remainStock = totalQty,
         )
     }
 }

--- a/deal-api-owner/src/main/kotlin/com/chaltteok/owner/dailystock/service/DailyStockServiceImpl.kt
+++ b/deal-api-owner/src/main/kotlin/com/chaltteok/owner/dailystock/service/DailyStockServiceImpl.kt
@@ -30,7 +30,7 @@ class DailyStockServiceImpl(
             throw BusinessException(DailyStockErrorCode.EVENT_PRICE_REQUIRED)
         }
 
-        val stock = dailyStocksRegisterRequest.toDailyStockEntity(productOption, finalPrice)
+        val stock = dailyStocksRegisterRequest.toDailyStockEntity(productOption.product, finalPrice)
 
         try {
             dailyStockRepository.save(stock)

--- a/deal-core/src/main/kotlin/com/chaltteok/core/domain/DailyStock.kt
+++ b/deal-core/src/main/kotlin/com/chaltteok/core/domain/DailyStock.kt
@@ -13,12 +13,13 @@ import java.util.*
     ],
     uniqueConstraints = [
         UniqueConstraint(name = "uk_stock_uuid", columnNames = ["stock_uuid"]),
-        UniqueConstraint(name = "uk_option_date_type", columnNames = ["option_id", "sale_date", "stock_type"])
+        UniqueConstraint(name = "uk_product_date_type", columnNames = ["product_id", "sale_date", "stock_type"])
     ]
 )
 class DailyStock(
-    @Column(name = "option_id", nullable = false)
-    val optionId: Long,
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "product_id", nullable = false)
+    val product: Product,
 
     @Column(name = "sale_date", nullable = false)
     val saleDate: LocalDate,
@@ -32,18 +33,18 @@ class DailyStock(
     @Column(name = "total_qty", nullable = false)
     val totalQty: Int,
 
-    @Column(name = "current_qty", nullable = false)
-    var currentQty: Int,
+    @Column(name = "remain_stock", nullable = false)
+    var remainStock: Int,
 
     @Version
     val version: Long = 0L,
 
+    @Enumerated(EnumType.STRING)
     @Column(length = 20)
-    var status: String = "OPEN",
+    var status: DailyStockStatus = DailyStockStatus.OPEN,
 
     @Column(name = "created_at", nullable = false, updatable = false)
     val createdAt: LocalDateTime = LocalDateTime.now()
-
 
 ) {
     @Id

--- a/deal-core/src/main/kotlin/com/chaltteok/core/domain/DailyStockStatus.kt
+++ b/deal-core/src/main/kotlin/com/chaltteok/core/domain/DailyStockStatus.kt
@@ -1,0 +1,5 @@
+package com.chaltteok.core.domain
+
+enum class DailyStockStatus {
+    OPEN, SOLD_OUT, CLOSED
+}

--- a/deal-core/src/main/kotlin/com/chaltteok/core/domain/EventHistory.kt
+++ b/deal-core/src/main/kotlin/com/chaltteok/core/domain/EventHistory.kt
@@ -9,14 +9,17 @@ import java.time.LocalDateTime
     uniqueConstraints = [UniqueConstraint(name = "uk_one_event_per_user", columnNames = ["user_id", "stock_id"])]
 )
 class EventHistory(
-    @Column(name = "user_id", nullable = false)
-    val userId: Long,
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    val user: User,
 
-    @Column(name = "stock_id", nullable = false)
-    val stockId: Long,
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "stock_id", nullable = false)
+    val dailyStock: DailyStock,
 
-    @Column(name = "order_id", nullable = false)
-    val orderId: Long,
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "order_id")
+    var order: Order? = null,
 
     @Column(name = "created_at", nullable = false, updatable = false)
     val createdAt: LocalDateTime = LocalDateTime.now()

--- a/deal-core/src/main/kotlin/com/chaltteok/core/domain/Order.kt
+++ b/deal-core/src/main/kotlin/com/chaltteok/core/domain/Order.kt
@@ -15,23 +15,25 @@ import java.util.*
     ]
 )
 class Order(
-    @Column(name = "user_id", nullable = false)
-    val userId: Long,
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    val user: User,
 
     @Column(name = "total_price", nullable = false)
     val totalPrice: Int,
 
+    @Enumerated(EnumType.STRING)
     @Column(name = "status", length = 20)
-    var status: String = "PENDING",
+    var status: OrderStatus = OrderStatus.PENDING,
 
     @Column(name = "receiver_name", nullable = false, length = 50)
-    val receiverName: String,
+    val receiverName: String = "",
 
     @Column(name = "receiver_phone", nullable = false, length = 20)
-    val receiverPhone: String,
+    val receiverPhone: String = "",
 
     @Column(name = "address", nullable = false, length = 255)
-    val address: String,
+    val address: String = "",
 
     @Column(name = "ordered_at", nullable = false, updatable = false)
     val orderedAt: LocalDateTime = LocalDateTime.now(),

--- a/deal-core/src/main/kotlin/com/chaltteok/core/domain/OrderItem.kt
+++ b/deal-core/src/main/kotlin/com/chaltteok/core/domain/OrderItem.kt
@@ -1,7 +1,6 @@
 package com.chaltteok.core.domain
 
 import jakarta.persistence.*
-import java.math.BigDecimal
 import java.util.*
 
 @Entity
@@ -15,14 +14,14 @@ class OrderItem(
     val order: Order? = null,
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "stock_id", nullable = false, referencedColumnName = "stock_id")
-    val stock: DailyStock,
+    @JoinColumn(name = "product_id", nullable = false)
+    val product: Product,
 
     @Column(name = "quantity", nullable = false)
     val quantity: Int,
 
-    @Column(name = "price_per_item", nullable = false)
-    val pricePerItem: BigDecimal
+    @Column(name = "price", nullable = false)
+    val price: Int
 ) {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/deal-core/src/main/kotlin/com/chaltteok/core/domain/OrderStatus.kt
+++ b/deal-core/src/main/kotlin/com/chaltteok/core/domain/OrderStatus.kt
@@ -1,0 +1,5 @@
+package com.chaltteok.core.domain
+
+enum class OrderStatus {
+    PENDING, COMPLETED, CANCELLED, FAILED
+}

--- a/deal-core/src/main/kotlin/com/chaltteok/core/domain/Product.kt
+++ b/deal-core/src/main/kotlin/com/chaltteok/core/domain/Product.kt
@@ -20,6 +20,9 @@ class Product(
     @Column(name = "image_url", length = 255)
     var imageUrl: String? = null,
 
+    @Column(name = "price", nullable = false)
+    var price: Int = 0,
+
     @Column(name = "is_active")
     var isActive: Boolean = true
 

--- a/deal-core/src/main/kotlin/com/chaltteok/core/repository/eventhistory/EventHistoryRepository.kt
+++ b/deal-core/src/main/kotlin/com/chaltteok/core/repository/eventhistory/EventHistoryRepository.kt
@@ -1,7 +1,10 @@
 package com.chaltteok.core.repository.eventhistory
 
+import com.chaltteok.core.domain.DailyStock
 import com.chaltteok.core.domain.EventHistory
+import com.chaltteok.core.domain.User
 import org.springframework.data.jpa.repository.JpaRepository
 
 interface EventHistoryRepository : JpaRepository<EventHistory, Long>, EventHistoryRepositoryCustom {
+    fun findByUserAndDailyStock(user: User, dailyStock: DailyStock): EventHistory?
 }


### PR DESCRIPTION
## Summary
- `OrderStatus`, `DailyStockStatus` enum 추가
- `Order`: `userId: Long` → `user: User` (ManyToOne), `status: String` → `status: OrderStatus`
- `DailyStock`: `optionId: Long` → `product: Product` (ManyToOne), `currentQty` → `remainStock`, `status` 타입 `DailyStockStatus`로 변경
- `OrderItem`: `stock: DailyStock` → `product: Product`, `pricePerItem: BigDecimal` → `price: Int`
- `EventHistory`: 원시 ID 필드 → 엔티티 참조 (`user`, `dailyStock`, `order?` nullable)
- `EventHistoryRepository`: `findByUserAndDailyStock` 메서드 추가
- `Product`: `price: Int` 필드 추가
- `DailyStocksRegisterRequest` / `DailyStockServiceImpl`: `productOption.product` 전달 방식으로 업데이트

## Test plan
- [ ] `deal-core:compileKotlin` 빌드 성공 확인
- [ ] `deal-consumer:compileKotlin` 빌드 성공 확인
- [ ] `deal-api-owner:compileKotlin` 빌드 성공 확인
- [ ] DDL 스크립트 기반 DB 재생성 후 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)