### PR TITLE
feat: 비밀번호 변경 API 추가

### DIFF
--- a/db/migration/add_user_password.sql
+++ b/db/migration/add_user_password.sql
@@ -1,0 +1,1 @@
+ALTER TABLE tb_users ADD COLUMN password VARCHAR(255) NULL;

--- a/deal-api-user/src/main/kotlin/com/chaltteok/user/profile/controller/UserProfileController.kt
+++ b/deal-api-user/src/main/kotlin/com/chaltteok/user/profile/controller/UserProfileController.kt
@@ -1,6 +1,7 @@
 package com.chaltteok.user.profile.controller
 
 import com.chaltteok.common.dto.ResponseDTO
+import com.chaltteok.user.profile.dto.ChangePasswordRequest
 import com.chaltteok.user.profile.dto.UpdateNicknameRequest
 import com.chaltteok.user.profile.dto.UserProfileResponse
 import com.chaltteok.user.profile.service.UserProfileService
@@ -24,4 +25,13 @@ class UserProfileController(
         @Valid @RequestBody request: UpdateNicknameRequest,
     ): ResponseDTO<UserProfileResponse> =
         ResponseDTO.success(userProfileService.updateNickname(userId, request))
+
+    @PatchMapping("/password")
+    fun changePassword(
+        @RequestHeader("X-User-Id") userId: Long,
+        @Valid @RequestBody request: ChangePasswordRequest,
+    ): ResponseDTO<Unit> {
+        userProfileService.changePassword(userId, request)
+        return ResponseDTO.success(Unit)
+    }
 }

--- a/deal-api-user/src/main/kotlin/com/chaltteok/user/profile/dto/ChangePasswordRequest.kt
+++ b/deal-api-user/src/main/kotlin/com/chaltteok/user/profile/dto/ChangePasswordRequest.kt
@@ -4,13 +4,13 @@ import jakarta.validation.constraints.NotBlank
 import jakarta.validation.constraints.Pattern
 import jakarta.validation.constraints.Size
 
