### PR TITLE
feat: 주문내역 및 내 정보 수정 API 추가

### DIFF
--- a/deal-api-user/src/main/kotlin/com/chaltteok/user/order/controller/OrderQueryController.kt
+++ b/deal-api-user/src/main/kotlin/com/chaltteok/user/order/controller/OrderQueryController.kt
@@ -1,0 +1,18 @@
+package com.chaltteok.user.order.controller
+
+import com.chaltteok.common.dto.ResponseDTO
+import com.chaltteok.user.order.dto.OrderHistoryResponse
+import com.chaltteok.user.order.service.OrderQueryService
+import org.springframework.web.bind.annotation.*
+
+@RestController
+@RequestMapping("/api/v1/user/orders")
+class OrderQueryController(
+    private val orderQueryService: OrderQueryService,
+) {
+    @GetMapping
+    fun getOrderHistory(
+        @RequestHeader("X-User-Id") userId: Long,
+    ): ResponseDTO<List<OrderHistoryResponse>> =
+        ResponseDTO.success(orderQueryService.getOrderHistory(userId))
+}

--- a/deal-api-user/src/main/kotlin/com/chaltteok/user/order/dto/OrderHistoryItemResponse.kt
+++ b/deal-api-user/src/main/kotlin/com/chaltteok/user/order/dto/OrderHistoryItemResponse.kt
@@ -1,0 +1,7 @@
+package com.chaltteok.user.order.dto
+
+data class OrderHistoryItemResponse(
+    val productName: String,
+    val quantity: Int,
+    val price: Long,
+)

--- a/deal-api-user/src/main/kotlin/com/chaltteok/user/order/dto/OrderHistoryResponse.kt
+++ b/deal-api-user/src/main/kotlin/com/chaltteok/user/order/dto/OrderHistoryResponse.kt
@@ -1,0 +1,9 @@
+package com.chaltteok.user.order.dto
+
+data class OrderHistoryResponse(
+    val orderUuid: String,
+    val totalPrice: Long,
+    val status: String,
+    val orderedAt: String,
+    val items: List<OrderHistoryItemResponse>,
+)

--- a/deal-api-user/src/main/kotlin/com/chaltteok/user/order/service/OrderQueryService.kt
+++ b/deal-api-user/src/main/kotlin/com/chaltteok/user/order/service/OrderQueryService.kt
@@ -1,0 +1,7 @@
+package com.chaltteok.user.order.service
+
+import com.chaltteok.user.order.dto.OrderHistoryResponse
+
+interface OrderQueryService {
+    fun getOrderHistory(userId: Long): List<OrderHistoryResponse>
+}

--- a/deal-api-user/src/main/kotlin/com/chaltteok/user/order/service/OrderQueryServiceImpl.kt
+++ b/deal-api-user/src/main/kotlin/com/chaltteok/user/order/service/OrderQueryServiceImpl.kt
@@ -1,0 +1,42 @@
+package com.chaltteok.user.order.service
+
+import com.chaltteok.core.repository.order.OrderRepository
+import com.chaltteok.core.repository.orderitem.OrderItemRepository
+import com.chaltteok.user.order.dto.OrderHistoryItemResponse
+import com.chaltteok.user.order.dto.OrderHistoryResponse
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class OrderQueryServiceImpl(
+    private val orderRepository: OrderRepository,
+    private val orderItemRepository: OrderItemRepository,
+) : OrderQueryService {
+
+    @Transactional(readOnly = true)
+    override fun getOrderHistory(userId: Long): List<OrderHistoryResponse> {
+        val orders = orderRepository.findByUser_IdOrderByOrderedAtDesc(userId)
+        if (orders.isEmpty()) return emptyList()
+
+        val orderIds = orders.mapNotNull { it.id }
+        val itemsByOrderId = orderItemRepository.findByOrder_IdIn(orderIds)
+            .groupBy { it.order?.id }
+
+        return orders.map { order ->
+            val items = itemsByOrderId[order.id].orEmpty().map { item ->
+                OrderHistoryItemResponse(
+                    productName = item.product.name,
+                    quantity = item.quantity,
+                    price = item.price.toLong(),
+                )
+            }
+            OrderHistoryResponse(
+                orderUuid = order.orderUuid,
+                totalPrice = order.totalPrice.toLong(),
+                status = order.status.name,
+                orderedAt = order.orderedAt.toString(),
+                items = items,
+            )
+        }
+    }
+}

