### PR TITLE
[FEAT] 팝업 관리 CRUD 및 비밀번호 90일 만료 알림

### DIFF
--- a/db/migration/add_notice_table.sql
+++ b/db/migration/add_notice_table.sql
@@ -1,0 +1,13 @@
+CREATE TABLE IF NOT EXISTS tb_notice (
+    notice_id   BIGINT       NOT NULL AUTO_INCREMENT PRIMARY KEY,
+    notice_uuid VARCHAR(36)  NOT NULL,
+    title       VARCHAR(200) NOT NULL,
+    content     TEXT         NOT NULL,
+    is_visible  TINYINT(1)   NOT NULL DEFAULT 1,
+    location    VARCHAR(50),
+    start_date  DATE,
+    end_date    DATE,
+    created_at  DATETIME     NOT NULL,
+    updated_at  DATETIME     NOT NULL,
+    CONSTRAINT uk_notice_uuid UNIQUE (notice_uuid)
+);

--- a/db/migration/add_password_changed_at.sql
+++ b/db/migration/add_password_changed_at.sql
@@ -1,0 +1,2 @@
+ALTER TABLE tb_users ADD COLUMN IF NOT EXISTS password_changed_at DATETIME NULL;
+ALTER TABLE tb_owner ADD COLUMN IF NOT EXISTS password_changed_at DATETIME NULL;

--- a/deal-api-owner/src/main/kotlin/com/chaltteok/owner/auth/controller/AuthController.kt
+++ b/deal-api-owner/src/main/kotlin/com/chaltteok/owner/auth/controller/AuthController.kt
@@ -3,6 +3,7 @@ package com.chaltteok.owner.auth.controller
 import com.chaltteok.common.dto.ResponseDTO
 import com.chaltteok.common.exception.BusinessException
 import com.chaltteok.common.security.dto.LoginRequest
+import com.chaltteok.common.security.dto.LoginResponseDto
 import com.chaltteok.common.security.dto.ReissueRequest
 import com.chaltteok.common.security.dto.TokenDto
 import com.chaltteok.common.security.enums.AuthErrorCode
