### PR TITLE
feat: 유저 상품 품절 표시 및 추천 상품 필터링 구현

### DIFF
--- a/deal-api-user/src/main/kotlin/com/chaltteok/user/product/dto/ProductResponse.kt
+++ b/deal-api-user/src/main/kotlin/com/chaltteok/user/product/dto/ProductResponse.kt
@@ -9,6 +9,7 @@ data class ProductResponse(
     val price: Long,
     val description: String?,
     val thumbnailUrl: String?,
+    val soldOut: Boolean,
 ) {
     companion object {
         fun from(product: Product) = ProductResponse(
@@ -18,6 +19,7 @@ data class ProductResponse(
             price = product.price.toLong(),
             description = product.description?.ifBlank { null },
             thumbnailUrl = product.imageUrl,
+            soldOut = product.isSoldOut,
         )
     }
 }

--- a/deal-api-user/src/main/kotlin/com/chaltteok/user/product/service/ProductQueryServiceImpl.kt
+++ b/deal-api-user/src/main/kotlin/com/chaltteok/user/product/service/ProductQueryServiceImpl.kt
@@ -17,6 +17,6 @@ class ProductQueryServiceImpl(
 
     @Transactional(readOnly = true)
     override fun getRecommendedProducts(): List<ProductResponse> =
-        productRepository.findAllByIsActiveTrue()
+        productRepository.findAllByIsActiveTrueAndIsRecommendedTrue()
             .map { ProductResponse.from(it) }
 }

--- a/deal-core/src/main/kotlin/com/chaltteok/core/repository/product/ProductRepository.kt
+++ b/deal-core/src/main/kotlin/com/chaltteok/core/repository/product/ProductRepository.kt
@@ -5,5 +5,6 @@ import org.springframework.data.jpa.repository.JpaRepository
 
 interface ProductRepository : JpaRepository<Product, Long>, ProductRepositoryCustom {
     fun findAllByIsActiveTrue(): List<Product>
+    fun findAllByIsActiveTrueAndIsRecommendedTrue(): List<Product>
     fun findByProductUuid(productUuid: String): Product?
 }


### PR DESCRIPTION
## Summary
- `ProductResponse`에 `soldOut` 필드 추가 — 품절 여부를 API로 노출
- `ProductRepository`에 `findAllByIsActiveTrueAndIsRecommendedTrue()` 메서드 추가
- `getRecommendedProducts()`가 `isRecommended=true` 상품만 반환하도록 수정 (기존에는 active 상품 전체 반환하던 버그 수정)
- `getProducts()`는 기존대로 `isActive=true` 필터 유지

## Test plan
- [ ] 일반 상품 목록 GET /api/v1/user/products — isActive=false 상품 미노출 확인
- [ ] 추천 상품 목록 GET /api/v1/user/products/recommended — isRecommended=true 상품만 반환 확인
- [ ] ProductResponse JSON에 soldOut 필드 포함 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)