--- a/deal-api-user/src/main/kotlin/com/chaltteok/user/order/service/OrderQueryServiceImpl.kt
+++ b/deal-api-user/src/main/kotlin/com/chaltteok/user/order/service/OrderQueryServiceImpl.kt
@@ -19,7 +19,7 @@ class OrderQueryServiceImpl(
         if (orders.isEmpty()) return emptyList()
 
         val orderIds = orders.mapNotNull { it.id }
-        val itemsByOrderId = orderItemRepository.findByOrder_IdIn(orderIds)
+        val itemsByOrderId = orderItemRepository.findByOrderIdsWithProduct(orderIds)
             .groupBy { it.order?.id }
 
         return orders.map { order ->

--- a/deal-api-user/src/main/kotlin/com/chaltteok/user/profile/controller/UserProfileController.kt
+++ b/deal-api-user/src/main/kotlin/com/chaltteok/user/profile/controller/UserProfileController.kt
@@ -1,0 +1,27 @@
+package com.chaltteok.user.profile.controller
+
+import com.chaltteok.common.dto.ResponseDTO
+import com.chaltteok.user.profile.dto.UpdateNicknameRequest
+import com.chaltteok.user.profile.dto.UserProfileResponse
+import com.chaltteok.user.profile.service.UserProfileService
+import jakarta.validation.Valid
+import org.springframework.web.bind.annotation.*
+
+@RestController
+@RequestMapping("/api/v1/user/me")
+class UserProfileController(
+    private val userProfileService: UserProfileService,
+) {
+    @GetMapping
+    fun getProfile(
+        @RequestHeader("X-User-Id") userId: Long,
+    ): ResponseDTO<UserProfileResponse> =
+        ResponseDTO.success(userProfileService.getProfile(userId))
+
+    @PatchMapping
+    fun updateNickname(
+        @RequestHeader("X-User-Id") userId: Long,
+        @Valid @RequestBody request: UpdateNicknameRequest,
+    ): ResponseDTO<UserProfileResponse> =
+        ResponseDTO.success(userProfileService.updateNickname(userId, request))
+}

--- a/deal-api-user/src/main/kotlin/com/chaltteok/user/profile/dto/UpdateNicknameRequest.kt
+++ b/deal-api-user/src/main/kotlin/com/chaltteok/user/profile/dto/UpdateNicknameRequest.kt
@@ -1,0 +1,7 @@
+package com.chaltteok.user.profile.dto
+
+import jakarta.validation.constraints.NotBlank
+
+data class UpdateNicknameRequest(
+    @field:NotBlank val nickname: String,
+)

--- a/deal-api-user/src/main/kotlin/com/chaltteok/user/profile/dto/UpdateNicknameRequest.kt
+++ b/deal-api-user/src/main/kotlin/com/chaltteok/user/profile/dto/UpdateNicknameRequest.kt
@@ -1,7 +1,8 @@
 package com.chaltteok.user.profile.dto
 
 import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.Size
 
 data class UpdateNicknameRequest(
-    @field:NotBlank val nickname: String,
+    @field:NotBlank @field:Size(max = 50) val nickname: String,
 )

--- a/deal-api-user/src/main/kotlin/com/chaltteok/user/profile/dto/UserProfileResponse.kt
+++ b/deal-api-user/src/main/kotlin/com/chaltteok/user/profile/dto/UserProfileResponse.kt
@@ -1,0 +1,15 @@
+package com.chaltteok.user.profile.dto
+
+import com.chaltteok.core.domain.User
+
+data class UserProfileResponse(
+    val email: String,
+    val nickname: String,
+) {
+    companion object {
+        fun from(user: User) = UserProfileResponse(
+            email = user.email,
+            nickname = user.nickname,
+        )
+    }
+}

--- a/deal-api-user/src/main/kotlin/com/chaltteok/user/profile/service/UserProfileService.kt
+++ b/deal-api-user/src/main/kotlin/com/chaltteok/user/profile/service/UserProfileService.kt
@@ -1,0 +1,9 @@
+package com.chaltteok.user.profile.service
+
+import com.chaltteok.user.profile.dto.UpdateNicknameRequest
+import com.chaltteok.user.profile.dto.UserProfileResponse
+
+interface UserProfileService {
+    fun getProfile(userId: Long): UserProfileResponse
+    fun updateNickname(userId: Long, request: UpdateNicknameRequest): UserProfileResponse
+}

--- a/deal-api-user/src/main/kotlin/com/chaltteok/user/profile/service/UserProfileServiceImpl.kt
+++ b/deal-api-user/src/main/kotlin/com/chaltteok/user/profile/service/UserProfileServiceImpl.kt
@@ -1,0 +1,30 @@
+package com.chaltteok.user.profile.service
+
+import com.chaltteok.common.exception.BusinessException
+import com.chaltteok.common.security.enums.AuthErrorCode
+import com.chaltteok.core.repository.user.UserRepository
+import com.chaltteok.user.profile.dto.UpdateNicknameRequest
+import com.chaltteok.user.profile.dto.UserProfileResponse
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class UserProfileServiceImpl(
+    private val userRepository: UserRepository,
+) : UserProfileService {
+
+    @Transactional(readOnly = true)
+    override fun getProfile(userId: Long): UserProfileResponse {
+        val user = userRepository.findById(userId)
+            .orElseThrow { BusinessException(AuthErrorCode.INVALID_CREDENTIALS) }
+        return UserProfileResponse.from(user)
+    }
+
+    @Transactional
+    override fun updateNickname(userId: Long, request: UpdateNicknameRequest): UserProfileResponse {
+        val user = userRepository.findById(userId)
+            .orElseThrow { BusinessException(AuthErrorCode.INVALID_CREDENTIALS) }
+        user.nickname = request.nickname
+        return UserProfileResponse.from(user)
+    }
+}

--- a/deal-core/src/main/kotlin/com/chaltteok/core/repository/order/OrderRepository.kt
+++ b/deal-core/src/main/kotlin/com/chaltteok/core/repository/order/OrderRepository.kt
@@ -4,4 +4,5 @@ import com.chaltteok.core.domain.Order
 import org.springframework.data.jpa.repository.JpaRepository
 
 interface OrderRepository : JpaRepository<Order, Long>, OrderRepositoryCustom {
+    fun findByUser_IdOrderByOrderedAtDesc(userId: Long): List<Order>
 }

--- a/deal-core/src/main/kotlin/com/chaltteok/core/repository/orderitem/OrderItemRepository.kt
+++ b/deal-core/src/main/kotlin/com/chaltteok/core/repository/orderitem/OrderItemRepository.kt
@@ -2,7 +2,9 @@ package com.chaltteok.core.repository.orderitem
 
 import com.chaltteok.core.domain.OrderItem
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
 
 interface OrderItemRepository : JpaRepository<OrderItem, Long>, OrderItemRepositoryCustom {
-    fun findByOrder_IdIn(orderIds: List<Long>): List<OrderItem>
+    @Query("SELECT oi FROM OrderItem oi JOIN FETCH oi.product WHERE oi.order.id IN :orderIds")
+    fun findByOrderIdsWithProduct(orderIds: List<Long>): List<OrderItem>
 }

--- a/deal-core/src/main/kotlin/com/chaltteok/core/repository/orderitem/OrderItemRepository.kt
+++ b/deal-core/src/main/kotlin/com/chaltteok/core/repository/orderitem/OrderItemRepository.kt
@@ -3,4 +3,6 @@ package com.chaltteok.core.repository.orderitem
 import com.chaltteok.core.domain.OrderItem
 import org.springframework.data.jpa.repository.JpaRepository
 
-interface OrderItemRepository : JpaRepository<OrderItem, Long>,OrderItemRepositoryCustom {}
+interface OrderItemRepository : JpaRepository<OrderItem, Long>, OrderItemRepositoryCustom {
+    fun findByOrder_IdIn(orderIds: List<Long>): List<OrderItem>
+}


### PR DESCRIPTION
## Summary
- `GET /api/v1/user/orders` — 로그인 사용자의 주문 내역 조회 (주문 상품 포함)
- `GET /api/v1/user/me` — 로그인 사용자 프로필 조회 (이메일, 닉네임)
- `PATCH /api/v1/user/me` — 닉네임 변경

## 주요 변경 사항
- `OrderRepository`: `findByUser_IdOrderByOrderedAtDesc` 파생 쿼리 추가
- `OrderItemRepository`: `findByOrder_IdIn` 파생 쿼리 추가 (N+1 방지 일괄 조회)
- `OrderQueryService` / `OrderQueryServiceImpl`: 주문 목록 + 주문 상품 조인 후 응답 구성
- `UserProfileService` / `UserProfileServiceImpl`: 프로필 조회 및 닉네임 수정
- 각 컨트롤러는 `X-User-Id` 헤더로 인증된 사용자 ID 수신

## Test plan
- [ ] GET /api/v1/user/orders — 주문 없을 때 빈 배열 반환
- [ ] GET /api/v1/user/orders — 주문 있을 때 최신순 정렬, 상품 목록 포함 반환
- [ ] GET /api/v1/user/me — 이메일·닉네임 반환
- [ ] PATCH /api/v1/user/me — 닉네임 변경 후 반환값 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)