@@ -21,7 +22,7 @@ class AuthController(
     private val jwtTokenProvider: JwtTokenProvider,
 ) {
     @PostMapping("/login")
-    fun login(@Valid @RequestBody request: LoginRequest): ResponseDTO<TokenDto> =
+    fun login(@Valid @RequestBody request: LoginRequest): ResponseDTO<LoginResponseDto> =
         ResponseDTO.success(ownerAuthService.login(request.email, request.password))
 
     @PostMapping("/reissue")

--- a/deal-api-owner/src/main/kotlin/com/chaltteok/owner/auth/service/OwnerAuthService.kt
+++ b/deal-api-owner/src/main/kotlin/com/chaltteok/owner/auth/service/OwnerAuthService.kt
@@ -1,7 +1,7 @@
 package com.chaltteok.owner.auth.service
 
-import com.chaltteok.common.security.dto.TokenDto
+import com.chaltteok.common.security.dto.LoginResponseDto
 
 interface OwnerAuthService {
-    fun login(username: String, password: String): TokenDto
+    fun login(username: String, password: String): LoginResponseDto
 }

--- a/deal-api-owner/src/main/kotlin/com/chaltteok/owner/auth/service/OwnerAuthServiceImpl.kt
+++ b/deal-api-owner/src/main/kotlin/com/chaltteok/owner/auth/service/OwnerAuthServiceImpl.kt
@@ -1,13 +1,14 @@
 package com.chaltteok.owner.auth.service
 
 import com.chaltteok.common.exception.BusinessException
-import com.chaltteok.common.security.dto.TokenDto
+import com.chaltteok.common.security.dto.LoginResponseDto
 import com.chaltteok.common.security.enums.AuthErrorCode
 import com.chaltteok.common.security.jwt.JwtTokenProvider
 import com.chaltteok.core.repository.owner.OwnerRepository
 import org.springframework.security.crypto.password.PasswordEncoder
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDateTime
 
 @Service
 class OwnerAuthServiceImpl(
@@ -21,7 +22,7 @@ class OwnerAuthServiceImpl(
     }
 
     @Transactional(readOnly = true)
-    override fun login(username: String, password: String): TokenDto {
+    override fun login(username: String, password: String): LoginResponseDto {
         val owner = ownerRepository.findByUsername(username)
             .orElseThrow { BusinessException(AuthErrorCode.INVALID_CREDENTIALS) }
 
@@ -30,8 +31,12 @@ class OwnerAuthServiceImpl(
         }
 
         val userId = owner.id ?: throw BusinessException(AuthErrorCode.INVALID_CREDENTIALS)
+
+        val requirePasswordChange = owner.passwordChangedAt == null ||
+            owner.passwordChangedAt!!.isBefore(LocalDateTime.now().minusDays(90))
+
         val accessToken = jwtTokenProvider.generateAccessToken(userId, ROLE)
         val refreshToken = jwtTokenProvider.generateRefreshToken(userId, ROLE)
-        return TokenDto(accessToken, refreshToken, userId)
+        return LoginResponseDto(accessToken, refreshToken, userId, requirePasswordChange)
     }
 }

--- a/deal-api-owner/src/main/kotlin/com/chaltteok/owner/popup/controller/PopupController.kt
+++ b/deal-api-owner/src/main/kotlin/com/chaltteok/owner/popup/controller/PopupController.kt
@@ -1,0 +1,47 @@
+package com.chaltteok.owner.popup.controller
+
+import com.chaltteok.common.dto.ResponseDTO
+import com.chaltteok.owner.popup.dto.PopupRequest
+import com.chaltteok.owner.popup.dto.PopupResponse
+import com.chaltteok.owner.popup.service.OwnerPopupService
+import jakarta.validation.Valid
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.DeleteMapping
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.PutMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/v1/owner/popups")
+class PopupController(private val ownerPopupService: OwnerPopupService) {
+
+    @GetMapping
+    fun getAll(): ResponseDTO<List<PopupResponse>> =
+        ResponseDTO.success(ownerPopupService.getAll())
+
+    @PostMapping
+    fun create(@Valid @RequestBody request: PopupRequest): ResponseEntity<ResponseDTO<Any>> {
+        ownerPopupService.create(request)
+        return ResponseEntity.status(HttpStatus.CREATED).body(ResponseDTO.success())
+    }
+
+    @PutMapping("/{popupUuid}")
+    fun update(
+        @PathVariable popupUuid: String,
+        @Valid @RequestBody request: PopupRequest,
+    ): ResponseDTO<Any> {
+        ownerPopupService.update(popupUuid, request)
+        return ResponseDTO.success()
+    }
+
+    @DeleteMapping("/{popupUuid}")
+    fun delete(@PathVariable popupUuid: String): ResponseDTO<Any> {
+        ownerPopupService.delete(popupUuid)
+        return ResponseDTO.success()
+    }
+}

--- a/deal-api-owner/src/main/kotlin/com/chaltteok/owner/popup/dto/PopupRequest.kt
+++ b/deal-api-owner/src/main/kotlin/com/chaltteok/owner/popup/dto/PopupRequest.kt
@@ -1,0 +1,13 @@
+package com.chaltteok.owner.popup.dto
+
+import jakarta.validation.constraints.NotBlank
+import java.time.LocalDate
+
+class PopupRequest(
+    @field:NotBlank val title: String,
+    @field:NotBlank val content: String,
+    val isVisible: Boolean = true,
+    val location: String? = null,
+    val startDate: LocalDate? = null,
+    val endDate: LocalDate? = null,
+)

--- a/deal-api-owner/src/main/kotlin/com/chaltteok/owner/popup/dto/PopupResponse.kt
+++ b/deal-api-owner/src/main/kotlin/com/chaltteok/owner/popup/dto/PopupResponse.kt
@@ -1,0 +1,29 @@
+package com.chaltteok.owner.popup.dto
+
+import com.chaltteok.core.domain.Notice
+import java.time.LocalDate
+import java.time.LocalDateTime
+
+class PopupResponse(
+    val popupUuid: String,
+    val title: String,
+    val content: String,
+    val isVisible: Boolean,
+    val location: String?,
+    val startDate: LocalDate?,
+    val endDate: LocalDate?,
+    val createdAt: LocalDateTime,
+) {
+    companion object {
+        fun from(notice: Notice) = PopupResponse(
+            popupUuid = notice.noticeUuid,
+            title = notice.title,
+            content = notice.content,
+            isVisible = notice.isVisible,
+            location = notice.location,
+            startDate = notice.startDate,
+            endDate = notice.endDate,
+            createdAt = notice.createdAt,
+        )
+    }
+}

--- a/deal-api-owner/src/main/kotlin/com/chaltteok/owner/popup/enums/PopupErrorCode.kt
+++ b/deal-api-owner/src/main/kotlin/com/chaltteok/owner/popup/enums/PopupErrorCode.kt
@@ -1,0 +1,11 @@
+package com.chaltteok.owner.popup.enums
+
+import com.chaltteok.common.enums.ErrorCode
+import org.springframework.http.HttpStatus
+
+enum class PopupErrorCode(
+    override val status: HttpStatus,
+    override val message: String,
+) : ErrorCode {
+    POPUP_NOT_FOUND(HttpStatus.NOT_FOUND, "팝업을 찾을 수 없습니다."),
+}

--- a/deal-api-owner/src/main/kotlin/com/chaltteok/owner/popup/service/OwnerPopupService.kt
+++ b/deal-api-owner/src/main/kotlin/com/chaltteok/owner/popup/service/OwnerPopupService.kt
@@ -1,0 +1,11 @@
+package com.chaltteok.owner.popup.service
+
+import com.chaltteok.owner.popup.dto.PopupRequest
+import com.chaltteok.owner.popup.dto.PopupResponse
+
+interface OwnerPopupService {
+    fun getAll(): List<PopupResponse>
+    fun create(request: PopupRequest)
+    fun update(popupUuid: String, request: PopupRequest)
+    fun delete(popupUuid: String)
+}

--- a/deal-api-owner/src/main/kotlin/com/chaltteok/owner/popup/service/OwnerPopupServiceImpl.kt
+++ b/deal-api-owner/src/main/kotlin/com/chaltteok/owner/popup/service/OwnerPopupServiceImpl.kt
@@ -1,0 +1,54 @@
+package com.chaltteok.owner.popup.service
+
+import com.chaltteok.common.exception.BusinessException
+import com.chaltteok.core.domain.Notice
+import com.chaltteok.core.repository.notice.NoticeRepository
+import com.chaltteok.owner.popup.dto.PopupRequest
+import com.chaltteok.owner.popup.dto.PopupResponse
+import com.chaltteok.owner.popup.enums.PopupErrorCode
+import org.springframework.data.domain.Sort
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class OwnerPopupServiceImpl(
+    private val noticeRepository: NoticeRepository,
+) : OwnerPopupService {
+
+    @Transactional(readOnly = true)
+    override fun getAll(): List<PopupResponse> =
+        noticeRepository.findAll(Sort.by(Sort.Direction.DESC, "createdAt"))
+            .map { PopupResponse.from(it) }
+
+    @Transactional
+    override fun create(request: PopupRequest) {
+        val notice = Notice(
+            title = request.title,
+            content = request.content,
+            isVisible = request.isVisible,
+            location = request.location,
+            startDate = request.startDate,
+            endDate = request.endDate,
+        )
+        noticeRepository.save(notice)
+    }
+
+    @Transactional
+    override fun update(popupUuid: String, request: PopupRequest) {
+        val notice = noticeRepository.findByNoticeUuid(popupUuid)
+            ?: throw BusinessException(PopupErrorCode.POPUP_NOT_FOUND)
+        notice.title = request.title
+        notice.content = request.content
+        notice.isVisible = request.isVisible
+        notice.location = request.location
+        notice.startDate = request.startDate
+        notice.endDate = request.endDate
+    }
+
+    @Transactional
+    override fun delete(popupUuid: String) {
+        val notice = noticeRepository.findByNoticeUuid(popupUuid)
+            ?: throw BusinessException(PopupErrorCode.POPUP_NOT_FOUND)
+        noticeRepository.delete(notice)
+    }
+}

--- a/deal-api-owner/src/main/kotlin/com/chaltteok/owner/profile/controller/OwnerProfileController.kt
+++ b/deal-api-owner/src/main/kotlin/com/chaltteok/owner/profile/controller/OwnerProfileController.kt
@@ -1,0 +1,25 @@
+package com.chaltteok.owner.profile.controller
+
+import com.chaltteok.common.dto.ResponseDTO
+import com.chaltteok.owner.profile.dto.ChangeOwnerPasswordRequest
+import com.chaltteok.owner.profile.service.OwnerProfileService
+import jakarta.validation.Valid
+import org.springframework.web.bind.annotation.PatchMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestHeader
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/v1/owner/me")
+class OwnerProfileController(private val ownerProfileService: OwnerProfileService) {
+
+    @PatchMapping("/password")
+    fun changePassword(
+        @RequestHeader("X-Owner-Id") ownerId: Long,
+        @Valid @RequestBody request: ChangeOwnerPasswordRequest,
+    ): ResponseDTO<Unit> {
+        ownerProfileService.changePassword(ownerId, request)
+        return ResponseDTO.success(Unit)
+    }
+}

--- a/deal-api-owner/src/main/kotlin/com/chaltteok/owner/profile/dto/ChangeOwnerPasswordRequest.kt
+++ b/deal-api-owner/src/main/kotlin/com/chaltteok/owner/profile/dto/ChangeOwnerPasswordRequest.kt
@@ -1,0 +1,9 @@
+package com.chaltteok.owner.profile.dto
+
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.Size
+
+class ChangeOwnerPasswordRequest(
+    val currentPassword: String?,
+    @field:NotBlank @field:Size(min = 8) val newPassword: String,
+)

--- a/deal-api-owner/src/main/kotlin/com/chaltteok/owner/profile/service/OwnerProfileService.kt
+++ b/deal-api-owner/src/main/kotlin/com/chaltteok/owner/profile/service/OwnerProfileService.kt
@@ -1,0 +1,7 @@
+package com.chaltteok.owner.profile.service
+
+import com.chaltteok.owner.profile.dto.ChangeOwnerPasswordRequest
+
+interface OwnerProfileService {
+    fun changePassword(ownerId: Long, request: ChangeOwnerPasswordRequest)
+}

--- a/deal-api-owner/src/main/kotlin/com/chaltteok/owner/profile/service/OwnerProfileServiceImpl.kt
+++ b/deal-api-owner/src/main/kotlin/com/chaltteok/owner/profile/service/OwnerProfileServiceImpl.kt
@@ -1,0 +1,31 @@
+package com.chaltteok.owner.profile.service
+
+import com.chaltteok.common.exception.BusinessException
+import com.chaltteok.common.security.enums.AuthErrorCode
+import com.chaltteok.core.repository.owner.OwnerRepository
+import com.chaltteok.owner.profile.dto.ChangeOwnerPasswordRequest
+import org.springframework.security.crypto.password.PasswordEncoder
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDateTime
+
+@Service
+class OwnerProfileServiceImpl(
+    private val ownerRepository: OwnerRepository,
+    private val passwordEncoder: PasswordEncoder,
+) : OwnerProfileService {
+
+    @Transactional
+    override fun changePassword(ownerId: Long, request: ChangeOwnerPasswordRequest) {
+        val owner = ownerRepository.findById(ownerId)
+            .orElseThrow { BusinessException(AuthErrorCode.INVALID_CREDENTIALS) }
+
+        if (!request.currentPassword.isNullOrBlank() &&
+            !passwordEncoder.matches(request.currentPassword, owner.password)) {
+            throw BusinessException(AuthErrorCode.INVALID_CREDENTIALS)
+        }
+
+        owner.password = passwordEncoder.encode(request.newPassword)
+        owner.passwordChangedAt = LocalDateTime.now()
+    }
+}

--- a/deal-api-user/src/main/kotlin/com/chaltteok/user/auth/controller/AuthController.kt
+++ b/deal-api-user/src/main/kotlin/com/chaltteok/user/auth/controller/AuthController.kt
@@ -3,6 +3,7 @@ package com.chaltteok.user.auth.controller
 import com.chaltteok.common.dto.ResponseDTO
 import com.chaltteok.common.exception.BusinessException
 import com.chaltteok.common.security.dto.LoginRequest
+import com.chaltteok.common.security.dto.LoginResponseDto
 import com.chaltteok.common.security.dto.ReissueRequest
 import com.chaltteok.common.security.dto.TokenDto
 import com.chaltteok.common.security.enums.AuthErrorCode
@@ -23,7 +24,7 @@ class AuthController(
 ) {
 
     @PostMapping("/login")
-    fun login(@Valid @RequestBody request: LoginRequest): ResponseDTO<TokenDto> =
+    fun login(@Valid @RequestBody request: LoginRequest): ResponseDTO<LoginResponseDto> =
         ResponseDTO.success(userAuthService.login(request.email, request.password))
 
     @PostMapping("/register")

--- a/deal-api-user/src/main/kotlin/com/chaltteok/user/auth/service/UserAuthService.kt
+++ b/deal-api-user/src/main/kotlin/com/chaltteok/user/auth/service/UserAuthService.kt
@@ -1,9 +1,9 @@
 package com.chaltteok.user.auth.service
 
-import com.chaltteok.common.security.dto.TokenDto
+import com.chaltteok.common.security.dto.LoginResponseDto
 import com.chaltteok.user.auth.dto.RegisterRequest
 
 interface UserAuthService {
-    fun login(email: String, password: String): TokenDto
+    fun login(email: String, password: String): LoginResponseDto
     fun register(request: RegisterRequest)
 }

--- a/deal-api-user/src/main/kotlin/com/chaltteok/user/auth/service/UserAuthServiceImpl.kt
+++ b/deal-api-user/src/main/kotlin/com/chaltteok/user/auth/service/UserAuthServiceImpl.kt
@@ -1,7 +1,7 @@
 package com.chaltteok.user.auth.service
 
 import com.chaltteok.common.exception.BusinessException
-import com.chaltteok.common.security.dto.TokenDto
+import com.chaltteok.common.security.dto.LoginResponseDto
 import com.chaltteok.common.security.enums.AuthErrorCode
 import com.chaltteok.common.security.jwt.JwtTokenProvider
 import com.chaltteok.core.domain.User
@@ -10,6 +10,7 @@ import com.chaltteok.user.auth.dto.RegisterRequest
 import org.springframework.security.crypto.password.PasswordEncoder
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDateTime
 
 @Service
 class UserAuthServiceImpl(
@@ -24,7 +25,7 @@ class UserAuthServiceImpl(
     }
 
     @Transactional(readOnly = true)
-    override fun login(email: String, password: String): TokenDto {
+    override fun login(email: String, password: String): LoginResponseDto {
         val user = userRepository.findByEmail(email)
             .orElseThrow { BusinessException(AuthErrorCode.INVALID_CREDENTIALS) }
 
@@ -34,9 +35,12 @@ class UserAuthServiceImpl(
             throw BusinessException(AuthErrorCode.INVALID_CREDENTIALS)
         }
 
+        val requirePasswordChange = user.passwordChangedAt == null ||
+            user.passwordChangedAt!!.isBefore(LocalDateTime.now().minusDays(90))
+
         val accessToken = jwtTokenProvider.generateAccessToken(user.id!!, ROLE)
         val refreshToken = jwtTokenProvider.generateRefreshToken(user.id!!, ROLE)
-        return TokenDto(accessToken, refreshToken, user.id!!)
+        return LoginResponseDto(accessToken, refreshToken, user.id!!, requirePasswordChange)
     }
 
     @Transactional

--- a/deal-api-user/src/main/kotlin/com/chaltteok/user/popup/controller/PopupController.kt
+++ b/deal-api-user/src/main/kotlin/com/chaltteok/user/popup/controller/PopupController.kt
@@ -1,0 +1,17 @@
+package com.chaltteok.user.popup.controller
+
+import com.chaltteok.common.dto.ResponseDTO
+import com.chaltteok.user.popup.dto.PopupResponse
+import com.chaltteok.user.popup.service.UserPopupService
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/v1/user/popups")
+class PopupController(private val userPopupService: UserPopupService) {
+
+    @GetMapping
+    fun getPopups(): ResponseDTO<List<PopupResponse>> =
+        ResponseDTO.success(userPopupService.getActivePopups())
+}

--- a/deal-api-user/src/main/kotlin/com/chaltteok/user/popup/dto/PopupResponse.kt
+++ b/deal-api-user/src/main/kotlin/com/chaltteok/user/popup/dto/PopupResponse.kt
@@ -1,0 +1,24 @@
+package com.chaltteok.user.popup.dto
+
+import com.chaltteok.core.domain.Notice
+import java.time.LocalDate
+
+class PopupResponse(
+    val popupUuid: String,
+    val title: String,
+    val content: String,
+    val location: String?,
+    val startDate: LocalDate?,
+    val endDate: LocalDate?,
+) {
+    companion object {
+        fun from(notice: Notice) = PopupResponse(
+            popupUuid = notice.noticeUuid,
+            title = notice.title,
+            content = notice.content,
+            location = notice.location,
+            startDate = notice.startDate,
+            endDate = notice.endDate,
+        )
+    }
+}

--- a/deal-api-user/src/main/kotlin/com/chaltteok/user/popup/service/UserPopupService.kt
+++ b/deal-api-user/src/main/kotlin/com/chaltteok/user/popup/service/UserPopupService.kt
@@ -1,0 +1,7 @@
+package com.chaltteok.user.popup.service
+
+import com.chaltteok.user.popup.dto.PopupResponse
+
+interface UserPopupService {
+    fun getActivePopups(): List<PopupResponse>
+}

--- a/deal-api-user/src/main/kotlin/com/chaltteok/user/popup/service/UserPopupServiceImpl.kt
+++ b/deal-api-user/src/main/kotlin/com/chaltteok/user/popup/service/UserPopupServiceImpl.kt
@@ -1,0 +1,17 @@
+package com.chaltteok.user.popup.service
+
+import com.chaltteok.core.repository.notice.NoticeRepository
+import com.chaltteok.user.popup.dto.PopupResponse
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDate
+
+@Service
+class UserPopupServiceImpl(
+    private val noticeRepository: NoticeRepository,
+) : UserPopupService {
+
+    @Transactional(readOnly = true)
+    override fun getActivePopups(): List<PopupResponse> =
+        noticeRepository.findActiveNotices(LocalDate.now()).map { PopupResponse.from(it) }
+}

--- a/deal-api-user/src/main/kotlin/com/chaltteok/user/profile/service/UserProfileServiceImpl.kt
+++ b/deal-api-user/src/main/kotlin/com/chaltteok/user/profile/service/UserProfileServiceImpl.kt
@@ -9,6 +9,7 @@ import com.chaltteok.user.profile.dto.UserProfileResponse
 import org.springframework.security.crypto.password.PasswordEncoder
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDateTime
 
 @Service
 class UserProfileServiceImpl(
@@ -44,5 +45,6 @@ class UserProfileServiceImpl(
         }
 
         user.password = passwordEncoder.encode(request.newPassword)
+        user.passwordChangedAt = LocalDateTime.now()
     }
 }

--- a/deal-common-api/src/main/kotlin/com/chaltteok/common/security/dto/LoginResponseDto.kt
+++ b/deal-common-api/src/main/kotlin/com/chaltteok/common/security/dto/LoginResponseDto.kt
@@ -1,0 +1,8 @@
+package com.chaltteok.common.security.dto
+
+class LoginResponseDto(
+    val accessToken: String,
+    val refreshToken: String,
+    val userId: Long,
+    val requirePasswordChange: Boolean = false,
+)

--- a/deal-core/src/main/kotlin/com/chaltteok/core/domain/Notice.kt
+++ b/deal-core/src/main/kotlin/com/chaltteok/core/domain/Notice.kt
@@ -1,0 +1,35 @@
+package com.chaltteok.core.domain
+
+import jakarta.persistence.*
+import java.time.LocalDate
+import java.util.UUID
+
+@Entity
+@Table(name = "tb_notice", uniqueConstraints = [UniqueConstraint(name = "uk_notice_uuid", columnNames = ["notice_uuid"])])
+class Notice(
+    @Column(name = "title", nullable = false, length = 200)
+    var title: String,
+
+    @Column(name = "content", columnDefinition = "TEXT")
+    var content: String,
+
+    @Column(name = "is_visible", nullable = false)
+    var isVisible: Boolean = true,
+
+    @Column(name = "location", length = 50)
+    var location: String? = null,
+
+    @Column(name = "start_date")
+    var startDate: LocalDate? = null,
+
+    @Column(name = "end_date")
+    var endDate: LocalDate? = null,
+) : BaseEntity() {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "notice_id")
+    var id: Long? = null
+
+    @Column(name = "notice_uuid", nullable = false, length = 36)
+    val noticeUuid: String = UUID.randomUUID().toString()
+}

--- a/deal-core/src/main/kotlin/com/chaltteok/core/domain/Owner.kt
+++ b/deal-core/src/main/kotlin/com/chaltteok/core/domain/Owner.kt
@@ -1,6 +1,7 @@
 package com.chaltteok.core.domain
 
 import jakarta.persistence.*
+import java.time.LocalDateTime
 import java.util.*
 
 @Entity
@@ -16,7 +17,7 @@ class Owner(
     val username: String,
 
     @Column(name = "password", nullable = false, length = 255)
-    val password: String,
+    var password: String,
 
     @Column(name = "name", nullable = false, length = 50)
     val name: String,
@@ -33,4 +34,7 @@ class Owner(
 
     @Column(name = "owner_uuid", nullable = false, unique = true, length = 36)
     val ownerUuid: String = UUID.randomUUID().toString()
+
+    @Column(name = "password_changed_at")
+    var passwordChangedAt: LocalDateTime? = null
 }

--- a/deal-core/src/main/kotlin/com/chaltteok/core/domain/User.kt
+++ b/deal-core/src/main/kotlin/com/chaltteok/core/domain/User.kt
@@ -1,6 +1,7 @@
 package com.chaltteok.core.domain
 
 import jakarta.persistence.*
+import java.time.LocalDateTime
 import java.util.*
 
 @Entity
@@ -35,4 +36,7 @@ class User(
 
     @Column(name = "password", nullable = true, length = 255)
     var password: String? = null
+
+    @Column(name = "password_changed_at")
+    var passwordChangedAt: LocalDateTime? = null
 }

--- a/deal-core/src/main/kotlin/com/chaltteok/core/repository/notice/NoticeRepository.kt
+++ b/deal-core/src/main/kotlin/com/chaltteok/core/repository/notice/NoticeRepository.kt
@@ -1,0 +1,20 @@
+package com.chaltteok.core.repository.notice
+
+import com.chaltteok.core.domain.Notice
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
+import java.time.LocalDate
+
+interface NoticeRepository : JpaRepository<Notice, Long> {
+    fun findByNoticeUuid(uuid: String): Notice?
+
+    @Query("""
+        SELECT n FROM Notice n
+        WHERE n.isVisible = true
+        AND (n.startDate IS NULL OR n.startDate <= :today)
+        AND (n.endDate IS NULL OR n.endDate >= :today)
+        ORDER BY n.createdAt DESC
+    """)
+    fun findActiveNotices(@Param("today") today: LocalDate): List<Notice>
+}


### PR DESCRIPTION
## Summary

- **팝업 관리 API**: `Notice` 엔티티(tb_notice)에 팝업 데이터 저장. 유저 조회(`GET /api/v1/user/popups`, 노출여부·기간 필터링) + 점주 CRUD(`GET/POST/PUT/DELETE /api/v1/owner/popups`)
- **비밀번호 90일 만료 체크**: `User`/`Owner` 엔티티에 `passwordChangedAt` 추가. 로그인 응답(`LoginResponseDto`)에 `requirePasswordChange` 플래그 반환. `changePassword()` 호출 시 갱신
- **점주 비밀번호 변경 API**: `PATCH /api/v1/owner/me/password` 신설

## Changed Files

| 파일 | 변경 내용 |
|------|----------|
| `deal-core/.../Notice.kt` | 팝업(공지) 엔티티 신설 |
| `deal-core/.../User.kt`, `Owner.kt` | `passwordChangedAt` 필드 추가 |
| `deal-common-api/.../LoginResponseDto.kt` | 로그인 응답 DTO (requirePasswordChange 포함) |
| `deal-api-user/.../popup/` | 유저 팝업 조회 API |
| `deal-api-owner/.../popup/` | 점주 팝업 CRUD API |
| `deal-api-owner/.../profile/` | 점주 비밀번호 변경 API |
| `db/migration/` | add_notice_table.sql, add_password_changed_at.sql |

## Test plan

- [ ] DB 마이그레이션 SQL 순서대로 실행
- [ ] `POST /api/v1/owner/auth/login` → 90일 경과 계정: `requirePasswordChange: true` 확인
- [ ] `GET /api/v1/user/popups` → 노출 여부 true + 기간 내 팝업만 반환 확인
- [ ] 점주 팝업 CRUD: 등록 → 수정 → 삭제 정상 동작 확인
- [ ] `PATCH /api/v1/owner/me/password` → `passwordChangedAt` 갱신 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)