### PR TITLE
[FIX/REFACTOR/FEAT] tb_notice→tb_popup 이름변경, 공지사항/문의 기능 추가

### DIFF
--- a/db/migration/rename_notice_to_popup_add_notice_inquiry.sql
+++ b/db/migration/rename_notice_to_popup_add_notice_inquiry.sql
@@ -1,0 +1,38 @@
+-- ① tb_notice(팝업 용도) → tb_popup 으로 이름 변경 + 컬럼명 정리
+RENAME TABLE tb_notice TO tb_popup;
+
+ALTER TABLE tb_popup
+    CHANGE COLUMN notice_id popup_id BIGINT NOT NULL AUTO_INCREMENT,
+    CHANGE COLUMN notice_uuid popup_uuid VARCHAR(36) NOT NULL;
+
+DROP INDEX uk_notice_uuid ON tb_popup;
+CREATE UNIQUE INDEX uk_popup_uuid ON tb_popup (popup_uuid);
+
+-- ② 공지사항 전용 tb_notice 테이블 신규 생성
+CREATE TABLE IF NOT EXISTS tb_notice (
+    notice_id   BIGINT NOT NULL AUTO_INCREMENT PRIMARY KEY,
+    notice_uuid VARCHAR(36)  NOT NULL,
+    title       VARCHAR(200) NOT NULL,
+    content     TEXT         NOT NULL,
+    is_visible  TINYINT(1)   NOT NULL DEFAULT 1,
+    created_at  DATETIME     NOT NULL,
+    updated_at  DATETIME     NOT NULL,
+    CONSTRAINT uk_notice_uuid UNIQUE (notice_uuid)
+);
+
+-- ③ 1:1 문의 tb_inquiry 테이블 신규 생성
+CREATE TABLE IF NOT EXISTS tb_inquiry (
+    inquiry_id   BIGINT NOT NULL AUTO_INCREMENT PRIMARY KEY,
+    inquiry_uuid VARCHAR(36)  NOT NULL,
+    user_id      BIGINT       NOT NULL,
+    title        VARCHAR(200) NOT NULL,
+    content      TEXT         NOT NULL,
+    status       VARCHAR(20)  NOT NULL DEFAULT 'PENDING',
+    answer       TEXT         NULL,
+    answered_at  DATETIME     NULL,
+    created_at   DATETIME     NOT NULL,
+    updated_at   DATETIME     NOT NULL,
+    CONSTRAINT uk_inquiry_uuid UNIQUE (inquiry_uuid)
+);
+
+CREATE INDEX idx_inquiry_user ON tb_inquiry (user_id);

--- a/deal-api-owner/src/main/kotlin/com/chaltteok/owner/inquiry/controller/OwnerInquiryController.kt
+++ b/deal-api-owner/src/main/kotlin/com/chaltteok/owner/inquiry/controller/OwnerInquiryController.kt
@@ -1,0 +1,26 @@
+package com.chaltteok.owner.inquiry.controller
+
+import com.chaltteok.common.dto.ResponseDTO
+import com.chaltteok.owner.inquiry.dto.AnswerRequest
+import com.chaltteok.owner.inquiry.dto.OwnerInquiryResponse
+import com.chaltteok.owner.inquiry.service.OwnerInquiryService
+import jakarta.validation.Valid
+import org.springframework.web.bind.annotation.*
+
+@RestController
+@RequestMapping("/api/v1/owner/inquiries")
+class OwnerInquiryController(private val ownerInquiryService: OwnerInquiryService) {
+
+    @GetMapping
+    fun getAll(): ResponseDTO<List<OwnerInquiryResponse>> =
+        ResponseDTO.success(ownerInquiryService.getAll())
+
+    @PutMapping("/{inquiryUuid}/answer")
+    fun answer(
+        @PathVariable inquiryUuid: String,
+        @Valid @RequestBody request: AnswerRequest,
+    ): ResponseDTO<Unit> {
+        ownerInquiryService.answer(inquiryUuid, request)
+        return ResponseDTO.success(Unit)
+    }
+}

--- a/deal-api-owner/src/main/kotlin/com/chaltteok/owner/inquiry/dto/AnswerRequest.kt
+++ b/deal-api-owner/src/main/kotlin/com/chaltteok/owner/inquiry/dto/AnswerRequest.kt
@@ -1,0 +1,7 @@
+package com.chaltteok.owner.inquiry.dto
+
+import jakarta.validation.constraints.NotBlank
+
+class AnswerRequest(
+    @field:NotBlank val answer: String,
+)

