### PR TITLE
[FIX] isVisible JSON 직렬화 오류 수정 (NoticeResponse, PopupResponse)

### DIFF
--- a/deal-api-owner/src/main/kotlin/com/chaltteok/owner/notice/dto/NoticeResponse.kt
+++ b/deal-api-owner/src/main/kotlin/com/chaltteok/owner/notice/dto/NoticeResponse.kt
@@ -1,13 +1,14 @@
 package com.chaltteok.owner.notice.dto
 
 import com.chaltteok.core.domain.Notice
+import com.fasterxml.jackson.annotation.JsonProperty
 import java.time.LocalDateTime
 
 class NoticeResponse(
     val noticeUuid: String,
     val title: String,
     val content: String,
-    val isVisible: Boolean,
+    @get:JsonProperty("isVisible") val isVisible: Boolean,
     val createdAt: LocalDateTime,
 ) {
     companion object {

--- a/deal-api-owner/src/main/kotlin/com/chaltteok/owner/popup/dto/PopupResponse.kt
+++ b/deal-api-owner/src/main/kotlin/com/chaltteok/owner/popup/dto/PopupResponse.kt
@@ -1,6 +1,7 @@
 package com.chaltteok.owner.popup.dto
 
 import com.chaltteok.core.domain.Popup
+import com.fasterxml.jackson.annotation.JsonProperty
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.LocalTime
@@ -9,7 +10,7 @@ class PopupResponse(
     val popupUuid: String,
     val title: String,
     val content: String,
-    val isVisible: Boolean,
+    @get:JsonProperty("isVisible") val isVisible: Boolean,
     val location: String?,
     val startDate: LocalDate?,
     val endDate: LocalDate?,


### PR DESCRIPTION
## Summary
- Kotlin `is`-prefix Boolean 필드(`isVisible`)가 Jackson JavaBean getter 규칙에 의해 `visible`로 직렬화되는 문제 수정
- `@get:JsonProperty("isVisible")` 추가로 프론트엔드가 기대하는 `isVisible` 키로 직렬화되도록 강제

## 영향 범위
- `NoticeResponse.kt` — 점주 공지사항 목록 노출 여부 오표기 수정
- `PopupResponse.kt` — 동일 잠재 이슈 선제 수정

## Test plan
- [ ] 노출 상태 공지사항이 목록에서 '노출' 배지로 표시 확인
- [ ] 비노출 공지사항 수정 시 체크박스가 해제된 상태로 모달 열림 확인
- [ ] 노출 공지사항 수정 시 체크박스가 체크된 상태로 모달 열림 확인

Resolves #43

🤖 Generated with [Claude Code](https://claude.com/claude-code)