### PR TITLE
[FIX] 댓글 닉네임 표시 및 비밀댓글 필터 제거

### DIFF
--- a/deal-api-user/src/main/kotlin/com/chaltteok/user/comment/dto/CommentResponse.kt
+++ b/deal-api-user/src/main/kotlin/com/chaltteok/user/comment/dto/CommentResponse.kt
@@ -5,7 +5,7 @@ import java.time.LocalDateTime
 
 class CommentResponse(
     val commentUuid: String,
-    val userId: Long,
+    val nickname: String?,
     val content: String,
     val rating: Int?,
     val isSecret: Boolean,
@@ -19,14 +19,15 @@ class CommentResponse(
             comment: Comment,
             replies: List<Comment> = emptyList(),
             requestingUserId: Long?,
+            nicknameMap: Map<Long, String> = emptyMap(),
         ): CommentResponse = CommentResponse(
             commentUuid = comment.commentUuid,
-            userId = comment.userId,
+            nickname = if (comment.isOwnerReply) null else nicknameMap[comment.userId],
             content = comment.content,
             rating = comment.rating,
             isSecret = comment.isSecret,
             isOwnerReply = comment.isOwnerReply,
-            replies = replies.map { from(it, emptyList(), requestingUserId) },
+            replies = replies.map { from(it, emptyList(), requestingUserId, nicknameMap) },
             createdAt = comment.createdAt,
             isMine = requestingUserId == comment.userId,
         )

--- a/deal-api-user/src/main/kotlin/com/chaltteok/user/comment/service/UserCommentServiceImpl.kt
+++ b/deal-api-user/src/main/kotlin/com/chaltteok/user/comment/service/UserCommentServiceImpl.kt
@@ -4,6 +4,7 @@ import com.chaltteok.common.exception.BusinessException
 import com.chaltteok.core.domain.Comment
 import com.chaltteok.core.repository.comment.CommentRepository
 import com.chaltteok.core.repository.product.ProductRepository
+import com.chaltteok.core.repository.user.UserRepository
 import com.chaltteok.user.comment.dto.CommentRequest
 import com.chaltteok.user.comment.dto.CommentResponse
 import com.chaltteok.user.comment.dto.ReplyRequest
@@ -15,18 +16,20 @@ import org.springframework.transaction.annotation.Transactional
 class UserCommentServiceImpl(
     private val commentRepository: CommentRepository,
     private val productRepository: ProductRepository,
+    private val userRepository: UserRepository,
 ) : UserCommentService {
 
     @Transactional(readOnly = true)
     override fun getComments(productUuid: String, requestingUserId: Long?): List<CommentResponse> {
         val roots = commentRepository.findRootCommentsByProductUuid(productUuid)
-            .filter { !it.isSecret || it.userId == requestingUserId }
         if (roots.isEmpty()) return emptyList()
-        val replyMap = commentRepository.findRepliesByParentIds(roots.mapNotNull { it.id })
-            .filter { !it.isSecret || it.userId == requestingUserId }
-            .groupBy { it.parentId }
+        val replies = commentRepository.findRepliesByParentIds(roots.mapNotNull { it.id })
+        val allComments = roots + replies
+        val userIds = allComments.filter { !it.isOwnerReply }.map { it.userId }.distinct()
+        val nicknameMap = userRepository.findAllById(userIds).associate { it.id!! to it.nickname }
+        val replyMap = replies.groupBy { it.parentId }
         return roots.map { root ->
-            CommentResponse.from(root, replyMap[root.id] ?: emptyList(), requestingUserId)
+            CommentResponse.from(root, replyMap[root.id] ?: emptyList(), requestingUserId, nicknameMap)
         }
     }
 
@@ -43,7 +46,8 @@ class UserCommentServiceImpl(
                 isSecret = request.isSecret,
             )
         )
-        return CommentResponse.from(comment, emptyList(), userId)
+        val nickname = userRepository.findById(userId).map { it.nickname }.orElse(null)
+        return CommentResponse.from(comment, emptyList(), userId, if (nickname != null) mapOf(userId to nickname) else emptyMap())
     }
 
     @Transactional
@@ -58,7 +62,8 @@ class UserCommentServiceImpl(
                 parentId = parent.id,
             )
         )
-        return CommentResponse.from(reply, emptyList(), userId)
+        val nickname = userRepository.findById(userId).map { it.nickname }.orElse(null)
+        return CommentResponse.from(reply, emptyList(), userId, if (nickname != null) mapOf(userId to nickname) else emptyMap())
     }
 
     @Transactional
@@ -69,7 +74,8 @@ class UserCommentServiceImpl(
         comment.content = request.content
         comment.rating = request.rating
         comment.isSecret = request.isSecret
-        return CommentResponse.from(comment, emptyList(), userId)
+        val nickname = userRepository.findById(userId).map { it.nickname }.orElse(null)
+        return CommentResponse.from(comment, emptyList(), userId, if (nickname != null) mapOf(userId to nickname) else emptyMap())
     }
 
     @Transactional


### PR DESCRIPTION
## Summary
- `CommentResponse`에서 `userId` 제거, `nickname` 필드 추가
- `UserCommentServiceImpl`: `UserRepository` 주입, 닉네임 배치 조회 (N+1 방지)
- 비밀댓글 서버 필터 제거 → 클라이언트 마스킹 방식으로 전환

## Test plan
- [ ] 댓글 목록 조회 시 nickname 포함 응답 확인
- [ ] 비밀댓글 포함 전체 댓글 반환 (필터 없음) 확인
- [ ] 점주 답글 nickname = null 확인

Resolves #45

🤖 Generated with [Claude Code](https://claude.com/claude-code)