### PR TITLE
fix: 유저 홈 공개 접근 및 게이트웨이 CORS 포트 추가

### DIFF
--- a/deal-common-api/src/main/kotlin/com/chaltteok/common/security/config/SecurityConfig.kt
+++ b/deal-common-api/src/main/kotlin/com/chaltteok/common/security/config/SecurityConfig.kt
@@ -29,8 +29,13 @@ class SecurityConfig(
             .authorizeHttpRequests { auth ->
                 auth
                     .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
+                    // owner
                     .requestMatchers("/api/v1/owner/auth/**").permitAll()
                     .requestMatchers("/api/v1/owner/**").hasAuthority("ROLE_OWNER")
+                    // user — 로그인 없이 접근 가능한 공개 엔드포인트
+                    .requestMatchers("/api/v1/user/auth/**").permitAll()
+                    .requestMatchers(HttpMethod.GET, "/api/v1/user/daily-stocks/open").permitAll()
+                    .requestMatchers(HttpMethod.GET, "/api/v1/user/products/**").permitAll()
                     .anyRequest().authenticated()
             }
             .exceptionHandling { ex ->

--- a/deal-gateway/src/main/resources/application.yml
+++ b/deal-gateway/src/main/resources/application.yml
@@ -17,6 +17,7 @@ spring:
           '[/**]':
             allowedOrigins:
               - "http://localhost:3000"
+              - "http://localhost:3001"
             allowedMethods:
               - GET
               - POST


### PR DESCRIPTION
## Summary
- 유저 메인 홈 API를 비로그인 상태에서도 접근 가능하도록 SecurityConfig 수정
- deal-gateway CORS 허용 오리진에 owner 앱 포트(3001) 추가

## 변경 내용
| 파일 | 내용 |
|---|---|
| `SecurityConfig.kt` | `GET /api/v1/user/daily-stocks/open`, `GET /api/v1/user/products/**`, `/api/v1/user/auth/**` → permitAll |
| `deal-gateway/application.yml` | CORS allowedOrigins에 `http://localhost:3001` 추가 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)