### PR TITLE
[FEAT] 팝업 시간 지정 및 상품 댓글/별점/비밀/답글 CRUD API

### DIFF
--- a/db/migration/add_popup_time_and_comment_table.sql
+++ b/db/migration/add_popup_time_and_comment_table.sql
@@ -1,0 +1,24 @@
+-- tb_notice에 시간 필드 추가
+ALTER TABLE tb_notice
+    ADD COLUMN IF NOT EXISTS start_time TIME NULL,
+    ADD COLUMN IF NOT EXISTS end_time TIME NULL;
+
+-- 댓글 테이블 생성
+CREATE TABLE IF NOT EXISTS tb_comment (
+    comment_id      BIGINT       NOT NULL AUTO_INCREMENT PRIMARY KEY,
+    comment_uuid    VARCHAR(36)  NOT NULL,
+    product_id      BIGINT       NOT NULL,
+    user_id         BIGINT       NOT NULL,
+    content         TEXT         NOT NULL,
+    rating          TINYINT      NULL,
+    is_secret       TINYINT(1)   NOT NULL DEFAULT 0,
+    parent_id       BIGINT       NULL,
+    is_owner_reply  TINYINT(1)   NOT NULL DEFAULT 0,
+    created_at      DATETIME     NOT NULL,
+    updated_at      DATETIME     NOT NULL,
+    CONSTRAINT uk_comment_uuid UNIQUE (comment_uuid),
+    CONSTRAINT fk_comment_product FOREIGN KEY (product_id) REFERENCES tb_products(product_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_comment_product ON tb_comment (product_id);
+CREATE INDEX IF NOT EXISTS idx_comment_parent  ON tb_comment (parent_id);

--- a/deal-api-owner/src/main/kotlin/com/chaltteok/owner/comment/controller/OwnerCommentController.kt
+++ b/deal-api-owner/src/main/kotlin/com/chaltteok/owner/comment/controller/OwnerCommentController.kt
@@ -1,0 +1,33 @@
+package com.chaltteok.owner.comment.controller
+
+import com.chaltteok.common.dto.ResponseDTO
+import com.chaltteok.owner.comment.dto.OwnerCommentResponse
+import com.chaltteok.owner.comment.dto.OwnerReplyRequest
+import com.chaltteok.owner.comment.service.OwnerCommentService
+import jakarta.validation.Valid
+import org.springframework.http.HttpStatus
+import org.springframework.web.bind.annotation.*
+
+@RestController
+@RequestMapping("/api/v1/owner/comments")
+class OwnerCommentController(private val ownerCommentService: OwnerCommentService) {
+
+    @GetMapping
+    fun getAll(): ResponseDTO<List<OwnerCommentResponse>> =
+        ResponseDTO.success(ownerCommentService.getAll())
+
+    @DeleteMapping("/{commentUuid}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    fun delete(@PathVariable commentUuid: String): ResponseDTO<Unit> {
+        ownerCommentService.delete(commentUuid)
+        return ResponseDTO.success(Unit)
+    }
+
+    @PostMapping("/{commentUuid}/reply")
+    @ResponseStatus(HttpStatus.CREATED)
+    fun reply(
+        @PathVariable commentUuid: String,
+        @Valid @RequestBody request: OwnerReplyRequest,
+    ): ResponseDTO<OwnerCommentResponse> =
+        ResponseDTO.success(ownerCommentService.reply(commentUuid, request))
+}

--- a/deal-api-owner/src/main/kotlin/com/chaltteok/owner/comment/dto/OwnerCommentResponse.kt
+++ b/deal-api-owner/src/main/kotlin/com/chaltteok/owner/comment/dto/OwnerCommentResponse.kt
@@ -1,0 +1,34 @@
+package com.chaltteok.owner.comment.dto
+
+import com.chaltteok.core.domain.Comment
+import java.time.LocalDateTime
+
+class OwnerCommentResponse(
+    val commentId: Long,
+    val commentUuid: String,
+    val productUuid: String,
+    val productName: String,
+    val userId: Long,
+    val content: String,
+    val rating: Int?,
+    val isSecret: Boolean,
+    val isOwnerReply: Boolean,
+    val parentId: Long?,
+    val createdAt: LocalDateTime,
+) {
+    companion object {
+        fun from(comment: Comment) = OwnerCommentResponse(
+            commentId = comment.id!!,
+            commentUuid = comment.commentUuid,
+            productUuid = comment.product.productUuid,
+            productName = comment.product.name,
+            userId = comment.userId,
+            content = comment.content,
+            rating = comment.rating,
+            isSecret = comment.isSecret,
+            isOwnerReply = comment.isOwnerReply,
+            parentId = comment.parentId,
+            createdAt = comment.createdAt,
+        )
+    }
+}

--- a/deal-api-owner/src/main/kotlin/com/chaltteok/owner/comment/dto/OwnerReplyRequest.kt
+++ b/deal-api-owner/src/main/kotlin/com/chaltteok/owner/comment/dto/OwnerReplyRequest.kt
@@ -1,0 +1,7 @@
+package com.chaltteok.owner.comment.dto
+
+import jakarta.validation.constraints.NotBlank
+
+class OwnerReplyRequest(
+    @field:NotBlank val content: String,
+)

--- a/deal-api-owner/src/main/kotlin/com/chaltteok/owner/comment/enums/OwnerCommentErrorCode.kt
+++ b/deal-api-owner/src/main/kotlin/com/chaltteok/owner/comment/enums/OwnerCommentErrorCode.kt
@@ -1,0 +1,11 @@
+package com.chaltteok.owner.comment.enums
+
+import com.chaltteok.common.enums.ErrorCode
+import org.springframework.http.HttpStatus
+
+enum class OwnerCommentErrorCode(
+    override val status: HttpStatus,
+    override val message: String,
+) : ErrorCode {
+    COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "댓글을 찾을 수 없습니다."),
+}

--- a/deal-api-owner/src/main/kotlin/com/chaltteok/owner/comment/service/OwnerCommentService.kt
+++ b/deal-api-owner/src/main/kotlin/com/chaltteok/owner/comment/service/OwnerCommentService.kt
@@ -1,0 +1,10 @@
+package com.chaltteok.owner.comment.service
+
+import com.chaltteok.owner.comment.dto.OwnerCommentResponse
+import com.chaltteok.owner.comment.dto.OwnerReplyRequest
+
+interface OwnerCommentService {
+    fun getAll(): List<OwnerCommentResponse>
+    fun delete(commentUuid: String)
+    fun reply(commentUuid: String, request: OwnerReplyRequest): OwnerCommentResponse
+}

--- a/deal-api-owner/src/main/kotlin/com/chaltteok/owner/comment/service/OwnerCommentServiceImpl.kt
+++ b/deal-api-owner/src/main/kotlin/com/chaltteok/owner/comment/service/OwnerCommentServiceImpl.kt
@@ -1,0 +1,43 @@
+package com.chaltteok.owner.comment.service
+
+import com.chaltteok.common.exception.BusinessException
+import com.chaltteok.core.domain.Comment
+import com.chaltteok.core.repository.comment.CommentRepository
+import com.chaltteok.owner.comment.dto.OwnerCommentResponse
+import com.chaltteok.owner.comment.dto.OwnerReplyRequest
+import com.chaltteok.owner.comment.enums.OwnerCommentErrorCode
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class OwnerCommentServiceImpl(
+    private val commentRepository: CommentRepository,
+) : OwnerCommentService {
+
+    @Transactional(readOnly = true)
+    override fun getAll(): List<OwnerCommentResponse> =
+        commentRepository.findAllOrderByCreatedAtDesc().map { OwnerCommentResponse.from(it) }
+
+    @Transactional
+    override fun delete(commentUuid: String) {
+        val comment = commentRepository.findByCommentUuid(commentUuid)
+            ?: throw BusinessException(OwnerCommentErrorCode.COMMENT_NOT_FOUND)
+        commentRepository.delete(comment)
+    }
+
+    @Transactional
+    override fun reply(commentUuid: String, request: OwnerReplyRequest): OwnerCommentResponse {
+        val parent = commentRepository.findByCommentUuid(commentUuid)
+            ?: throw BusinessException(OwnerCommentErrorCode.COMMENT_NOT_FOUND)
+        val reply = commentRepository.save(
+            Comment(
+                product = parent.product,
+                userId = 0L,
+                content = request.content,
+                parentId = parent.id,
+                isOwnerReply = true,
+            )
+        )
+        return OwnerCommentResponse.from(reply)
+    }
+}

--- a/deal-api-owner/src/main/kotlin/com/chaltteok/owner/popup/dto/PopupRequest.kt
+++ b/deal-api-owner/src/main/kotlin/com/chaltteok/owner/popup/dto/PopupRequest.kt
@@ -2,6 +2,7 @@ package com.chaltteok.owner.popup.dto
 
 import jakarta.validation.constraints.NotBlank
 import java.time.LocalDate
+import java.time.LocalTime
 
 class PopupRequest(
     @field:NotBlank val title: String,
@@ -10,4 +11,6 @@ class PopupRequest(
     val location: String? = null,
     val startDate: LocalDate? = null,
     val endDate: LocalDate? = null,
+    val startTime: LocalTime? = null,
+    val endTime: LocalTime? = null,
 )

--- a/deal-api-owner/src/main/kotlin/com/chaltteok/owner/popup/dto/PopupResponse.kt
+++ b/deal-api-owner/src/main/kotlin/com/chaltteok/owner/popup/dto/PopupResponse.kt
@@ -3,6 +3,7 @@ package com.chaltteok.owner.popup.dto
 import com.chaltteok.core.domain.Notice
 import java.time.LocalDate
 import java.time.LocalDateTime
+import java.time.LocalTime
 
 class PopupResponse(
     val popupUuid: String,
@@ -12,6 +13,8 @@ class PopupResponse(
     val location: String?,
     val startDate: LocalDate?,
     val endDate: LocalDate?,
+    val startTime: LocalTime?,
+    val endTime: LocalTime?,
     val createdAt: LocalDateTime,
 ) {
     companion object {
@@ -23,6 +26,8 @@ class PopupResponse(
             location = notice.location,
             startDate = notice.startDate,
             endDate = notice.endDate,
+            startTime = notice.startTime,
+            endTime = notice.endTime,
             createdAt = notice.createdAt,
         )
     }

--- a/deal-api-owner/src/main/kotlin/com/chaltteok/owner/popup/service/OwnerPopupServiceImpl.kt
+++ b/deal-api-owner/src/main/kotlin/com/chaltteok/owner/popup/service/OwnerPopupServiceImpl.kt
@@ -29,6 +29,8 @@ class OwnerPopupServiceImpl(
             location = request.location,
             startDate = request.startDate,
             endDate = request.endDate,
+            startTime = request.startTime,
+            endTime = request.endTime,
         )
         noticeRepository.save(notice)
     }
@@ -43,6 +45,8 @@ class OwnerPopupServiceImpl(
         notice.location = request.location
         notice.startDate = request.startDate
         notice.endDate = request.endDate
+        notice.startTime = request.startTime
+        notice.endTime = request.endTime
     }
 
     @Transactional

--- a/deal-api-user/src/main/kotlin/com/chaltteok/user/comment/controller/CommentController.kt
+++ b/deal-api-user/src/main/kotlin/com/chaltteok/user/comment/controller/CommentController.kt
@@ -1,0 +1,58 @@
+package com.chaltteok.user.comment.controller
+
+import com.chaltteok.common.dto.ResponseDTO
+import com.chaltteok.user.comment.dto.CommentRequest
+import com.chaltteok.user.comment.dto.CommentResponse
+import com.chaltteok.user.comment.dto.ReplyRequest
+import com.chaltteok.user.comment.service.UserCommentService
+import jakarta.validation.Valid
+import org.springframework.http.HttpStatus
+import org.springframework.web.bind.annotation.*
+
+@RestController
+@RequestMapping("/api/v1/user")
+class CommentController(private val userCommentService: UserCommentService) {
+
+    @GetMapping("/products/{productUuid}/comments")
+    fun getComments(
+        @PathVariable productUuid: String,
+        @RequestHeader(value = "X-User-Id", required = false) userId: Long?,
+    ): ResponseDTO<List<CommentResponse>> =
+        ResponseDTO.success(userCommentService.getComments(productUuid, userId))
+
+    @PostMapping("/products/{productUuid}/comments")
+    @ResponseStatus(HttpStatus.CREATED)
+    fun createComment(
+        @PathVariable productUuid: String,
+        @RequestHeader("X-User-Id") userId: Long,
+        @Valid @RequestBody request: CommentRequest,
+    ): ResponseDTO<CommentResponse> =
+        ResponseDTO.success(userCommentService.create(productUuid, userId, request))
+
+    @PostMapping("/comments/{commentUuid}/reply")
+    @ResponseStatus(HttpStatus.CREATED)
+    fun replyComment(
+        @PathVariable commentUuid: String,
+        @RequestHeader("X-User-Id") userId: Long,
+        @Valid @RequestBody request: ReplyRequest,
+    ): ResponseDTO<CommentResponse> =
+        ResponseDTO.success(userCommentService.reply(commentUuid, userId, request))
+
+    @PutMapping("/comments/{commentUuid}")
+    fun updateComment(
+        @PathVariable commentUuid: String,
+        @RequestHeader("X-User-Id") userId: Long,
+        @Valid @RequestBody request: CommentRequest,
+    ): ResponseDTO<CommentResponse> =
+        ResponseDTO.success(userCommentService.update(commentUuid, userId, request))
+
+    @DeleteMapping("/comments/{commentUuid}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    fun deleteComment(
+        @PathVariable commentUuid: String,
+        @RequestHeader("X-User-Id") userId: Long,
+    ): ResponseDTO<Unit> {
+        userCommentService.delete(commentUuid, userId)
+        return ResponseDTO.success(Unit)
+    }
+}

--- a/deal-api-user/src/main/kotlin/com/chaltteok/user/comment/dto/CommentRequest.kt
+++ b/deal-api-user/src/main/kotlin/com/chaltteok/user/comment/dto/CommentRequest.kt
@@ -1,0 +1,11 @@
+package com.chaltteok.user.comment.dto
+
+import jakarta.validation.constraints.Max
+import jakarta.validation.constraints.Min
+import jakarta.validation.constraints.NotBlank
+
+class CommentRequest(
+    @field:NotBlank val content: String,
+    @field:Min(1) @field:Max(5) val rating: Int? = null,
+    val isSecret: Boolean = false,
+)

--- a/deal-api-user/src/main/kotlin/com/chaltteok/user/comment/dto/CommentResponse.kt
+++ b/deal-api-user/src/main/kotlin/com/chaltteok/user/comment/dto/CommentResponse.kt
@@ -1,0 +1,38 @@
+package com.chaltteok.user.comment.dto
+
+import com.chaltteok.core.domain.Comment
+import java.time.LocalDateTime
+
+class CommentResponse(
+    val commentUuid: String,
+    val userId: Long,
+    val content: String,
+    val rating: Int?,
+    val isSecret: Boolean,
+    val isOwnerReply: Boolean,
+    val replies: List<CommentResponse>,
+    val createdAt: LocalDateTime,
+    val isMine: Boolean,
+) {
+    companion object {
+        fun from(
+            comment: Comment,
+            replies: List<Comment> = emptyList(),
+            requestingUserId: Long?,
+            isOwner: Boolean = false,
+        ): CommentResponse {
+            val secretMasked = comment.isSecret && requestingUserId != comment.userId && !isOwner
+            return CommentResponse(
+                commentUuid = comment.commentUuid,
+                userId = comment.userId,
+                content = if (secretMasked) "비밀 댓글입니다." else comment.content,
+                rating = comment.rating,
+                isSecret = comment.isSecret,
+                isOwnerReply = comment.isOwnerReply,
+                replies = replies.map { from(it, emptyList(), requestingUserId, isOwner) },
+                createdAt = comment.createdAt,
+                isMine = requestingUserId == comment.userId,
+            )
+        }
+    }
+}

--- a/deal-api-user/src/main/kotlin/com/chaltteok/user/comment/dto/ReplyRequest.kt
+++ b/deal-api-user/src/main/kotlin/com/chaltteok/user/comment/dto/ReplyRequest.kt
@@ -1,0 +1,7 @@
+package com.chaltteok.user.comment.dto
+
+import jakarta.validation.constraints.NotBlank
+
+class ReplyRequest(
+    @field:NotBlank val content: String,
+)

--- a/deal-api-user/src/main/kotlin/com/chaltteok/user/comment/enums/CommentErrorCode.kt
+++ b/deal-api-user/src/main/kotlin/com/chaltteok/user/comment/enums/CommentErrorCode.kt
@@ -1,0 +1,13 @@
+package com.chaltteok.user.comment.enums
+
+import com.chaltteok.common.enums.ErrorCode
+import org.springframework.http.HttpStatus
+
+enum class CommentErrorCode(
+    override val status: HttpStatus,
+    override val message: String,
+) : ErrorCode {
+    COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "댓글을 찾을 수 없습니다."),
+    COMMENT_ACCESS_DENIED(HttpStatus.FORBIDDEN, "댓글 수정/삭제 권한이 없습니다."),
+    PRODUCT_NOT_FOUND(HttpStatus.NOT_FOUND, "상품을 찾을 수 없습니다."),
+}

--- a/deal-api-user/src/main/kotlin/com/chaltteok/user/comment/service/UserCommentService.kt
+++ b/deal-api-user/src/main/kotlin/com/chaltteok/user/comment/service/UserCommentService.kt
@@ -1,0 +1,13 @@
+package com.chaltteok.user.comment.service
+
+import com.chaltteok.user.comment.dto.CommentRequest
+import com.chaltteok.user.comment.dto.CommentResponse
+import com.chaltteok.user.comment.dto.ReplyRequest
+
+interface UserCommentService {
+    fun getComments(productUuid: String, requestingUserId: Long?): List<CommentResponse>
+    fun create(productUuid: String, userId: Long, request: CommentRequest): CommentResponse
+    fun reply(commentUuid: String, userId: Long, request: ReplyRequest): CommentResponse
+    fun update(commentUuid: String, userId: Long, request: CommentRequest): CommentResponse
+    fun delete(commentUuid: String, userId: Long)
+}

--- a/deal-api-user/src/main/kotlin/com/chaltteok/user/comment/service/UserCommentServiceImpl.kt
+++ b/deal-api-user/src/main/kotlin/com/chaltteok/user/comment/service/UserCommentServiceImpl.kt
@@ -1,0 +1,80 @@
+package com.chaltteok.user.comment.service
+
+import com.chaltteok.common.exception.BusinessException
+import com.chaltteok.core.domain.Comment
+import com.chaltteok.core.repository.comment.CommentRepository
+import com.chaltteok.core.repository.product.ProductRepository
+import com.chaltteok.user.comment.dto.CommentRequest
+import com.chaltteok.user.comment.dto.CommentResponse
+import com.chaltteok.user.comment.dto.ReplyRequest
+import com.chaltteok.user.comment.enums.CommentErrorCode
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class UserCommentServiceImpl(
+    private val commentRepository: CommentRepository,
+    private val productRepository: ProductRepository,
+) : UserCommentService {
+
+    @Transactional(readOnly = true)
+    override fun getComments(productUuid: String, requestingUserId: Long?): List<CommentResponse> {
+        val roots = commentRepository.findRootCommentsByProductUuid(productUuid)
+        if (roots.isEmpty()) return emptyList()
+        val replyMap = commentRepository.findRepliesByParentIds(roots.mapNotNull { it.id })
+            .groupBy { it.parentId }
+        return roots.map { root ->
+            CommentResponse.from(root, replyMap[root.id] ?: emptyList(), requestingUserId)
+        }
+    }
+
+    @Transactional
+    override fun create(productUuid: String, userId: Long, request: CommentRequest): CommentResponse {
+        val product = productRepository.findByProductUuid(productUuid)
+            ?: throw BusinessException(CommentErrorCode.PRODUCT_NOT_FOUND)
+        val comment = commentRepository.save(
+            Comment(
+                product = product,
+                userId = userId,
+                content = request.content,
+                rating = request.rating,
+                isSecret = request.isSecret,
+            )
+        )
+        return CommentResponse.from(comment, emptyList(), userId)
+    }
+
+    @Transactional
+    override fun reply(commentUuid: String, userId: Long, request: ReplyRequest): CommentResponse {
+        val parent = commentRepository.findByCommentUuid(commentUuid)
+            ?: throw BusinessException(CommentErrorCode.COMMENT_NOT_FOUND)
+        val reply = commentRepository.save(
+            Comment(
+                product = parent.product,
+                userId = userId,
+                content = request.content,
+                parentId = parent.id,
+            )
+        )
+        return CommentResponse.from(reply, emptyList(), userId)
+    }
+
+    @Transactional
+    override fun update(commentUuid: String, userId: Long, request: CommentRequest): CommentResponse {
+        val comment = commentRepository.findByCommentUuid(commentUuid)
+            ?: throw BusinessException(CommentErrorCode.COMMENT_NOT_FOUND)
+        if (comment.userId != userId) throw BusinessException(CommentErrorCode.COMMENT_ACCESS_DENIED)
+        comment.content = request.content
+        comment.rating = request.rating
+        comment.isSecret = request.isSecret
+        return CommentResponse.from(comment, emptyList(), userId)
+    }
+
+    @Transactional
+    override fun delete(commentUuid: String, userId: Long) {
+        val comment = commentRepository.findByCommentUuid(commentUuid)
+            ?: throw BusinessException(CommentErrorCode.COMMENT_NOT_FOUND)
+        if (comment.userId != userId) throw BusinessException(CommentErrorCode.COMMENT_ACCESS_DENIED)
+        commentRepository.delete(comment)
+    }
+}

--- a/deal-api-user/src/main/kotlin/com/chaltteok/user/popup/service/UserPopupServiceImpl.kt
+++ b/deal-api-user/src/main/kotlin/com/chaltteok/user/popup/service/UserPopupServiceImpl.kt
@@ -5,6 +5,7 @@ import com.chaltteok.user.popup.dto.PopupResponse
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.time.LocalDate
+import java.time.LocalTime
 
 @Service
 class UserPopupServiceImpl(
@@ -13,5 +14,5 @@ class UserPopupServiceImpl(
 
     @Transactional(readOnly = true)
     override fun getActivePopups(): List<PopupResponse> =
-        noticeRepository.findActiveNotices(LocalDate.now()).map { PopupResponse.from(it) }
+        noticeRepository.findActiveNotices(LocalDate.now(), LocalTime.now()).map { PopupResponse.from(it) }
 }

--- a/deal-core/src/main/kotlin/com/chaltteok/core/domain/Comment.kt
+++ b/deal-core/src/main/kotlin/com/chaltteok/core/domain/Comment.kt
@@ -1,0 +1,41 @@
+package com.chaltteok.core.domain
+
+import jakarta.persistence.*
+import java.util.UUID
+
+@Entity
+@Table(
+    name = "tb_comment",
+    uniqueConstraints = [UniqueConstraint(name = "uk_comment_uuid", columnNames = ["comment_uuid"])]
+)
+class Comment(
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "product_id", nullable = false)
+    val product: Product,
+
+    @Column(name = "user_id", nullable = false)
+    val userId: Long,
+
+    @Column(name = "content", columnDefinition = "TEXT", nullable = false)
+    var content: String,
+
+    @Column(name = "rating")
+    var rating: Int? = null,
+
+    @Column(name = "is_secret", nullable = false)
+    var isSecret: Boolean = false,
+
+    @Column(name = "parent_id")
+    val parentId: Long? = null,
+
+    @Column(name = "is_owner_reply", nullable = false)
+    val isOwnerReply: Boolean = false,
+) : BaseEntity() {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "comment_id")
+    var id: Long? = null
+
+    @Column(name = "comment_uuid", nullable = false, length = 36)
+    val commentUuid: String = UUID.randomUUID().toString()
+}

--- a/deal-core/src/main/kotlin/com/chaltteok/core/domain/Notice.kt
+++ b/deal-core/src/main/kotlin/com/chaltteok/core/domain/Notice.kt
@@ -2,6 +2,7 @@ package com.chaltteok.core.domain
 
 import jakarta.persistence.*
 import java.time.LocalDate
+import java.time.LocalTime
 import java.util.UUID
 
 @Entity
@@ -24,6 +25,12 @@ class Notice(
 
     @Column(name = "end_date")
     var endDate: LocalDate? = null,
+
+    @Column(name = "start_time")
+    var startTime: LocalTime? = null,
+
+    @Column(name = "end_time")
+    var endTime: LocalTime? = null,
 ) : BaseEntity() {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/deal-core/src/main/kotlin/com/chaltteok/core/repository/comment/CommentRepository.kt
+++ b/deal-core/src/main/kotlin/com/chaltteok/core/repository/comment/CommentRepository.kt
@@ -1,0 +1,31 @@
+package com.chaltteok.core.repository.comment
+
+import com.chaltteok.core.domain.Comment
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
+
+interface CommentRepository : JpaRepository<Comment, Long> {
+    fun findByCommentUuid(uuid: String): Comment?
+
+    @Query("""
+        SELECT c FROM Comment c
+        WHERE c.product.productUuid = :productUuid
+        AND c.parentId IS NULL
+        ORDER BY c.createdAt ASC
+    """)
+    fun findRootCommentsByProductUuid(@Param("productUuid") productUuid: String): List<Comment>
+
+    @Query("""
+        SELECT c FROM Comment c
+        WHERE c.parentId IN :parentIds
+        ORDER BY c.createdAt ASC
+    """)
+    fun findRepliesByParentIds(@Param("parentIds") parentIds: List<Long>): List<Comment>
+
+    @Query("""
+        SELECT c FROM Comment c
+        ORDER BY c.createdAt DESC
+    """)
+    fun findAllOrderByCreatedAtDesc(): List<Comment>
+}

--- a/deal-core/src/main/kotlin/com/chaltteok/core/repository/notice/NoticeRepository.kt
+++ b/deal-core/src/main/kotlin/com/chaltteok/core/repository/notice/NoticeRepository.kt
@@ -5,6 +5,7 @@ import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
 import org.springframework.data.repository.query.Param
 import java.time.LocalDate
+import java.time.LocalTime
 
 interface NoticeRepository : JpaRepository<Notice, Long> {
     fun findByNoticeUuid(uuid: String): Notice?
@@ -14,7 +15,9 @@ interface NoticeRepository : JpaRepository<Notice, Long> {
         WHERE n.isVisible = true
         AND (n.startDate IS NULL OR n.startDate <= :today)
         AND (n.endDate IS NULL OR n.endDate >= :today)
+        AND (n.startTime IS NULL OR n.startTime <= :now)
+        AND (n.endTime IS NULL OR n.endTime >= :now)
         ORDER BY n.createdAt DESC
     """)
-    fun findActiveNotices(@Param("today") today: LocalDate): List<Notice>
+    fun findActiveNotices(@Param("today") today: LocalDate, @Param("now") now: LocalTime): List<Notice>
 }


### PR DESCRIPTION
## Summary

- `Notice` 엔티티에 `startTime`/`endTime`(LocalTime) 추가, 팝업 활성 조회 시 날짜+시간 범위 필터링
- `Comment` 엔티티 신규 생성: 별점(1~5)·비밀 여부·답글(`parentId`)·점주 답글(`isOwnerReply`) 지원
- 유저 댓글 CRUD API (`/api/v1/user/products/{uuid}/comments`, `/api/v1/user/comments/{uuid}`)
- 점주 댓글 관리 API (`GET/DELETE /api/v1/owner/comments/{uuid}`, `POST .../reply`)
- DB 마이그레이션: `tb_notice`에 시간 컬럼 추가, `tb_comment` 신규 생성

## Test plan

- [ ] `./gradlew :deal-api-user:compileKotlin :deal-api-owner:compileKotlin` → BUILD SUCCESSFUL
- [ ] DB 마이그레이션 SQL 적용 (`add_popup_time_and_comment_table.sql`)
- [ ] `GET /api/v1/user/popups` 호출 → startTime/endTime 범위 내 팝업만 반환
- [ ] `POST /api/v1/user/products/{uuid}/comments` → 댓글 등록 확인
- [ ] `POST /api/v1/owner/comments/{uuid}/reply` → 점주 답글 확인

Resolves #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)