--- a/deal-api-owner/src/main/kotlin/com/chaltteok/owner/inquiry/dto/OwnerInquiryResponse.kt
+++ b/deal-api-owner/src/main/kotlin/com/chaltteok/owner/inquiry/dto/OwnerInquiryResponse.kt
@@ -1,0 +1,28 @@
+package com.chaltteok.owner.inquiry.dto
+
+import com.chaltteok.core.domain.Inquiry
+import java.time.LocalDateTime
+
+class OwnerInquiryResponse(
+    val inquiryUuid: String,
+    val userId: Long,
+    val title: String,
+    val content: String,
+    val status: String,
+    val answer: String?,
+    val answeredAt: LocalDateTime?,
+    val createdAt: LocalDateTime,
+) {
+    companion object {
+        fun from(inquiry: Inquiry) = OwnerInquiryResponse(
+            inquiryUuid = inquiry.inquiryUuid,
+            userId = inquiry.userId,
+            title = inquiry.title,
+            content = inquiry.content,
+            status = inquiry.status,
+            answer = inquiry.answer,
+            answeredAt = inquiry.answeredAt,
+            createdAt = inquiry.createdAt,
+        )
+    }
+}

--- a/deal-api-owner/src/main/kotlin/com/chaltteok/owner/inquiry/enums/InquiryErrorCode.kt
+++ b/deal-api-owner/src/main/kotlin/com/chaltteok/owner/inquiry/enums/InquiryErrorCode.kt
@@ -1,0 +1,11 @@
+package com.chaltteok.owner.inquiry.enums
+
+import com.chaltteok.common.enums.ErrorCode
+import org.springframework.http.HttpStatus
+
+enum class InquiryErrorCode(
+    override val status: HttpStatus,
+    override val message: String,
+) : ErrorCode {
+    INQUIRY_NOT_FOUND(HttpStatus.NOT_FOUND, "문의를 찾을 수 없습니다."),
+}

--- a/deal-api-owner/src/main/kotlin/com/chaltteok/owner/inquiry/service/OwnerInquiryService.kt
+++ b/deal-api-owner/src/main/kotlin/com/chaltteok/owner/inquiry/service/OwnerInquiryService.kt
@@ -1,0 +1,9 @@
+package com.chaltteok.owner.inquiry.service
+
+import com.chaltteok.owner.inquiry.dto.AnswerRequest
+import com.chaltteok.owner.inquiry.dto.OwnerInquiryResponse
+
+interface OwnerInquiryService {
+    fun getAll(): List<OwnerInquiryResponse>
+    fun answer(inquiryUuid: String, request: AnswerRequest)
+}

--- a/deal-api-owner/src/main/kotlin/com/chaltteok/owner/inquiry/service/OwnerInquiryServiceImpl.kt
+++ b/deal-api-owner/src/main/kotlin/com/chaltteok/owner/inquiry/service/OwnerInquiryServiceImpl.kt
@@ -1,0 +1,29 @@
+package com.chaltteok.owner.inquiry.service
+
+import com.chaltteok.common.exception.BusinessException
+import com.chaltteok.core.repository.inquiry.InquiryRepository
+import com.chaltteok.owner.inquiry.dto.AnswerRequest
+import com.chaltteok.owner.inquiry.dto.OwnerInquiryResponse
+import com.chaltteok.owner.inquiry.enums.InquiryErrorCode
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDateTime
+
+@Service
+class OwnerInquiryServiceImpl(
+    private val inquiryRepository: InquiryRepository,
+) : OwnerInquiryService {
+
+    @Transactional(readOnly = true)
+    override fun getAll(): List<OwnerInquiryResponse> =
+        inquiryRepository.findAllByOrderByCreatedAtDesc().map { OwnerInquiryResponse.from(it) }
+
+    @Transactional
+    override fun answer(inquiryUuid: String, request: AnswerRequest) {
+        val inquiry = inquiryRepository.findByInquiryUuid(inquiryUuid)
+            ?: throw BusinessException(InquiryErrorCode.INQUIRY_NOT_FOUND)
+        inquiry.answer = request.answer
+        inquiry.status = "ANSWERED"
+        inquiry.answeredAt = LocalDateTime.now()
+    }
+}

--- a/deal-api-owner/src/main/kotlin/com/chaltteok/owner/notice/controller/OwnerNoticeController.kt
+++ b/deal-api-owner/src/main/kotlin/com/chaltteok/owner/notice/controller/OwnerNoticeController.kt
@@ -1,0 +1,41 @@
+package com.chaltteok.owner.notice.controller
+
+import com.chaltteok.common.dto.ResponseDTO
+import com.chaltteok.owner.notice.dto.NoticeRequest
+import com.chaltteok.owner.notice.dto.NoticeResponse
+import com.chaltteok.owner.notice.service.OwnerNoticeService
+import jakarta.validation.Valid
+import org.springframework.http.HttpStatus
+import org.springframework.web.bind.annotation.*
+
+@RestController
+@RequestMapping("/api/v1/owner/notices")
+class OwnerNoticeController(private val ownerNoticeService: OwnerNoticeService) {
+
+    @GetMapping
+    fun getAll(): ResponseDTO<List<NoticeResponse>> =
+        ResponseDTO.success(ownerNoticeService.getAll())
+
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    fun create(@Valid @RequestBody request: NoticeRequest): ResponseDTO<Unit> {
+        ownerNoticeService.create(request)
+        return ResponseDTO.success(Unit)
+    }
+
+    @PutMapping("/{noticeUuid}")
+    fun update(
+        @PathVariable noticeUuid: String,
+        @Valid @RequestBody request: NoticeRequest,
+    ): ResponseDTO<Unit> {
+        ownerNoticeService.update(noticeUuid, request)
+        return ResponseDTO.success(Unit)
+    }
+
+    @DeleteMapping("/{noticeUuid}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    fun delete(@PathVariable noticeUuid: String): ResponseDTO<Unit> {
+        ownerNoticeService.delete(noticeUuid)
+        return ResponseDTO.success(Unit)
+    }
+}