-data class ChangePasswordRequest(
+class ChangePasswordRequest(
     val currentPassword: String?,
 
     @field:NotBlank
-    @field:Size(min = 10, message = "비밀번호는 10자 이상이어야 합니다.")
+    @field:Size(min = 10, max = 255, message = "비밀번호는 10자 이상 255자 이하이어야 합니다.")
     @field:Pattern(
-        regexp = "^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)(?=.*[!@#\$%^&*()_+\\-=\\[\\]{};':\"\\\\|,.<>\\/?]).{10,}\$",
+        regexp = "^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)(?=.*[!@#\$%^&*()_+\\-=\\[\\]{};':\"\\\\|,.<>\\/?]).{10,255}\$",
         message = "비밀번호는 대문자, 소문자, 숫자, 특수문자를 각 1개 이상 포함해야 합니다."
     )
     val newPassword: String,

--- a/deal-api-user/src/main/kotlin/com/chaltteok/user/profile/dto/ChangePasswordRequest.kt
+++ b/deal-api-user/src/main/kotlin/com/chaltteok/user/profile/dto/ChangePasswordRequest.kt
@@ -1,0 +1,17 @@
+package com.chaltteok.user.profile.dto
+
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.Pattern
+import jakarta.validation.constraints.Size
+
+data class ChangePasswordRequest(
+    val currentPassword: String?,
+
+    @field:NotBlank
+    @field:Size(min = 10, message = "비밀번호는 10자 이상이어야 합니다.")
+    @field:Pattern(
+        regexp = "^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)(?=.*[!@#\$%^&*()_+\\-=\\[\\]{};':\"\\\\|,.<>\\/?]).{10,}\$",
+        message = "비밀번호는 대문자, 소문자, 숫자, 특수문자를 각 1개 이상 포함해야 합니다."
+    )
+    val newPassword: String,
+)

--- a/deal-api-user/src/main/kotlin/com/chaltteok/user/profile/service/UserProfileService.kt
+++ b/deal-api-user/src/main/kotlin/com/chaltteok/user/profile/service/UserProfileService.kt
@@ -1,9 +1,11 @@
 package com.chaltteok.user.profile.service
 
+import com.chaltteok.user.profile.dto.ChangePasswordRequest
 import com.chaltteok.user.profile.dto.UpdateNicknameRequest
 import com.chaltteok.user.profile.dto.UserProfileResponse
 
 interface UserProfileService {
     fun getProfile(userId: Long): UserProfileResponse
     fun updateNickname(userId: Long, request: UpdateNicknameRequest): UserProfileResponse
+    fun changePassword(userId: Long, request: ChangePasswordRequest)
 }

--- a/deal-api-user/src/main/kotlin/com/chaltteok/user/profile/service/UserProfileServiceImpl.kt
+++ b/deal-api-user/src/main/kotlin/com/chaltteok/user/profile/service/UserProfileServiceImpl.kt
@@ -3,14 +3,17 @@ package com.chaltteok.user.profile.service
 import com.chaltteok.common.exception.BusinessException
 import com.chaltteok.common.security.enums.AuthErrorCode
 import com.chaltteok.core.repository.user.UserRepository
+import com.chaltteok.user.profile.dto.ChangePasswordRequest
 import com.chaltteok.user.profile.dto.UpdateNicknameRequest
 import com.chaltteok.user.profile.dto.UserProfileResponse
+import org.springframework.security.crypto.password.PasswordEncoder
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
 @Service
 class UserProfileServiceImpl(
     private val userRepository: UserRepository,
+    private val passwordEncoder: PasswordEncoder,
 ) : UserProfileService {
 
     @Transactional(readOnly = true)
@@ -26,5 +29,20 @@ class UserProfileServiceImpl(
             .orElseThrow { BusinessException(AuthErrorCode.INVALID_CREDENTIALS) }
         user.nickname = request.nickname
         return UserProfileResponse.from(user)
+    }
+
+    @Transactional
+    override fun changePassword(userId: Long, request: ChangePasswordRequest) {
+        val user = userRepository.findById(userId)
+            .orElseThrow { BusinessException(AuthErrorCode.INVALID_CREDENTIALS) }
+
+        if (user.password != null) {
+            if (request.currentPassword.isNullOrBlank() ||
+                !passwordEncoder.matches(request.currentPassword, user.password)) {
+                throw BusinessException(AuthErrorCode.INVALID_CREDENTIALS)
+            }
+        }
+
+        user.password = passwordEncoder.encode(request.newPassword)
     }
 }

--- a/deal-core/src/main/kotlin/com/chaltteok/core/domain/User.kt
+++ b/deal-core/src/main/kotlin/com/chaltteok/core/domain/User.kt
@@ -32,4 +32,7 @@ class User(
 
     @Column(name = "user_uuid", nullable = false, length = 36)
     val userUuid: String = UUID.randomUUID().toString()
+
+    @Column(name = "password", nullable = true, length = 255)
+    var password: String? = null
 }


### PR DESCRIPTION
## Summary
- `PATCH /api/v1/user/me/password` 엔드포인트 추가
- `User` 엔티티에 `password` 필드(nullable) 추가 및 BCrypt 해시 저장
- 최초 설정 시 현재 비밀번호 생략 가능, 기존 비밀번호 보유 시 검증
- 서버 측 정규식: 10자 이상, 대·소문자·숫자·특수문자 각 1개 이상

## Changed Files
- `deal-core/.../domain/User.kt` — `password: String?` 필드 추가
- `db/migration/add_user_password.sql` — tb_users 컬럼 추가 마이그레이션
- `deal-api-user/.../profile/dto/ChangePasswordRequest.kt` (NEW) — 검증 DTO
- `deal-api-user/.../profile/service/UserProfileService.kt` — `changePassword` 인터페이스
- `deal-api-user/.../profile/service/UserProfileServiceImpl.kt` — 구현체 (PasswordEncoder 주입)
- `deal-api-user/.../profile/controller/UserProfileController.kt` — PATCH /password 엔드포인트

## Test plan
- [ ] 최초 비밀번호 설정: 현재 비밀번호 없이 새 비밀번호 설정 가능 확인
- [ ] 비밀번호 재변경: 현재 비밀번호 검증 후 변경 확인
- [ ] 현재 비밀번호 틀렸을 때 401 응답 확인
- [ ] 정규식 미달 시 400 응답 확인 (길이, 대소문자, 숫자, 특수문자)
- [ ] `./gradlew build -x test` 통과 확인 ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)