### PR TITLE
feat: 점주 앱 매출 대시보드 분석 기능 구현

### DIFF
--- a/deal-api-owner/src/main/kotlin/com/chaltteok/owner/dashboard/controller/DashboardController.kt
+++ b/deal-api-owner/src/main/kotlin/com/chaltteok/owner/dashboard/controller/DashboardController.kt
@@ -1,0 +1,39 @@
+package com.chaltteok.owner.dashboard.controller
+
+import com.chaltteok.common.dto.ResponseDTO
+import com.chaltteok.owner.dashboard.enums.DashboardPeriod
+import com.chaltteok.owner.dashboard.service.DashboardService
+import org.springframework.format.annotation.DateTimeFormat
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+import java.time.LocalDate
+
+@RestController
+@RequestMapping("/api/v1/owner/dashboard")
+class DashboardController(private val dashboardService: DashboardService) {
+
+    @GetMapping("/overview")
+    fun getOverview(
+        @RequestParam(defaultValue = "DAILY") period: DashboardPeriod,
+    ) = ResponseDTO.success(dashboardService.getOverview(period))
+
+    @GetMapping("/sales-trend")
+    fun getSalesTrend(
+        @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) from: LocalDate,
+        @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) to: LocalDate,
+    ) = ResponseDTO.success(dashboardService.getSalesTrend(from, to))
+
+    @GetMapping("/top-products")
+    fun getTopProducts(
+        @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) from: LocalDate,
+        @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) to: LocalDate,
+        @RequestParam(defaultValue = "10") limit: Int,
+    ) = ResponseDTO.success(dashboardService.getTopProducts(from, to, limit))
+
+    @GetMapping("/hourly-sales")
+    fun getHourlySales(
+        @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) date: LocalDate,
+    ) = ResponseDTO.success(dashboardService.getHourlySales(date))
+}

--- a/deal-api-owner/src/main/kotlin/com/chaltteok/owner/dashboard/dto/DashboardOverviewResponse.kt
+++ b/deal-api-owner/src/main/kotlin/com/chaltteok/owner/dashboard/dto/DashboardOverviewResponse.kt
@@ -1,0 +1,15 @@
+package com.chaltteok.owner.dashboard.dto
+
+import java.time.LocalDateTime
+
+class DashboardOverviewResponse(
+    val period: String,
+    val from: LocalDateTime,
+    val to: LocalDateTime,
+    val totalRevenue: Long,
+    val orderCount: Long,
+    val avgOrderValue: Long,
+    val newCustomers: Long,
+    val repeatCustomers: Long,
+    val cancelledCount: Long,
+)

--- a/deal-api-owner/src/main/kotlin/com/chaltteok/owner/dashboard/dto/HourlySalesResponse.kt
+++ b/deal-api-owner/src/main/kotlin/com/chaltteok/owner/dashboard/dto/HourlySalesResponse.kt
@@ -1,0 +1,14 @@
+package com.chaltteok.owner.dashboard.dto
+
+import java.time.LocalDate
+
+class HourlySalesResponse(
+    val date: LocalDate,
+    val hourlySales: List<HourlySalesItem>,
+)
+
+class HourlySalesItem(
+    val hour: Int,
+    val orderCount: Long,
+    val revenue: Long,
+)

--- a/deal-api-owner/src/main/kotlin/com/chaltteok/owner/dashboard/dto/SalesTrendResponse.kt
+++ b/deal-api-owner/src/main/kotlin/com/chaltteok/owner/dashboard/dto/SalesTrendResponse.kt
@@ -1,0 +1,13 @@
+package com.chaltteok.owner.dashboard.dto
+
+import java.time.LocalDate
+
+class SalesTrendResponse(
+    val trend: List<SalesTrendItem>,
+)
+
+class SalesTrendItem(
+    val date: LocalDate,
+    val orderCount: Long,
+    val revenue: Long,
+)

--- a/deal-api-owner/src/main/kotlin/com/chaltteok/owner/dashboard/dto/TopProductsResponse.kt
+++ b/deal-api-owner/src/main/kotlin/com/chaltteok/owner/dashboard/dto/TopProductsResponse.kt
@@ -1,0 +1,12 @@
+package com.chaltteok.owner.dashboard.dto
+
+class TopProductsResponse(
+    val products: List<TopProductItem>,
+)
+
+class TopProductItem(
+    val productUuid: String,
+    val productName: String,
+    val totalQty: Long,
+    val totalRevenue: Long,
+)

