### PR TITLE
refactor: 도메인 enum 타입을 domain/enums 패키지로 분리

### DIFF
--- a/deal-api-user/src/main/kotlin/com/chaltteok/user/checkout/service/CheckoutServiceImpl.kt
+++ b/deal-api-user/src/main/kotlin/com/chaltteok/user/checkout/service/CheckoutServiceImpl.kt
@@ -3,9 +3,9 @@ package com.chaltteok.user.checkout.service
 import com.chaltteok.common.exception.BusinessException
 import com.chaltteok.core.domain.Order
 import com.chaltteok.core.domain.OrderItem
-import com.chaltteok.core.domain.OrderStatus
+import com.chaltteok.core.domain.enums.OrderStatus
 import com.chaltteok.core.domain.Payment
-import com.chaltteok.core.domain.PaymentStatus
+import com.chaltteok.core.domain.enums.PaymentStatus
 import com.chaltteok.core.repository.order.OrderRepository
 import com.chaltteok.core.repository.orderitem.OrderItemRepository
 import com.chaltteok.core.repository.payment.PaymentRepository

--- a/deal-api-user/src/main/kotlin/com/chaltteok/user/dailystock/service/DailyStockQueryServiceImpl.kt
+++ b/deal-api-user/src/main/kotlin/com/chaltteok/user/dailystock/service/DailyStockQueryServiceImpl.kt
@@ -1,6 +1,6 @@
 package com.chaltteok.user.dailystock.service
 
-import com.chaltteok.core.domain.DailyStockStatus
+import com.chaltteok.core.domain.enums.DailyStockStatus
 import com.chaltteok.core.repository.dailystock.DailyStockRepository
 import com.chaltteok.core.repository.eventhistory.EventHistoryRepository
 import com.chaltteok.user.dailystock.dto.OpenDailyStockResponse

--- a/deal-api-user/src/main/kotlin/com/chaltteok/user/order/service/OrderServiceImpl.kt
+++ b/deal-api-user/src/main/kotlin/com/chaltteok/user/order/service/OrderServiceImpl.kt
@@ -1,7 +1,7 @@
 package com.chaltteok.user.order.service
 
 import com.chaltteok.common.exception.BusinessException
-import com.chaltteok.core.domain.DailyStockStatus
+import com.chaltteok.core.domain.enums.DailyStockStatus
 import com.chaltteok.core.repository.dailystock.DailyStockRepository
 import com.chaltteok.core.repository.eventhistory.EventHistoryRepository
 import com.chaltteok.core.repository.user.UserRepository

--- a/deal-consumer/src/main/kotlin/com/chaltteok/consumer/order/service/OrderProcessServiceImpl.kt
+++ b/deal-consumer/src/main/kotlin/com/chaltteok/consumer/order/service/OrderProcessServiceImpl.kt
@@ -4,7 +4,7 @@ import com.chaltteok.consumer.order.service.helper.EventHistoryDuplicateChecker
 import com.chaltteok.consumer.order.service.helper.StockDecrementHelper
 import com.chaltteok.core.domain.Order
 import com.chaltteok.core.domain.OrderItem
-import com.chaltteok.core.domain.OrderStatus
+import com.chaltteok.core.domain.enums.OrderStatus
 import com.chaltteok.core.repository.dailystock.DailyStockRepository
 import com.chaltteok.core.repository.eventhistory.EventHistoryRepository
 import com.chaltteok.core.repository.order.OrderRepository

--- a/deal-consumer/src/main/kotlin/com/chaltteok/consumer/order/service/helper/StockDecrementHelper.kt
+++ b/deal-consumer/src/main/kotlin/com/chaltteok/consumer/order/service/helper/StockDecrementHelper.kt
@@ -1,6 +1,6 @@
 package com.chaltteok.consumer.order.service.helper
 
-import com.chaltteok.core.domain.DailyStockStatus
+import com.chaltteok.core.domain.enums.DailyStockStatus
 import com.chaltteok.core.repository.dailystock.DailyStockRepository
 import org.springframework.stereotype.Component
 import org.springframework.transaction.annotation.Propagation

