### PR TITLE
[FIX/FEAT] 비밀 댓글 완전 숨김 및 상품별 댓글 수 포함

### DIFF
--- a/deal-api-user/src/main/kotlin/com/chaltteok/user/comment/dto/CommentResponse.kt
+++ b/deal-api-user/src/main/kotlin/com/chaltteok/user/comment/dto/CommentResponse.kt
@@ -19,20 +19,16 @@ class CommentResponse(
             comment: Comment,
             replies: List<Comment> = emptyList(),
             requestingUserId: Long?,
-            isOwner: Boolean = false,
-        ): CommentResponse {
-            val secretMasked = comment.isSecret && requestingUserId != comment.userId && !isOwner
-            return CommentResponse(
-                commentUuid = comment.commentUuid,
-                userId = comment.userId,
-                content = if (secretMasked) "비밀 댓글입니다." else comment.content,
-                rating = comment.rating,
-                isSecret = comment.isSecret,
-                isOwnerReply = comment.isOwnerReply,
-                replies = replies.map { from(it, emptyList(), requestingUserId, isOwner) },
-                createdAt = comment.createdAt,
-                isMine = requestingUserId == comment.userId,
-            )
-        }
+        ): CommentResponse = CommentResponse(
+            commentUuid = comment.commentUuid,
+            userId = comment.userId,
+            content = comment.content,
+            rating = comment.rating,
+            isSecret = comment.isSecret,
+            isOwnerReply = comment.isOwnerReply,
+            replies = replies.map { from(it, emptyList(), requestingUserId) },
+            createdAt = comment.createdAt,
+            isMine = requestingUserId == comment.userId,
+        )
     }
 }