--- a/deal-api-owner/src/main/kotlin/com/chaltteok/owner/dashboard/enums/DashboardPeriod.kt
+++ b/deal-api-owner/src/main/kotlin/com/chaltteok/owner/dashboard/enums/DashboardPeriod.kt
@@ -1,0 +1,3 @@
+package com.chaltteok.owner.dashboard.enums
+
+enum class DashboardPeriod { DAILY, WEEKLY, MONTHLY }

--- a/deal-api-owner/src/main/kotlin/com/chaltteok/owner/dashboard/service/DashboardService.kt
+++ b/deal-api-owner/src/main/kotlin/com/chaltteok/owner/dashboard/service/DashboardService.kt
@@ -1,0 +1,15 @@
+package com.chaltteok.owner.dashboard.service
+
+import com.chaltteok.owner.dashboard.dto.DashboardOverviewResponse
+import com.chaltteok.owner.dashboard.dto.HourlySalesResponse
+import com.chaltteok.owner.dashboard.dto.SalesTrendResponse
+import com.chaltteok.owner.dashboard.dto.TopProductsResponse
+import com.chaltteok.owner.dashboard.enums.DashboardPeriod
+import java.time.LocalDate
+
+interface DashboardService {
+    fun getOverview(period: DashboardPeriod): DashboardOverviewResponse
+    fun getSalesTrend(from: LocalDate, to: LocalDate): SalesTrendResponse
+    fun getTopProducts(from: LocalDate, to: LocalDate, limit: Int): TopProductsResponse
+    fun getHourlySales(date: LocalDate): HourlySalesResponse
+}

--- a/deal-api-owner/src/main/kotlin/com/chaltteok/owner/dashboard/service/DashboardServiceImpl.kt
+++ b/deal-api-owner/src/main/kotlin/com/chaltteok/owner/dashboard/service/DashboardServiceImpl.kt
@@ -1,0 +1,91 @@
+package com.chaltteok.owner.dashboard.service
+
+import com.chaltteok.core.repository.order.OrderRepository
+import com.chaltteok.core.repository.orderitem.OrderItemRepository
+import com.chaltteok.core.repository.user.UserRepository
+import com.chaltteok.owner.dashboard.dto.DashboardOverviewResponse
+import com.chaltteok.owner.dashboard.dto.HourlySalesItem
+import com.chaltteok.owner.dashboard.dto.HourlySalesResponse
+import com.chaltteok.owner.dashboard.dto.SalesTrendItem
+import com.chaltteok.owner.dashboard.dto.SalesTrendResponse
+import com.chaltteok.owner.dashboard.dto.TopProductItem
+import com.chaltteok.owner.dashboard.dto.TopProductsResponse
+import com.chaltteok.owner.dashboard.enums.DashboardPeriod
+import org.springframework.stereotype.Service
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.LocalTime
+import java.time.temporal.TemporalAdjusters
+
+@Service
+class DashboardServiceImpl(
+    private val orderRepository: OrderRepository,
+    private val orderItemRepository: OrderItemRepository,
+    private val userRepository: UserRepository,
+) : DashboardService {
+
+    override fun getOverview(period: DashboardPeriod): DashboardOverviewResponse {
+        val (from, to) = resolvePeriodRange(period)
+
+        val salesAgg = orderRepository.findSalesPeriodAgg(from, to)
+        val newCustomers = userRepository.countNewUsers(from, to)
+        val repeatCustomers = userRepository.countRepeatOrderUsers(from, to)
+        val avgOrderValue = if (salesAgg.orderCount > 0) salesAgg.totalRevenue / salesAgg.orderCount else 0L
+
+        return DashboardOverviewResponse(
+            period = period.name,
+            from = from,
+            to = to,
+            totalRevenue = salesAgg.totalRevenue,
+            orderCount = salesAgg.orderCount,
+            avgOrderValue = avgOrderValue,
+            newCustomers = newCustomers,
+            repeatCustomers = repeatCustomers,
+            cancelledCount = salesAgg.cancelledCount,
+        )
+    }
+
+    override fun getSalesTrend(from: LocalDate, to: LocalDate): SalesTrendResponse {
+        val fromDt = from.atStartOfDay()
+        val toDt = to.atTime(LocalTime.MAX)
+
+        val items = orderRepository.findDailySalesTrend(fromDt, toDt).map { agg ->
+            SalesTrendItem(date = agg.date, orderCount = agg.orderCount, revenue = agg.revenue)
+        }
+        return SalesTrendResponse(trend = items)
+    }
+
+    override fun getTopProducts(from: LocalDate, to: LocalDate, limit: Int): TopProductsResponse {
+        val fromDt = from.atStartOfDay()
+        val toDt = to.atTime(LocalTime.MAX)
+
+        val products = orderItemRepository.findTopProducts(fromDt, toDt, limit).map { agg ->
+            TopProductItem(
+                productUuid = agg.productUuid,
+                productName = agg.productName,
+                totalQty = agg.totalQty,
+                totalRevenue = agg.totalRevenue,
+            )
+        }
+        return TopProductsResponse(products = products)
+    }
+
+    override fun getHourlySales(date: LocalDate): HourlySalesResponse {
+        val items = orderRepository.findHourlySales(date).map { agg ->
+            HourlySalesItem(hour = agg.hour, orderCount = agg.orderCount, revenue = agg.revenue)
+        }
+        return HourlySalesResponse(date = date, hourlySales = items)
+    }
+
+    private fun resolvePeriodRange(period: DashboardPeriod): Pair<LocalDateTime, LocalDateTime> {
+        val today = LocalDate.now()
+        return when (period) {
+            DashboardPeriod.DAILY -> Pair(today.atStartOfDay(), today.atTime(LocalTime.MAX))
+            DashboardPeriod.WEEKLY -> Pair(today.minusDays(6).atStartOfDay(), today.atTime(LocalTime.MAX))
+            DashboardPeriod.MONTHLY -> Pair(
+                today.with(TemporalAdjusters.firstDayOfMonth()).atStartOfDay(),
+                today.atTime(LocalTime.MAX),
+            )
+        }
+    }
+}

