### PR TITLE
fix: 점주 대시보드 일별 매출 트렌드 ClassCastException 수정

### DIFF
--- a/deal-core/src/main/kotlin/com/chaltteok/core/repository/order/OrderRepositoryImpl.kt
+++ b/deal-core/src/main/kotlin/com/chaltteok/core/repository/order/OrderRepositoryImpl.kt
@@ -52,7 +52,7 @@ class OrderRepositoryImpl(private val jpaQueryFactory: JPAQueryFactory) : OrderR
     }
 
     override fun findDailySalesTrend(from: LocalDateTime, to: LocalDateTime): List<DailySalesAgg> {
-        val dateExpr = Expressions.dateTemplate(LocalDate::class.java, "DATE({0})", qOrder.orderedAt)
+        val dateExpr = Expressions.dateTemplate(java.sql.Date::class.java, "DATE({0})", qOrder.orderedAt)
         val countExpr = qOrder.id.count()
         val revenueExpr = qOrder.totalPrice.longValue().sum()
 
@@ -68,7 +68,7 @@ class OrderRepositoryImpl(private val jpaQueryFactory: JPAQueryFactory) : OrderR
             .fetch()
             .map { tuple ->
                 DailySalesAgg(
-                    date = tuple.get(dateExpr)!!,
+                    date = tuple.get(dateExpr)!!.toLocalDate(),
                     orderCount = tuple.get(countExpr) ?: 0L,
                     revenue = tuple.get(revenueExpr) ?: 0L,
                 )


### PR DESCRIPTION
## Summary
- `findDailySalesTrend`에서 `Expressions.dateTemplate` 타입을 `LocalDate` → `java.sql.Date`로 변경
- 매핑 시 `.toLocalDate()` 호출로 변환

## Root Cause
MySQL JDBC 드라이버가 `DATE()` 함수 결과를 `java.sql.Date`로 반환하는데, QueryDSL 템플릿에 `LocalDate::class.java`를 지정하면 런타임에 직접 캐스팅을 시도하다 `ClassCastException` 발생.

## Test plan
- [ ] 점주 대시보드 조회 시 500 에러 없이 일별 매출 그래프 정상 렌더링 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)