--- a/deal-api-owner/src/main/kotlin/com/chaltteok/owner/notice/dto/NoticeRequest.kt
+++ b/deal-api-owner/src/main/kotlin/com/chaltteok/owner/notice/dto/NoticeRequest.kt
@@ -1,0 +1,9 @@
+package com.chaltteok.owner.notice.dto
+
+import jakarta.validation.constraints.NotBlank
+
+class NoticeRequest(
+    @field:NotBlank val title: String,
+    @field:NotBlank val content: String,
+    val isVisible: Boolean = true,
+)

--- a/deal-api-owner/src/main/kotlin/com/chaltteok/owner/notice/dto/NoticeResponse.kt
+++ b/deal-api-owner/src/main/kotlin/com/chaltteok/owner/notice/dto/NoticeResponse.kt
@@ -1,0 +1,22 @@
+package com.chaltteok.owner.notice.dto
+
+import com.chaltteok.core.domain.Notice
+import java.time.LocalDateTime
+
+class NoticeResponse(
+    val noticeUuid: String,
+    val title: String,
+    val content: String,
+    val isVisible: Boolean,
+    val createdAt: LocalDateTime,
+) {
+    companion object {
+        fun from(notice: Notice) = NoticeResponse(
+            noticeUuid = notice.noticeUuid,
+            title = notice.title,
+            content = notice.content,
+            isVisible = notice.isVisible,
+            createdAt = notice.createdAt,
+        )
+    }
+}

--- a/deal-api-owner/src/main/kotlin/com/chaltteok/owner/notice/enums/NoticeErrorCode.kt
+++ b/deal-api-owner/src/main/kotlin/com/chaltteok/owner/notice/enums/NoticeErrorCode.kt
@@ -1,0 +1,11 @@
+package com.chaltteok.owner.notice.enums
+
+import com.chaltteok.common.enums.ErrorCode
+import org.springframework.http.HttpStatus
+
+enum class NoticeErrorCode(
+    override val status: HttpStatus,
+    override val message: String,
+) : ErrorCode {
+    NOTICE_NOT_FOUND(HttpStatus.NOT_FOUND, "공지사항을 찾을 수 없습니다."),
+}

--- a/deal-api-owner/src/main/kotlin/com/chaltteok/owner/notice/service/OwnerNoticeService.kt
+++ b/deal-api-owner/src/main/kotlin/com/chaltteok/owner/notice/service/OwnerNoticeService.kt
@@ -1,0 +1,11 @@
+package com.chaltteok.owner.notice.service
+
+import com.chaltteok.owner.notice.dto.NoticeRequest
+import com.chaltteok.owner.notice.dto.NoticeResponse
+
+interface OwnerNoticeService {
+    fun getAll(): List<NoticeResponse>
+    fun create(request: NoticeRequest)
+    fun update(noticeUuid: String, request: NoticeRequest)
+    fun delete(noticeUuid: String)
+}

--- a/deal-api-owner/src/main/kotlin/com/chaltteok/owner/notice/service/OwnerNoticeServiceImpl.kt
+++ b/deal-api-owner/src/main/kotlin/com/chaltteok/owner/notice/service/OwnerNoticeServiceImpl.kt
@@ -1,0 +1,49 @@
+package com.chaltteok.owner.notice.service
+
+import com.chaltteok.common.exception.BusinessException
+import com.chaltteok.core.domain.Notice
+import com.chaltteok.core.repository.notice.NoticeRepository
+import com.chaltteok.owner.notice.dto.NoticeRequest
+import com.chaltteok.owner.notice.dto.NoticeResponse
+import com.chaltteok.owner.notice.enums.NoticeErrorCode
+import org.springframework.data.domain.Sort
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class OwnerNoticeServiceImpl(
+    private val noticeRepository: NoticeRepository,
+) : OwnerNoticeService {
+
+    @Transactional(readOnly = true)
+    override fun getAll(): List<NoticeResponse> =
+        noticeRepository.findAll(Sort.by(Sort.Direction.DESC, "createdAt"))
+            .map { NoticeResponse.from(it) }
+
+    @Transactional
+    override fun create(request: NoticeRequest) {
+        noticeRepository.save(
+            Notice(
+                title = request.title,
+                content = request.content,
+                isVisible = request.isVisible,
+            )
+        )
+    }
+
+    @Transactional
+    override fun update(noticeUuid: String, request: NoticeRequest) {
+        val notice = noticeRepository.findByNoticeUuid(noticeUuid)
+            ?: throw BusinessException(NoticeErrorCode.NOTICE_NOT_FOUND)
+        notice.title = request.title
+        notice.content = request.content
+        notice.isVisible = request.isVisible
+    }
+
+    @Transactional
+    override fun delete(noticeUuid: String) {
+        val notice = noticeRepository.findByNoticeUuid(noticeUuid)
+            ?: throw BusinessException(NoticeErrorCode.NOTICE_NOT_FOUND)
+        noticeRepository.delete(notice)
+    }
+}