--- a/deal-core/src/main/kotlin/com/chaltteok/core/repository/order/OrderRepositoryCustom.kt
+++ b/deal-core/src/main/kotlin/com/chaltteok/core/repository/order/OrderRepositoryCustom.kt
@@ -1,4 +1,13 @@
 package com.chaltteok.core.repository.order
 
+import com.chaltteok.core.repository.order.dto.DailySalesAgg
+import com.chaltteok.core.repository.order.dto.HourlySalesAgg
+import com.chaltteok.core.repository.order.dto.SalesPeriodAgg
+import java.time.LocalDate
+import java.time.LocalDateTime
+
 interface OrderRepositoryCustom {
+    fun findSalesPeriodAgg(from: LocalDateTime, to: LocalDateTime): SalesPeriodAgg
+    fun findDailySalesTrend(from: LocalDateTime, to: LocalDateTime): List<DailySalesAgg>
+    fun findHourlySales(targetDate: LocalDate): List<HourlySalesAgg>
 }

--- a/deal-core/src/main/kotlin/com/chaltteok/core/repository/order/OrderRepositoryImpl.kt
+++ b/deal-core/src/main/kotlin/com/chaltteok/core/repository/order/OrderRepositoryImpl.kt
@@ -1,8 +1,103 @@
 package com.chaltteok.core.repository.order
 
+import com.chaltteok.core.domain.QOrder
+import com.chaltteok.core.domain.enums.OrderStatus
+import com.chaltteok.core.repository.order.dto.DailySalesAgg
+import com.chaltteok.core.repository.order.dto.HourlySalesAgg
+import com.chaltteok.core.repository.order.dto.SalesPeriodAgg
+import com.querydsl.core.types.dsl.Expressions
 import com.querydsl.jpa.impl.JPAQueryFactory
 import org.springframework.stereotype.Repository
+import java.time.LocalDate
+import java.time.LocalDateTime
 
 @Repository
