### PR TITLE
fix: application.yml 누락 및 .gitignore 범위 수정

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,8 @@ out/
 .kotlin
 
 
-**/src/main/resources/*.yml
+**/src/main/resources/application-core.yml
+**/src/main/resources/application-local.yml
+**/src/main/resources/application-secret.yml
 logs
 uploads

--- a/deal-api-admin/src/main/resources/application.yml
+++ b/deal-api-admin/src/main/resources/application.yml
@@ -1,0 +1,8 @@
+spring:
+  application:
+    name: deal-api-admin
+  config:
+    import: classpath:application-core.yml
+
+server:
+  port: 8082

--- a/deal-api-owner/src/main/resources/application.yml
+++ b/deal-api-owner/src/main/resources/application.yml
@@ -1,0 +1,8 @@
+spring:
+  application:
+    name: deal-api-owner
+  config:
+    import: classpath:application-core.yml
+
+server:
+  port: 8081


### PR DESCRIPTION
## Summary

- `.gitignore`가 `**/src/main/resources/*.yml`로 설정되어 `application.yml`까지 제외되던 문제 수정
  - 민감 파일(`application-core.yml`, `application-local.yml`, `application-secret.yml`)만 제외하도록 변경
- `deal-api-owner`(port 8081), `deal-api-admin`(port 8082) `application.yml` 추가
  - `application-core.yml` import로 DB/Redis/Kafka/JWT 설정 공유

## Root Cause

develop 브랜치의 `.gitignore`가 `**/src/main/resources/*.yml` 패턴으로 설정되어  
`application.yml` 파일이 git 추적에서 제외됨 → 신규 클론 시 파일 누락 → 서버 구동 불가

🤖 Generated with [Claude Code](https://claude.com/claude-code)