--- a/deal-api-owner/src/main/kotlin/com/chaltteok/owner/popup/dto/PopupResponse.kt
+++ b/deal-api-owner/src/main/kotlin/com/chaltteok/owner/popup/dto/PopupResponse.kt
@@ -1,6 +1,6 @@
 package com.chaltteok.owner.popup.dto
 
-import com.chaltteok.core.domain.Notice
+import com.chaltteok.core.domain.Popup
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.LocalTime
@@ -18,17 +18,17 @@ class PopupResponse(
     val createdAt: LocalDateTime,
 ) {
     companion object {
-        fun from(notice: Notice) = PopupResponse(
-            popupUuid = notice.noticeUuid,
-            title = notice.title,
-            content = notice.content,
-            isVisible = notice.isVisible,
-            location = notice.location,
-            startDate = notice.startDate,
-            endDate = notice.endDate,
-            startTime = notice.startTime,
-            endTime = notice.endTime,
-            createdAt = notice.createdAt,
+        fun from(popup: Popup) = PopupResponse(
+            popupUuid = popup.popupUuid,
+            title = popup.title,
+            content = popup.content,
+            isVisible = popup.isVisible,
+            location = popup.location,
+            startDate = popup.startDate,
+            endDate = popup.endDate,
+            startTime = popup.startTime,
+            endTime = popup.endTime,
+            createdAt = popup.createdAt,
         )
     }
 }

--- a/deal-api-owner/src/main/kotlin/com/chaltteok/owner/popup/service/OwnerPopupServiceImpl.kt
+++ b/deal-api-owner/src/main/kotlin/com/chaltteok/owner/popup/service/OwnerPopupServiceImpl.kt
@@ -1,8 +1,8 @@
 package com.chaltteok.owner.popup.service
 
 import com.chaltteok.common.exception.BusinessException
-import com.chaltteok.core.domain.Notice
-import com.chaltteok.core.repository.notice.NoticeRepository
+import com.chaltteok.core.domain.Popup
+import com.chaltteok.core.repository.popup.PopupRepository
 import com.chaltteok.owner.popup.dto.PopupRequest
 import com.chaltteok.owner.popup.dto.PopupResponse
 import com.chaltteok.owner.popup.enums.PopupErrorCode
@@ -12,17 +12,17 @@ import org.springframework.transaction.annotation.Transactional
 
 @Service
 class OwnerPopupServiceImpl(
-    private val noticeRepository: NoticeRepository,
+    private val popupRepository: PopupRepository,
 ) : OwnerPopupService {
 
     @Transactional(readOnly = true)
     override fun getAll(): List<PopupResponse> =
-        noticeRepository.findAll(Sort.by(Sort.Direction.DESC, "createdAt"))
+        popupRepository.findAll(Sort.by(Sort.Direction.DESC, "createdAt"))
             .map { PopupResponse.from(it) }
 
     @Transactional
     override fun create(request: PopupRequest) {
-        val notice = Notice(
+        val popup = Popup(
             title = request.title,
             content = request.content,
             isVisible = request.isVisible,
@@ -32,27 +32,27 @@ class OwnerPopupServiceImpl(
             startTime = request.startTime,
             endTime = request.endTime,
         )
-        noticeRepository.save(notice)
+        popupRepository.save(popup)
     }
 
     @Transactional
     override fun update(popupUuid: String, request: PopupRequest) {
-        val notice = noticeRepository.findByNoticeUuid(popupUuid)
+        val popup = popupRepository.findByPopupUuid(popupUuid)
             ?: throw BusinessException(PopupErrorCode.POPUP_NOT_FOUND)
-        notice.title = request.title
-        notice.content = request.content
-        notice.isVisible = request.isVisible
-        notice.location = request.location
-        notice.startDate = request.startDate
-        notice.endDate = request.endDate
-        notice.startTime = request.startTime
-        notice.endTime = request.endTime
+        popup.title = request.title
+        popup.content = request.content
+        popup.isVisible = request.isVisible
+        popup.location = request.location
+        popup.startDate = request.startDate
+        popup.endDate = request.endDate
+        popup.startTime = request.startTime
+        popup.endTime = request.endTime
     }
 
     @Transactional
     override fun delete(popupUuid: String) {
-        val notice = noticeRepository.findByNoticeUuid(popupUuid)
+        val popup = popupRepository.findByPopupUuid(popupUuid)
             ?: throw BusinessException(PopupErrorCode.POPUP_NOT_FOUND)
-        noticeRepository.delete(notice)
+        popupRepository.delete(popup)
     }
 }

--- a/deal-api-user/src/main/kotlin/com/chaltteok/user/inquiry/controller/UserInquiryController.kt
+++ b/deal-api-user/src/main/kotlin/com/chaltteok/user/inquiry/controller/UserInquiryController.kt
@@ -1,0 +1,28 @@
+package com.chaltteok.user.inquiry.controller
+
+import com.chaltteok.common.dto.ResponseDTO
+import com.chaltteok.user.inquiry.dto.InquiryRequest
+import com.chaltteok.user.inquiry.dto.InquiryResponse
+import com.chaltteok.user.inquiry.service.UserInquiryService
+import jakarta.validation.Valid
+import org.springframework.http.HttpStatus
+import org.springframework.web.bind.annotation.*
+
+@RestController
+@RequestMapping("/api/v1/user/inquiries")
+class UserInquiryController(private val userInquiryService: UserInquiryService) {
+
+    @GetMapping
+    fun getMyInquiries(
+        @RequestHeader("X-User-Id") userId: Long,
+    ): ResponseDTO<List<InquiryResponse>> =
+        ResponseDTO.success(userInquiryService.getMyInquiries(userId))
+
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    fun create(
+        @RequestHeader("X-User-Id") userId: Long,
+        @Valid @RequestBody request: InquiryRequest,
+    ): ResponseDTO<InquiryResponse> =
+        ResponseDTO.success(userInquiryService.create(userId, request))
+}

--- a/deal-api-user/src/main/kotlin/com/chaltteok/user/inquiry/dto/InquiryRequest.kt
+++ b/deal-api-user/src/main/kotlin/com/chaltteok/user/inquiry/dto/InquiryRequest.kt
@@ -1,0 +1,8 @@
+package com.chaltteok.user.inquiry.dto
+
+import jakarta.validation.constraints.NotBlank
+
+class InquiryRequest(
+    @field:NotBlank val title: String,
+    @field:NotBlank val content: String,
+)

--- a/deal-api-user/src/main/kotlin/com/chaltteok/user/inquiry/dto/InquiryResponse.kt
+++ b/deal-api-user/src/main/kotlin/com/chaltteok/user/inquiry/dto/InquiryResponse.kt
@@ -1,0 +1,26 @@
+package com.chaltteok.user.inquiry.dto
+
+import com.chaltteok.core.domain.Inquiry
+import java.time.LocalDateTime
+
+class InquiryResponse(
+    val inquiryUuid: String,
+    val title: String,
+    val content: String,
+    val status: String,
+    val answer: String?,
+    val answeredAt: LocalDateTime?,
+    val createdAt: LocalDateTime,
+) {
+    companion object {
+        fun from(inquiry: Inquiry) = InquiryResponse(
+            inquiryUuid = inquiry.inquiryUuid,
+            title = inquiry.title,
+            content = inquiry.content,
+            status = inquiry.status,
+            answer = inquiry.answer,
+            answeredAt = inquiry.answeredAt,
+            createdAt = inquiry.createdAt,
+        )
+    }
+}

--- a/deal-api-user/src/main/kotlin/com/chaltteok/user/inquiry/enums/InquiryErrorCode.kt
+++ b/deal-api-user/src/main/kotlin/com/chaltteok/user/inquiry/enums/InquiryErrorCode.kt
@@ -1,0 +1,11 @@
+package com.chaltteok.user.inquiry.enums
+
+import com.chaltteok.common.enums.ErrorCode
+import org.springframework.http.HttpStatus
+
+enum class InquiryErrorCode(
+    override val status: HttpStatus,
+    override val message: String,
+) : ErrorCode {
+    INQUIRY_NOT_FOUND(HttpStatus.NOT_FOUND, "문의를 찾을 수 없습니다."),
+}

--- a/deal-api-user/src/main/kotlin/com/chaltteok/user/inquiry/service/UserInquiryService.kt
+++ b/deal-api-user/src/main/kotlin/com/chaltteok/user/inquiry/service/UserInquiryService.kt
@@ -1,0 +1,9 @@
+package com.chaltteok.user.inquiry.service
+
+import com.chaltteok.user.inquiry.dto.InquiryRequest
+import com.chaltteok.user.inquiry.dto.InquiryResponse
+
+interface UserInquiryService {
+    fun getMyInquiries(userId: Long): List<InquiryResponse>
+    fun create(userId: Long, request: InquiryRequest): InquiryResponse
+}

--- a/deal-api-user/src/main/kotlin/com/chaltteok/user/inquiry/service/UserInquiryServiceImpl.kt
+++ b/deal-api-user/src/main/kotlin/com/chaltteok/user/inquiry/service/UserInquiryServiceImpl.kt
@@ -1,0 +1,30 @@
+package com.chaltteok.user.inquiry.service
+
+import com.chaltteok.core.domain.Inquiry
+import com.chaltteok.core.repository.inquiry.InquiryRepository
+import com.chaltteok.user.inquiry.dto.InquiryRequest
+import com.chaltteok.user.inquiry.dto.InquiryResponse
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class UserInquiryServiceImpl(
+    private val inquiryRepository: InquiryRepository,
+) : UserInquiryService {
+
+    @Transactional(readOnly = true)
+    override fun getMyInquiries(userId: Long): List<InquiryResponse> =
+        inquiryRepository.findByUserIdOrderByCreatedAtDesc(userId).map { InquiryResponse.from(it) }
+
+    @Transactional
+    override fun create(userId: Long, request: InquiryRequest): InquiryResponse {
+        val inquiry = inquiryRepository.save(
+            Inquiry(
+                userId = userId,
+                title = request.title,
+                content = request.content,
+            )
+        )
+        return InquiryResponse.from(inquiry)
+    }
+}

--- a/deal-api-user/src/main/kotlin/com/chaltteok/user/notice/controller/UserNoticeController.kt
+++ b/deal-api-user/src/main/kotlin/com/chaltteok/user/notice/controller/UserNoticeController.kt
@@ -1,0 +1,17 @@
+package com.chaltteok.user.notice.controller
+
+import com.chaltteok.common.dto.ResponseDTO
+import com.chaltteok.user.notice.dto.NoticeResponse
+import com.chaltteok.user.notice.service.UserNoticeService
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/v1/user/notices")
+class UserNoticeController(private val userNoticeService: UserNoticeService) {
+
+    @GetMapping
+    fun getNotices(): ResponseDTO<List<NoticeResponse>> =
+        ResponseDTO.success(userNoticeService.getVisibleNotices())
+}

--- a/deal-api-user/src/main/kotlin/com/chaltteok/user/notice/dto/NoticeResponse.kt
+++ b/deal-api-user/src/main/kotlin/com/chaltteok/user/notice/dto/NoticeResponse.kt
@@ -1,0 +1,20 @@
+package com.chaltteok.user.notice.dto
+
+import com.chaltteok.core.domain.Notice
+import java.time.LocalDateTime
+
+class NoticeResponse(
+    val noticeUuid: String,
+    val title: String,
+    val content: String,
+    val createdAt: LocalDateTime,
+) {
+    companion object {
+        fun from(notice: Notice) = NoticeResponse(
+            noticeUuid = notice.noticeUuid,
+            title = notice.title,
+            content = notice.content,
+            createdAt = notice.createdAt,
+        )
+    }
+}

--- a/deal-api-user/src/main/kotlin/com/chaltteok/user/notice/service/UserNoticeService.kt
+++ b/deal-api-user/src/main/kotlin/com/chaltteok/user/notice/service/UserNoticeService.kt
@@ -1,0 +1,7 @@
+package com.chaltteok.user.notice.service
+
+import com.chaltteok.user.notice.dto.NoticeResponse
+
+interface UserNoticeService {
+    fun getVisibleNotices(): List<NoticeResponse>
+}

--- a/deal-api-user/src/main/kotlin/com/chaltteok/user/notice/service/UserNoticeServiceImpl.kt
+++ b/deal-api-user/src/main/kotlin/com/chaltteok/user/notice/service/UserNoticeServiceImpl.kt
@@ -1,0 +1,16 @@
+package com.chaltteok.user.notice.service
+
+import com.chaltteok.core.repository.notice.NoticeRepository
+import com.chaltteok.user.notice.dto.NoticeResponse
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class UserNoticeServiceImpl(
+    private val noticeRepository: NoticeRepository,
+) : UserNoticeService {
+
+    @Transactional(readOnly = true)
+    override fun getVisibleNotices(): List<NoticeResponse> =
+        noticeRepository.findAllByIsVisibleTrueOrderByCreatedAtDesc().map { NoticeResponse.from(it) }
+}

--- a/deal-api-user/src/main/kotlin/com/chaltteok/user/popup/dto/PopupResponse.kt
+++ b/deal-api-user/src/main/kotlin/com/chaltteok/user/popup/dto/PopupResponse.kt
@@ -1,6 +1,6 @@
 package com.chaltteok.user.popup.dto
 
-import com.chaltteok.core.domain.Notice
+import com.chaltteok.core.domain.Popup
 import java.time.LocalDate
 
 class PopupResponse(
@@ -12,13 +12,13 @@ class PopupResponse(
     val endDate: LocalDate?,
 ) {
     companion object {
-        fun from(notice: Notice) = PopupResponse(
-            popupUuid = notice.noticeUuid,
-            title = notice.title,
-            content = notice.content,
-            location = notice.location,
-            startDate = notice.startDate,
-            endDate = notice.endDate,
+        fun from(popup: Popup) = PopupResponse(
+            popupUuid = popup.popupUuid,
+            title = popup.title,
+            content = popup.content,
+            location = popup.location,
+            startDate = popup.startDate,
+            endDate = popup.endDate,
         )
     }
 }

--- a/deal-api-user/src/main/kotlin/com/chaltteok/user/popup/service/UserPopupServiceImpl.kt
+++ b/deal-api-user/src/main/kotlin/com/chaltteok/user/popup/service/UserPopupServiceImpl.kt
@@ -1,6 +1,6 @@
 package com.chaltteok.user.popup.service
 
-import com.chaltteok.core.repository.notice.NoticeRepository
+import com.chaltteok.core.repository.popup.PopupRepository
 import com.chaltteok.user.popup.dto.PopupResponse
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -9,10 +9,10 @@ import java.time.LocalTime
 
 @Service
 class UserPopupServiceImpl(
-    private val noticeRepository: NoticeRepository,
+    private val popupRepository: PopupRepository,
 ) : UserPopupService {
 
     @Transactional(readOnly = true)
     override fun getActivePopups(): List<PopupResponse> =
-        noticeRepository.findActiveNotices(LocalDate.now(), LocalTime.now()).map { PopupResponse.from(it) }
+        popupRepository.findActivePopups(LocalDate.now(), LocalTime.now()).map { PopupResponse.from(it) }
 }

--- a/deal-core/src/main/kotlin/com/chaltteok/core/domain/Inquiry.kt
+++ b/deal-core/src/main/kotlin/com/chaltteok/core/domain/Inquiry.kt
@@ -1,0 +1,35 @@
+package com.chaltteok.core.domain
+
+import jakarta.persistence.*
+import java.time.LocalDateTime
+import java.util.UUID
+
+@Entity
+@Table(name = "tb_inquiry", uniqueConstraints = [UniqueConstraint(name = "uk_inquiry_uuid", columnNames = ["inquiry_uuid"])])
+class Inquiry(
+    @Column(name = "user_id", nullable = false)
+    val userId: Long,
+
+    @Column(name = "title", nullable = false, length = 200)
+    var title: String,
+
+    @Column(name = "content", columnDefinition = "TEXT", nullable = false)
+    var content: String,
+
+    @Column(name = "status", nullable = false, length = 20)
+    var status: String = "PENDING",
+
+    @Column(name = "answer", columnDefinition = "TEXT")
+    var answer: String? = null,
+
+    @Column(name = "answered_at")
+    var answeredAt: LocalDateTime? = null,
+) : BaseEntity() {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "inquiry_id")
+    var id: Long? = null
+
+    @Column(name = "inquiry_uuid", nullable = false, length = 36)
+    val inquiryUuid: String = UUID.randomUUID().toString()
+}

--- a/deal-core/src/main/kotlin/com/chaltteok/core/domain/Notice.kt
+++ b/deal-core/src/main/kotlin/com/chaltteok/core/domain/Notice.kt
@@ -1,8 +1,6 @@
 package com.chaltteok.core.domain
 
 import jakarta.persistence.*
-import java.time.LocalDate
-import java.time.LocalTime
 import java.util.UUID
 
 @Entity
@@ -11,26 +9,11 @@ class Notice(
     @Column(name = "title", nullable = false, length = 200)
     var title: String,
 
-    @Column(name = "content", columnDefinition = "TEXT")
+    @Column(name = "content", columnDefinition = "TEXT", nullable = false)
     var content: String,
 
     @Column(name = "is_visible", nullable = false)
     var isVisible: Boolean = true,
-
-    @Column(name = "location", length = 50)
-    var location: String? = null,
-
-    @Column(name = "start_date")
-    var startDate: LocalDate? = null,
-
-    @Column(name = "end_date")
-    var endDate: LocalDate? = null,
-
-    @Column(name = "start_time")
-    var startTime: LocalTime? = null,
-
-    @Column(name = "end_time")
-    var endTime: LocalTime? = null,
 ) : BaseEntity() {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/deal-core/src/main/kotlin/com/chaltteok/core/domain/Popup.kt
+++ b/deal-core/src/main/kotlin/com/chaltteok/core/domain/Popup.kt
@@ -1,0 +1,42 @@
+package com.chaltteok.core.domain
+
+import jakarta.persistence.*
+import java.time.LocalDate
+import java.time.LocalTime
+import java.util.UUID
+
+@Entity
+@Table(name = "tb_popup", uniqueConstraints = [UniqueConstraint(name = "uk_popup_uuid", columnNames = ["popup_uuid"])])
+class Popup(
+    @Column(name = "title", nullable = false, length = 200)
+    var title: String,
+
+    @Column(name = "content", columnDefinition = "TEXT")
+    var content: String,
+
+    @Column(name = "is_visible", nullable = false)
+    var isVisible: Boolean = true,
+
+    @Column(name = "location", length = 50)
+    var location: String? = null,
+
+    @Column(name = "start_date")
+    var startDate: LocalDate? = null,
+
+    @Column(name = "end_date")
+    var endDate: LocalDate? = null,
+
+    @Column(name = "start_time")
+    var startTime: LocalTime? = null,
+
+    @Column(name = "end_time")
+    var endTime: LocalTime? = null,
+) : BaseEntity() {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "popup_id")
+    var id: Long? = null
+
+    @Column(name = "popup_uuid", nullable = false, length = 36)
+    val popupUuid: String = UUID.randomUUID().toString()
+}

--- a/deal-core/src/main/kotlin/com/chaltteok/core/repository/comment/CommentRepository.kt
+++ b/deal-core/src/main/kotlin/com/chaltteok/core/repository/comment/CommentRepository.kt
@@ -39,6 +39,7 @@ interface CommentRepository : JpaRepository<Comment, Long> {
         FROM Comment c
         WHERE c.product.id IN :productIds
         AND c.parentId IS NULL
+        AND c.isSecret = false
         GROUP BY c.product.id
     """)
     fun countRootCommentsByProductIds(@Param("productIds") productIds: List<Long>): List<CommentCountProjection>

--- a/deal-core/src/main/kotlin/com/chaltteok/core/repository/inquiry/InquiryRepository.kt
+++ b/deal-core/src/main/kotlin/com/chaltteok/core/repository/inquiry/InquiryRepository.kt
@@ -1,0 +1,10 @@
+package com.chaltteok.core.repository.inquiry
+
+import com.chaltteok.core.domain.Inquiry
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface InquiryRepository : JpaRepository<Inquiry, Long> {
+    fun findByInquiryUuid(uuid: String): Inquiry?
+    fun findByUserIdOrderByCreatedAtDesc(userId: Long): List<Inquiry>
+    fun findAllByOrderByCreatedAtDesc(): List<Inquiry>
+}

--- a/deal-core/src/main/kotlin/com/chaltteok/core/repository/notice/NoticeRepository.kt
+++ b/deal-core/src/main/kotlin/com/chaltteok/core/repository/notice/NoticeRepository.kt
@@ -2,22 +2,8 @@ package com.chaltteok.core.repository.notice
 
 import com.chaltteok.core.domain.Notice
 import org.springframework.data.jpa.repository.JpaRepository
-import org.springframework.data.jpa.repository.Query
-import org.springframework.data.repository.query.Param
-import java.time.LocalDate
-import java.time.LocalTime
 
 interface NoticeRepository : JpaRepository<Notice, Long> {
     fun findByNoticeUuid(uuid: String): Notice?
-
-    @Query("""
-        SELECT n FROM Notice n
-        WHERE n.isVisible = true
-        AND (n.startDate IS NULL OR n.startDate <= :today)
-        AND (n.endDate IS NULL OR n.endDate >= :today)
-        AND (n.startTime IS NULL OR n.startTime <= :now)
-        AND (n.endTime IS NULL OR n.endTime >= :now)
-        ORDER BY n.createdAt DESC
-    """)
-    fun findActiveNotices(@Param("today") today: LocalDate, @Param("now") now: LocalTime): List<Notice>
+    fun findAllByIsVisibleTrueOrderByCreatedAtDesc(): List<Notice>
 }

--- a/deal-core/src/main/kotlin/com/chaltteok/core/repository/popup/PopupRepository.kt
+++ b/deal-core/src/main/kotlin/com/chaltteok/core/repository/popup/PopupRepository.kt
@@ -1,0 +1,23 @@
+package com.chaltteok.core.repository.popup
+
+import com.chaltteok.core.domain.Popup
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
+import java.time.LocalDate
+import java.time.LocalTime
+
+interface PopupRepository : JpaRepository<Popup, Long> {
+    fun findByPopupUuid(uuid: String): Popup?
+
+    @Query("""
+        SELECT p FROM Popup p
+        WHERE p.isVisible = true
+        AND (p.startDate IS NULL OR p.startDate <= :today)
+        AND (p.endDate IS NULL OR p.endDate >= :today)
+        AND (p.startTime IS NULL OR p.startTime <= :now)
+        AND (p.endTime IS NULL OR p.endTime >= :now)
+        ORDER BY p.createdAt DESC
+    """)
+    fun findActivePopups(@Param("today") today: LocalDate, @Param("now") now: LocalTime): List<Popup>
+}


### PR DESCRIPTION
## Summary
- `tb_notice`(팝업용) → `tb_popup` 테이블/클래스 리네임 + PopupRepository 신규 생성
- 공지사항 전용 `Notice` 엔티티(`tb_notice`) + 유저 조회 / 점주 CRUD API
- 1:1 문의 `Inquiry` 엔티티(`tb_inquiry`) + 유저 등록/목록 / 점주 전체조회 + 답변 API
- `commentCount` 쿼리: 비밀 댓글(`isSecret=false`) 제외로 클릭 전/후 수 일치

## Changes
- `Popup.kt`: Notice 클래스 → Popup 클래스, `@Table(tb_popup)`, 컬럼명 popup_id/popup_uuid
- `PopupRepository`: `findByPopupUuid`, `findActivePopups` JPQL 쿼리
- `Notice.kt`: 공지사항 전용 엔티티 (title, content, isVisible)
- `NoticeRepository`: `findByNoticeUuid`, `findAllByIsVisibleTrueOrderByCreatedAtDesc`
- `Inquiry.kt`: userId, title, content, status, answer, answeredAt
- 유저 공지사항: `GET /api/v1/user/notices`
- 점주 공지사항: `GET/POST/PUT/DELETE /api/v1/owner/notices/{uuid}`
- 유저 문의: `GET/POST /api/v1/user/inquiries`
- 점주 문의: `GET /api/v1/owner/inquiries`, `PUT /api/v1/owner/inquiries/{uuid}/answer`

## Test plan
- [ ] 기존 팝업 CRUD 정상 동작 확인 (tb_popup 마이그레이션 후)
- [ ] 공지사항 등록/수정/삭제/조회
- [ ] 문의 등록 → 점주 답변 → 유저 답변 확인
- [ ] commentCount가 비밀 댓글 제외 후 목록과 일치

Resolves #35
Resolves #36
Resolves #37
Resolves #38
Resolves #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)