-class OrderRepositoryImpl(private val jpaQueryFactory: JPAQueryFactory):OrderRepositoryCustom {
+class OrderRepositoryImpl(private val jpaQueryFactory: JPAQueryFactory) : OrderRepositoryCustom {
+
+    private val qOrder = QOrder.order
+
+    override fun findSalesPeriodAgg(from: LocalDateTime, to: LocalDateTime): SalesPeriodAgg {
+        val completedCount = jpaQueryFactory
+            .select(qOrder.id.count())
+            .from(qOrder)
+            .where(
+                qOrder.status.eq(OrderStatus.COMPLETED),
+                qOrder.orderedAt.between(from, to),
+            )
+            .fetchOne() ?: 0L
+
+        val totalRevenue = jpaQueryFactory
+            .select(qOrder.totalPrice.longValue().sum())
+            .from(qOrder)
+            .where(
+                qOrder.status.eq(OrderStatus.COMPLETED),
+                qOrder.orderedAt.between(from, to),
+            )
+            .fetchOne() ?: 0L
+
+        val cancelledCount = jpaQueryFactory
+            .select(qOrder.id.count())
+            .from(qOrder)
+            .where(
+                qOrder.status.`in`(OrderStatus.CANCELLED, OrderStatus.FAILED),
+                qOrder.orderedAt.between(from, to),
+            )
+            .fetchOne() ?: 0L
+
+        return SalesPeriodAgg(
+            orderCount = completedCount,
+            totalRevenue = totalRevenue,
+            cancelledCount = cancelledCount,
+        )
+    }
+
+    override fun findDailySalesTrend(from: LocalDateTime, to: LocalDateTime): List<DailySalesAgg> {
+        val dateExpr = Expressions.dateTemplate(LocalDate::class.java, "DATE({0})", qOrder.orderedAt)
+        val countExpr = qOrder.id.count()
+        val revenueExpr = qOrder.totalPrice.longValue().sum()
+
+        return jpaQueryFactory
+            .select(dateExpr, countExpr, revenueExpr)
+            .from(qOrder)
+            .where(
+                qOrder.status.eq(OrderStatus.COMPLETED),
+                qOrder.orderedAt.between(from, to),
+            )
+            .groupBy(dateExpr)
+            .orderBy(dateExpr.asc())
+            .fetch()
+            .map { tuple ->
+                DailySalesAgg(
+                    date = tuple.get(dateExpr)!!,
+                    orderCount = tuple.get(countExpr) ?: 0L,
+                    revenue = tuple.get(revenueExpr) ?: 0L,
+                )
+            }
+    }
+
+    override fun findHourlySales(targetDate: LocalDate): List<HourlySalesAgg> {
+        val from = targetDate.atStartOfDay()
+        val to = targetDate.atTime(23, 59, 59)
+        val hourExpr = Expressions.numberTemplate(Int::class.java, "HOUR({0})", qOrder.orderedAt)
+        val countExpr = qOrder.id.count()
+        val revenueExpr = qOrder.totalPrice.longValue().sum()
+
+        return jpaQueryFactory
+            .select(hourExpr, countExpr, revenueExpr)
+            .from(qOrder)
+            .where(
+                qOrder.status.eq(OrderStatus.COMPLETED),
+                qOrder.orderedAt.between(from, to),
+            )
+            .groupBy(hourExpr)
+            .orderBy(hourExpr.asc())
+            .fetch()
+            .map { tuple ->
+                HourlySalesAgg(
+                    hour = tuple.get(hourExpr) ?: 0,
+                    orderCount = tuple.get(countExpr) ?: 0L,
+                    revenue = tuple.get(revenueExpr) ?: 0L,
+                )
+            }
+    }
 }

--- a/deal-core/src/main/kotlin/com/chaltteok/core/repository/order/dto/DailySalesAgg.kt
+++ b/deal-core/src/main/kotlin/com/chaltteok/core/repository/order/dto/DailySalesAgg.kt
@@ -1,0 +1,9 @@
+package com.chaltteok.core.repository.order.dto
+
+import java.time.LocalDate
+
+class DailySalesAgg(
+    val date: LocalDate,
+    val orderCount: Long,
+    val revenue: Long,
+)

--- a/deal-core/src/main/kotlin/com/chaltteok/core/repository/order/dto/HourlySalesAgg.kt
+++ b/deal-core/src/main/kotlin/com/chaltteok/core/repository/order/dto/HourlySalesAgg.kt
@@ -1,0 +1,7 @@
+package com.chaltteok.core.repository.order.dto
+
+class HourlySalesAgg(
+    val hour: Int,
+    val orderCount: Long,
+    val revenue: Long,
+)

--- a/deal-core/src/main/kotlin/com/chaltteok/core/repository/order/dto/SalesPeriodAgg.kt
+++ b/deal-core/src/main/kotlin/com/chaltteok/core/repository/order/dto/SalesPeriodAgg.kt
@@ -1,0 +1,7 @@
+package com.chaltteok.core.repository.order.dto
+
+class SalesPeriodAgg(
+    val orderCount: Long,
+    val totalRevenue: Long,
+    val cancelledCount: Long,
+)

--- a/deal-core/src/main/kotlin/com/chaltteok/core/repository/orderitem/OrderItemRepositoryCustom.kt
+++ b/deal-core/src/main/kotlin/com/chaltteok/core/repository/orderitem/OrderItemRepositoryCustom.kt
@@ -1,4 +1,8 @@
 package com.chaltteok.core.repository.orderitem
 
+import com.chaltteok.core.repository.orderitem.dto.TopProductAgg
+import java.time.LocalDateTime
+
 interface OrderItemRepositoryCustom {
+    fun findTopProducts(from: LocalDateTime, to: LocalDateTime, limit: Int): List<TopProductAgg>
 }

--- a/deal-core/src/main/kotlin/com/chaltteok/core/repository/orderitem/OrderItemRepositoryImpl.kt
+++ b/deal-core/src/main/kotlin/com/chaltteok/core/repository/orderitem/OrderItemRepositoryImpl.kt
@@ -1,6 +1,47 @@
 package com.chaltteok.core.repository.orderitem
 
+import com.chaltteok.core.domain.QOrder
+import com.chaltteok.core.domain.QOrderItem
+import com.chaltteok.core.domain.QProduct
+import com.chaltteok.core.domain.enums.OrderStatus
+import com.chaltteok.core.repository.orderitem.dto.TopProductAgg
 import com.querydsl.jpa.impl.JPAQueryFactory
+import org.springframework.stereotype.Repository
+import java.time.LocalDateTime
 
-class OrderItemRepositoryImpl(private val jpaQueryFactory: JPAQueryFactory): OrderItemRepositoryCustom {
+@Repository
+class OrderItemRepositoryImpl(private val jpaQueryFactory: JPAQueryFactory) : OrderItemRepositoryCustom {
+
+    private val qOrderItem = QOrderItem.orderItem
+    private val qOrder = QOrder.order
+    private val qProduct = QProduct.product
+
+    override fun findTopProducts(from: LocalDateTime, to: LocalDateTime, limit: Int): List<TopProductAgg> {
+        val uuidExpr = qProduct.productUuid
+        val nameExpr = qProduct.name
+        val qtyExpr = qOrderItem.quantity.longValue().sum()
+        val revenueExpr = qOrderItem.price.multiply(qOrderItem.quantity).longValue().sum()
+
+        return jpaQueryFactory
+            .select(uuidExpr, nameExpr, qtyExpr, revenueExpr)
+            .from(qOrderItem)
+            .join(qOrderItem.order, qOrder)
+            .join(qOrderItem.product, qProduct)
+            .where(
+                qOrder.status.eq(OrderStatus.COMPLETED),
+                qOrder.orderedAt.between(from, to),
+            )
+            .groupBy(qProduct.id, qProduct.productUuid, qProduct.name)
+            .orderBy(qtyExpr.desc())
+            .limit(limit.toLong())
+            .fetch()
+            .map { tuple ->
+                TopProductAgg(
+                    productUuid = tuple.get(uuidExpr)!!,
+                    productName = tuple.get(nameExpr)!!,
+                    totalQty = tuple.get(qtyExpr) ?: 0L,
+                    totalRevenue = tuple.get(revenueExpr) ?: 0L,
+                )
+            }
+    }
 }

--- a/deal-core/src/main/kotlin/com/chaltteok/core/repository/orderitem/dto/TopProductAgg.kt
+++ b/deal-core/src/main/kotlin/com/chaltteok/core/repository/orderitem/dto/TopProductAgg.kt
@@ -1,0 +1,8 @@
+package com.chaltteok.core.repository.orderitem.dto
+
+class TopProductAgg(
+    val productUuid: String,
+    val productName: String,
+    val totalQty: Long,
+    val totalRevenue: Long,
+)

--- a/deal-core/src/main/kotlin/com/chaltteok/core/repository/user/UserRepositoryCustom.kt
+++ b/deal-core/src/main/kotlin/com/chaltteok/core/repository/user/UserRepositoryCustom.kt
@@ -1,4 +1,8 @@
 package com.chaltteok.core.repository.user
 
+import java.time.LocalDateTime
+
 interface UserRepositoryCustom {
+    fun countNewUsers(from: LocalDateTime, to: LocalDateTime): Long
+    fun countRepeatOrderUsers(from: LocalDateTime, to: LocalDateTime): Long
 }

--- a/deal-core/src/main/kotlin/com/chaltteok/core/repository/user/UserRepositoryImpl.kt
+++ b/deal-core/src/main/kotlin/com/chaltteok/core/repository/user/UserRepositoryImpl.kt
@@ -1,10 +1,39 @@
 package com.chaltteok.core.repository.user
 
+import com.chaltteok.core.domain.QOrder
+import com.chaltteok.core.domain.QUser
+import com.chaltteok.core.domain.enums.OrderStatus
 import com.querydsl.jpa.impl.JPAQueryFactory
 import org.springframework.stereotype.Repository
+import java.time.LocalDateTime
 
 @Repository
 class UserRepositoryImpl(
-    private val queryFactory: JPAQueryFactory
+    private val queryFactory: JPAQueryFactory,
 ) : UserRepositoryCustom {
+
+    private val qUser = QUser.user
+    private val qOrder = QOrder.order
+
+    override fun countNewUsers(from: LocalDateTime, to: LocalDateTime): Long {
+        return queryFactory
+            .select(qUser.id.count())
+            .from(qUser)
+            .where(qUser.createdAt.between(from, to))
+            .fetchOne() ?: 0L
+    }
+
+    override fun countRepeatOrderUsers(from: LocalDateTime, to: LocalDateTime): Long {
+        return queryFactory
+            .select(qOrder.user.id)
+            .from(qOrder)
+            .where(
+                qOrder.status.eq(OrderStatus.COMPLETED),
+                qOrder.orderedAt.between(from, to),
+            )
+            .groupBy(qOrder.user.id)
+            .having(qOrder.id.count().gt(1L))
+            .fetch()
+            .size.toLong()
+    }
 }


### PR DESCRIPTION
## Summary

- **deal-core**: OrderRepository, OrderItemRepository, UserRepository에 대시보드 집계용 QueryDSL 쿼리 추가
- **deal-api-owner**: `/api/v1/owner/dashboard/*` 엔드포인트 4개 신규 구현

## 구현 기능

### 1. 실시간 매출 현황 (`GET /overview?period=DAILY|WEEKLY|MONTHLY`)
- 총 매출액, 주문 건수, 객단가 (avgOrderValue)

### 2. 고객 데이터 (`GET /overview`)
- 신규 고객 수 (해당 기간 내 가입)
- 재주문 고객 수 (2건 이상 주문 고객)

### 3. 메뉴 분석
- `GET /top-products?from=&to=&limit=10` — 인기 메뉴 순위 (판매량 기준)
- `GET /hourly-sales?date=` — 시간대별 판매량

### 4. 운영 지표 (`GET /overview`)
- 취소/환불(CANCELLED, FAILED) 건수

## Architecture Checklist
- [x] `data class` 미사용, `val` 중심 불변 설계
- [x] UUID/PK 분리 (응답 DTO는 UUID만 노출)
- [x] 멀티 모듈 계층 준수 (deal-core에 QueryDSL 쿼리, deal-api-owner에 비즈니스 로직)
- [x] `deal-api-owner` 빌드 (`./gradlew :deal-api-owner:build -x test`) 통과

## Test plan
- [ ] `GET /api/v1/owner/dashboard/overview?period=DAILY` 응답 확인
- [ ] `GET /api/v1/owner/dashboard/sales-trend?from=2025-05-01&to=2025-05-12` 응답 확인
- [ ] `GET /api/v1/owner/dashboard/top-products?from=2025-05-01&to=2025-05-12` 응답 확인
- [ ] `GET /api/v1/owner/dashboard/hourly-sales?date=2025-05-12` 응답 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)