--- a/deal-core/src/main/kotlin/com/chaltteok/core/domain/DailyStock.kt
+++ b/deal-core/src/main/kotlin/com/chaltteok/core/domain/DailyStock.kt
@@ -1,5 +1,6 @@
 package com.chaltteok.core.domain
 
+import com.chaltteok.core.domain.enums.DailyStockStatus
 import jakarta.persistence.*
 import java.time.LocalDate
 import java.time.LocalDateTime

--- a/deal-core/src/main/kotlin/com/chaltteok/core/domain/Order.kt
+++ b/deal-core/src/main/kotlin/com/chaltteok/core/domain/Order.kt
@@ -1,5 +1,6 @@
 package com.chaltteok.core.domain
 
+import com.chaltteok.core.domain.enums.OrderStatus
 import jakarta.persistence.*
 import java.time.LocalDateTime
 import java.util.*

--- a/deal-core/src/main/kotlin/com/chaltteok/core/domain/Payment.kt
+++ b/deal-core/src/main/kotlin/com/chaltteok/core/domain/Payment.kt
@@ -1,5 +1,6 @@
 package com.chaltteok.core.domain
 
+import com.chaltteok.core.domain.enums.PaymentStatus
 import jakarta.persistence.*
 import java.time.LocalDateTime
 import java.util.*

--- a/deal-core/src/main/kotlin/com/chaltteok/core/domain/enums/DailyStockStatus.kt
+++ b/deal-core/src/main/kotlin/com/chaltteok/core/domain/enums/DailyStockStatus.kt
@@ -1,4 +1,4 @@
-package com.chaltteok.core.domain
+package com.chaltteok.core.domain.enums
 
 enum class DailyStockStatus {
     OPEN, SOLD_OUT, CLOSED

--- a/deal-core/src/main/kotlin/com/chaltteok/core/domain/enums/OrderStatus.kt
+++ b/deal-core/src/main/kotlin/com/chaltteok/core/domain/enums/OrderStatus.kt
@@ -1,4 +1,4 @@
-package com.chaltteok.core.domain
+package com.chaltteok.core.domain.enums
 
 enum class OrderStatus {
     PENDING, COMPLETED, CANCELLED, FAILED

--- a/deal-core/src/main/kotlin/com/chaltteok/core/domain/enums/PaymentStatus.kt
+++ b/deal-core/src/main/kotlin/com/chaltteok/core/domain/enums/PaymentStatus.kt
@@ -1,4 +1,4 @@
-package com.chaltteok.core.domain
+package com.chaltteok.core.domain.enums
 
 enum class PaymentStatus {
     READY, SUCCESS, FAILED, CANCELLED

--- a/deal-core/src/main/kotlin/com/chaltteok/core/repository/dailystock/DailyStockRepository.kt
+++ b/deal-core/src/main/kotlin/com/chaltteok/core/repository/dailystock/DailyStockRepository.kt
@@ -1,7 +1,7 @@
 package com.chaltteok.core.repository.dailystock
 
 import com.chaltteok.core.domain.DailyStock
-import com.chaltteok.core.domain.DailyStockStatus
+import com.chaltteok.core.domain.enums.DailyStockStatus
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
 


### PR DESCRIPTION
## Summary
- `DailyStockStatus`, `OrderStatus`, `PaymentStatus` enum을 `com.chaltteok.core.domain` → `com.chaltteok.core.domain.enums`로 분리
- 참조하는 모든 모듈 import 일괄 업데이트

## 변경 파일
| 변경 유형 | 파일 |
|---|---|
| 이동 (패키지 변경) | `DailyStockStatus`, `OrderStatus`, `PaymentStatus` |
| import 수정 | `DailyStock`, `Order`, `Payment` (deal-core 엔티티) |
| import 수정 | `DailyStockRepository` (deal-core) |
| import 수정 | `OrderProcessServiceImpl`, `StockDecrementHelper` (deal-consumer) |
| import 수정 | `DailyStockQueryServiceImpl`, `OrderServiceImpl`, `CheckoutServiceImpl` (deal-api-user) |

## Test plan
- [ ] 전체 모듈 `compileKotlin` 성공 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)