### PR TITLE
fix: /images/** 정적 이미지 공개 접근 허용

### DIFF
--- a/deal-common-api/src/main/kotlin/com/chaltteok/common/security/config/SecurityConfig.kt
+++ b/deal-common-api/src/main/kotlin/com/chaltteok/common/security/config/SecurityConfig.kt
@@ -36,6 +36,8 @@ class SecurityConfig(
                     .requestMatchers("/api/v1/user/auth/**").permitAll()
                     .requestMatchers(HttpMethod.GET, "/api/v1/user/daily-stocks/open").permitAll()
                     .requestMatchers(HttpMethod.GET, "/api/v1/user/products/**").permitAll()
+                    // 정적 이미지 파일 공개 접근
+                    .requestMatchers(HttpMethod.GET, "/images/**").permitAll()
                     .anyRequest().authenticated()
             }
             .exceptionHandling { ex ->


### PR DESCRIPTION
## Summary
- `SecurityConfig`에 `GET /images/**` 공개 접근 허용 규칙 추가
- 기존 `.anyRequest().authenticated()` 가 `/images/**`도 차단하여 이미지 서빙 시 401 반환 → "received null" 에러 발생

## Root Cause
Next.js `<Image>` 컴포넌트는 서버사이드에서 `/_next/image?url=/images/...` 요청을 처리할 때 백엔드로 인증 헤더 없이 요청을 보냄. Spring Security가 이를 인증되지 않은 요청으로 판단하여 401 반환.

## Test plan
- [ ] 상품 목록에서 이미지가 정상 노출되는지 확인
- [ ] 브라우저에서 `http://localhost:8081/images/{uuid}.jpeg` 직접 접근 가능한지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)