### PR TITLE
feat: 상품 이미지 파일 관리 및 정적 서빙

### DIFF
--- a/deal-api-owner/src/main/kotlin/com/chaltteok/owner/config/WebConfig.kt
+++ b/deal-api-owner/src/main/kotlin/com/chaltteok/owner/config/WebConfig.kt
@@ -1,16 +1,32 @@
 package com.chaltteok.owner.config
 
+import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.annotation.Configuration
 import org.springframework.web.servlet.config.annotation.CorsRegistry
+import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer
 
 @Configuration
-class WebConfig : WebMvcConfigurer {
+class WebConfig(
+    @Value("\${file.upload-dir}")
+    private val uploadDir: String
+) : WebMvcConfigurer {
+
     override fun addCorsMappings(registry: CorsRegistry) {
         registry.addMapping("/api/**")
             .allowedOriginPatterns("*")
             .allowedMethods("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS")
             .allowedHeaders("*")
             .allowCredentials(true)
+        registry.addMapping("/images/**")
+            .allowedOriginPatterns("*")
+            .allowedMethods("GET", "OPTIONS")
+            .allowedHeaders("*")
+            .allowCredentials(false)
+    }
+
+    override fun addResourceHandlers(registry: ResourceHandlerRegistry) {
+        registry.addResourceHandler("/images/**")
+            .addResourceLocations("file:$uploadDir/")
     }
 }

--- a/deal-api-owner/src/main/kotlin/com/chaltteok/owner/product/service/ProductServiceImpl.kt
+++ b/deal-api-owner/src/main/kotlin/com/chaltteok/owner/product/service/ProductServiceImpl.kt
@@ -39,7 +39,10 @@ class ProductServiceImpl(
     override fun updateProduct(productUuid: String, request: ProductUpdateRequest, image: MultipartFile?) {
         val product = productRepository.findByProductUuid(productUuid)
             ?: throw BusinessException(ProductErrorCode.PRODUCT_NOT_FOUND)
-        val imageUrl = image?.takeIf { !it.isEmpty }?.let { fileUploader.uploadFile(it) }
+        val newImageUrl = image?.takeIf { !it.isEmpty }?.let { newImage ->
+            product.imageUrl?.let { fileUploader.deleteFile(it) }
+            fileUploader.uploadFile(newImage)
+        }
 
         product.name = request.name
         product.description = request.descp
@@ -47,13 +50,14 @@ class ProductServiceImpl(
         product.isActive = request.isActive
         product.isSoldOut = request.isSoldOut
         product.isRecommended = request.isRecommended
-        if (imageUrl != null) product.imageUrl = imageUrl
+        if (newImageUrl != null) product.imageUrl = newImageUrl
     }
 
     @Transactional
     override fun deleteProduct(productUuid: String) {
         val product = productRepository.findByProductUuid(productUuid)
             ?: throw BusinessException(ProductErrorCode.PRODUCT_NOT_FOUND)
+        product.imageUrl?.let { fileUploader.deleteFile(it) }
         productOptionRepository.deleteAll(
             productOptionRepository.findAll().filter { it.product.id == product.id }
         )

--- a/deal-api-owner/src/main/kotlin/com/chaltteok/owner/product/util/LocalFileUploader.kt
+++ b/deal-api-owner/src/main/kotlin/com/chaltteok/owner/product/util/LocalFileUploader.kt
@@ -57,7 +57,13 @@ class LocalFileUploader(
         val filePath = directory.resolve(savedFileName)
         file.transferTo(filePath.toFile())
 
-        // 저장된 경로 반환
-        return "$uploadDir/$savedFileName"
+        // URL 경로 반환 (/images/xxx.jpg 형태로 정적 파일 서빙)
+        return "/images/$savedFileName"
+    }
+
+    fun deleteFile(imageUrl: String) {
+        val fileName = imageUrl.removePrefix("/images/")
+        val filePath = Paths.get(uploadDir).toAbsolutePath().normalize().resolve(fileName)
+        Files.deleteIfExists(filePath)
     }
 }


### PR DESCRIPTION
## Summary
- 상품 수정 시 기존 이미지 파일 삭제 후 신규 이미지 저장
- 상품 삭제 시 연결된 이미지 파일도 함께 삭제
- `/images/**` 경로로 업로드 디렉토리 정적 파일 서빙 추가 (CORS 포함)
- `LocalFileUploader` 반환값을 절대경로 → `/images/{파일명}` URL 경로로 변경

## Changes
- `LocalFileUploader`: `deleteFile()` 추가, `uploadFile()` 반환값 URL 경로로 변경
- `ProductServiceImpl`: update/delete 시 이미지 삭제 로직 추가
- `WebConfig`: `/images/**` 리소스 핸들러 및 CORS 설정 추가

## Test plan
- [ ] 상품 등록 후 이미지가 `/images/xxx.jpg` URL로 접근 가능한지 확인
- [ ] 상품 수정 시 기존 이미지 파일이 업로드 디렉토리에서 삭제되는지 확인
- [ ] 상품 삭제 시 이미지 파일이 업로드 디렉토리에서 삭제되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)