### PR TITLE
[FIX] 로그인 파라미터 email→username 변경 및 공지사항 공개 엔드포인트 추가

### DIFF
--- a/deal-api-owner/src/main/kotlin/com/chaltteok/owner/auth/controller/AuthController.kt
+++ b/deal-api-owner/src/main/kotlin/com/chaltteok/owner/auth/controller/AuthController.kt
@@ -23,7 +23,7 @@ class AuthController(
 ) {
     @PostMapping("/login")
     fun login(@Valid @RequestBody request: LoginRequest): ResponseDTO<LoginResponseDto> =
-        ResponseDTO.success(ownerAuthService.login(request.email, request.password))
+        ResponseDTO.success(ownerAuthService.login(request.username, request.password))
 
     @PostMapping("/reissue")
     fun reissue(@Valid @RequestBody request: ReissueRequest): ResponseDTO<TokenDto> {

--- a/deal-api-user/src/main/kotlin/com/chaltteok/user/auth/controller/AuthController.kt
+++ b/deal-api-user/src/main/kotlin/com/chaltteok/user/auth/controller/AuthController.kt
@@ -25,7 +25,7 @@ class AuthController(
 
     @PostMapping("/login")
     fun login(@Valid @RequestBody request: LoginRequest): ResponseDTO<LoginResponseDto> =
-        ResponseDTO.success(userAuthService.login(request.email, request.password))
+        ResponseDTO.success(userAuthService.login(request.username, request.password))
 
     @PostMapping("/register")
     fun register(@Valid @RequestBody request: RegisterRequest): ResponseDTO<Unit> {

--- a/deal-common-api/src/main/kotlin/com/chaltteok/common/security/config/SecurityConfig.kt
+++ b/deal-common-api/src/main/kotlin/com/chaltteok/common/security/config/SecurityConfig.kt
@@ -34,6 +34,7 @@ class SecurityConfig(
                     .requestMatchers("/api/v1/owner/**").hasAuthority("ROLE_OWNER")
                     // user — 로그인 없이 접근 가능한 공개 엔드포인트
                     .requestMatchers("/api/v1/user/auth/**").permitAll()
+                    .requestMatchers("/api/v1/user/notices/**").permitAll()
                     .requestMatchers(HttpMethod.GET, "/api/v1/user/daily-stocks/open").permitAll()
                     .requestMatchers(HttpMethod.GET, "/api/v1/user/products/**").permitAll()
                     // 정적 이미지 파일 공개 접근

--- a/deal-common-api/src/main/kotlin/com/chaltteok/common/security/dto/LoginRequest.kt
+++ b/deal-common-api/src/main/kotlin/com/chaltteok/common/security/dto/LoginRequest.kt
@@ -3,6 +3,6 @@ package com.chaltteok.common.security.dto
 import jakarta.validation.constraints.NotBlank
 
 data class LoginRequest(
-    @field:NotBlank val email: String,
+    @field:NotBlank val username: String,
     @field:NotBlank val password: String,
 )


### PR DESCRIPTION
## Summary
- `LoginRequest.email` → `username` 필드명 변경으로 프론트엔드-백엔드 파라미터 일치
- Owner/User AuthController에서 `request.email` → `request.username` 참조 수정
- SecurityConfig에 `/api/v1/user/notices/**` permitAll() 추가 (비로그인 접근 허용)

## Test plan
- [ ] 유저 로그인 요청 시 `username` 파라미터로 정상 로그인 확인
- [ ] 점주 로그인 요청 시 `username` 파라미터로 정상 로그인 확인
- [ ] 비로그인 상태에서 `/api/v1/user/notices` GET 요청 성공 확인

Resolves #41

🤖 Generated with [Claude Code](https://claude.com/claude-code)