--- a/deal-api-user/src/main/kotlin/com/chaltteok/user/comment/service/UserCommentServiceImpl.kt
+++ b/deal-api-user/src/main/kotlin/com/chaltteok/user/comment/service/UserCommentServiceImpl.kt
@@ -20,8 +20,10 @@ class UserCommentServiceImpl(
     @Transactional(readOnly = true)
     override fun getComments(productUuid: String, requestingUserId: Long?): List<CommentResponse> {
         val roots = commentRepository.findRootCommentsByProductUuid(productUuid)
+            .filter { !it.isSecret || it.userId == requestingUserId }
         if (roots.isEmpty()) return emptyList()
         val replyMap = commentRepository.findRepliesByParentIds(roots.mapNotNull { it.id })
+            .filter { !it.isSecret || it.userId == requestingUserId }
             .groupBy { it.parentId }
         return roots.map { root ->
             CommentResponse.from(root, replyMap[root.id] ?: emptyList(), requestingUserId)

--- a/deal-api-user/src/main/kotlin/com/chaltteok/user/product/dto/ProductResponse.kt
+++ b/deal-api-user/src/main/kotlin/com/chaltteok/user/product/dto/ProductResponse.kt
@@ -10,9 +10,10 @@ data class ProductResponse(
     val description: String?,
     val thumbnailUrl: String?,
     val soldOut: Boolean,
+    val commentCount: Int = 0,
 ) {
     companion object {
-        fun from(product: Product) = ProductResponse(
+        fun from(product: Product, commentCount: Int = 0) = ProductResponse(
             id = product.id!!,
             productUuid = product.productUuid,
             name = product.name,
@@ -20,6 +21,7 @@ data class ProductResponse(
             description = product.description?.ifBlank { null },
             thumbnailUrl = product.imageUrl,
             soldOut = product.isSoldOut,
+            commentCount = commentCount,
         )
     }
 }

--- a/deal-api-user/src/main/kotlin/com/chaltteok/user/product/service/ProductQueryServiceImpl.kt
+++ b/deal-api-user/src/main/kotlin/com/chaltteok/user/product/service/ProductQueryServiceImpl.kt
@@ -1,5 +1,6 @@
 package com.chaltteok.user.product.service
 
+import com.chaltteok.core.repository.comment.CommentRepository
 import com.chaltteok.core.repository.product.ProductRepository
 import com.chaltteok.user.product.dto.ProductResponse
 import org.springframework.stereotype.Service
@@ -8,19 +9,30 @@ import org.springframework.transaction.annotation.Transactional
 @Service
 class ProductQueryServiceImpl(
     private val productRepository: ProductRepository,
+    private val commentRepository: CommentRepository,
 ) : ProductQueryService {
 
     @Transactional(readOnly = true)
-    override fun getProducts(): List<ProductResponse> =
-        productRepository.findAllByIsActiveTrue()
-            .map { ProductResponse.from(it) }
+    override fun getProducts(): List<ProductResponse> {
+        val products = productRepository.findAllByIsActiveTrue()
+        val countMap = commentRepository.countRootCommentsByProductIds(products.mapNotNull { it.id })
+            .associate { it.productId to it.cnt.toInt() }
+        return products.map { ProductResponse.from(it, countMap[it.id!!] ?: 0) }
+    }
 
     @Transactional(readOnly = true)
-    override fun getRecommendedProducts(): List<ProductResponse> =
-        productRepository.findAllByIsActiveTrueAndIsRecommendedTrue()
-            .map { ProductResponse.from(it) }
+    override fun getRecommendedProducts(): List<ProductResponse> {
+        val products = productRepository.findAllByIsActiveTrueAndIsRecommendedTrue()
+        val countMap = commentRepository.countRootCommentsByProductIds(products.mapNotNull { it.id })
+            .associate { it.productId to it.cnt.toInt() }
+        return products.map { ProductResponse.from(it, countMap[it.id!!] ?: 0) }
+    }
 
     @Transactional(readOnly = true)
-    override fun searchProducts(keyword: String): List<ProductResponse> =
-        productRepository.searchByKeyword(keyword).map { ProductResponse.from(it) }
+    override fun searchProducts(keyword: String): List<ProductResponse> {
+        val products = productRepository.searchByKeyword(keyword)
+        val countMap = commentRepository.countRootCommentsByProductIds(products.mapNotNull { it.id })
+            .associate { it.productId to it.cnt.toInt() }
+        return products.map { ProductResponse.from(it, countMap[it.id!!] ?: 0) }
+    }
 }

--- a/deal-api-user/src/main/kotlin/com/chaltteok/user/product/service/ProductQueryServiceImpl.kt
+++ b/deal-api-user/src/main/kotlin/com/chaltteok/user/product/service/ProductQueryServiceImpl.kt
@@ -15,6 +15,7 @@ class ProductQueryServiceImpl(
     @Transactional(readOnly = true)
     override fun getProducts(): List<ProductResponse> {
         val products = productRepository.findAllByIsActiveTrue()
+        if (products.isEmpty()) return emptyList()
         val countMap = commentRepository.countRootCommentsByProductIds(products.mapNotNull { it.id })
             .associate { it.productId to it.cnt.toInt() }
         return products.map { ProductResponse.from(it, countMap[it.id!!] ?: 0) }
@@ -23,6 +24,7 @@ class ProductQueryServiceImpl(
     @Transactional(readOnly = true)
     override fun getRecommendedProducts(): List<ProductResponse> {
         val products = productRepository.findAllByIsActiveTrueAndIsRecommendedTrue()
+        if (products.isEmpty()) return emptyList()
         val countMap = commentRepository.countRootCommentsByProductIds(products.mapNotNull { it.id })
             .associate { it.productId to it.cnt.toInt() }
         return products.map { ProductResponse.from(it, countMap[it.id!!] ?: 0) }
@@ -31,6 +33,7 @@ class ProductQueryServiceImpl(
     @Transactional(readOnly = true)
     override fun searchProducts(keyword: String): List<ProductResponse> {
         val products = productRepository.searchByKeyword(keyword)
+        if (products.isEmpty()) return emptyList()
         val countMap = commentRepository.countRootCommentsByProductIds(products.mapNotNull { it.id })
             .associate { it.productId to it.cnt.toInt() }
         return products.map { ProductResponse.from(it, countMap[it.id!!] ?: 0) }

--- a/deal-core/src/main/kotlin/com/chaltteok/core/repository/comment/CommentRepository.kt
+++ b/deal-core/src/main/kotlin/com/chaltteok/core/repository/comment/CommentRepository.kt
@@ -5,6 +5,11 @@ import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
 import org.springframework.data.repository.query.Param
 
+interface CommentCountProjection {
+    val productId: Long
+    val cnt: Long
+}
+
 interface CommentRepository : JpaRepository<Comment, Long> {
     fun findByCommentUuid(uuid: String): Comment?
 
@@ -28,4 +33,13 @@ interface CommentRepository : JpaRepository<Comment, Long> {
         ORDER BY c.createdAt DESC
     """)
     fun findAllOrderByCreatedAtDesc(): List<Comment>
+
+    @Query("""
+        SELECT c.product.id AS productId, COUNT(c) AS cnt
+        FROM Comment c
+        WHERE c.product.id IN :productIds
+        AND c.parentId IS NULL
+        GROUP BY c.product.id
+    """)
+    fun countRootCommentsByProductIds(@Param("productIds") productIds: List<Long>): List<CommentCountProjection>
 }


### PR DESCRIPTION
## Summary
- 비밀 댓글을 서비스 레이어 필터링으로 작성자 외 사용자에게 완전 미노출 처리 (기존 내용 마스킹 → 목록 제외)
- 상품 목록 응답에 `commentCount` 필드 추가 (배치 쿼리, N+1 없음)
- `CommentResponse.from()` 마스킹 로직 제거, 시그니처 단순화

## Changes
- `CommentRepository`: `CommentCountProjection` + `countRootCommentsByProductIds()` 추가
- `ProductResponse`: `commentCount: Int = 0` 필드 추가
- `ProductQueryServiceImpl`: 댓글 수 배치 조회 후 상품 응답에 매핑
- `UserCommentServiceImpl.getComments()`: 루트/답글 모두 비밀 댓글 필터링 적용
- `CommentResponse.from()`: 마스킹 파라미터(`isOwner`) 제거, 로직 단순화

## Test plan
- [ ] 비밀 댓글 작성 후 다른 유저 조회 시 목록에 미노출 확인
- [ ] 비밀 댓글 작성자 본인 조회 시 정상 노출 확인
- [ ] 비로그인(userId=null) 조회 시 비밀 댓글 미노출 확인
- [ ] `GET /api/v1/user/products` 응답에 `commentCount` 필드 포함 확인

Resolves #32
Resolves #33

🤖 Generated with [Claude Code](https://claude.com/claude-code)