### PR TITLE
[FIX] 비밀댓글 마스킹, 댓글/문의 페이징, 이메일 중복확인 API

### DIFF
--- a/deal-api-owner/src/main/kotlin/com/chaltteok/owner/comment/controller/OwnerCommentController.kt
+++ b/deal-api-owner/src/main/kotlin/com/chaltteok/owner/comment/controller/OwnerCommentController.kt
@@ -1,6 +1,7 @@
 package com.chaltteok.owner.comment.controller
 
 import com.chaltteok.common.dto.ResponseDTO
+import com.chaltteok.owner.comment.dto.OwnerCommentPageResponse
 import com.chaltteok.owner.comment.dto.OwnerCommentResponse
 import com.chaltteok.owner.comment.dto.OwnerReplyRequest
 import com.chaltteok.owner.comment.service.OwnerCommentService
@@ -13,8 +14,11 @@ import org.springframework.web.bind.annotation.*
 class OwnerCommentController(private val ownerCommentService: OwnerCommentService) {
 
     @GetMapping
-    fun getAll(): ResponseDTO<List<OwnerCommentResponse>> =
-        ResponseDTO.success(ownerCommentService.getAll())
+    fun getAll(
+        @RequestParam(defaultValue = "0") page: Int,
+        @RequestParam(defaultValue = "10") size: Int,
+    ): ResponseDTO<OwnerCommentPageResponse> =
+        ResponseDTO.success(ownerCommentService.getAll(page, size))
 
     @DeleteMapping("/{commentUuid}")
     @ResponseStatus(HttpStatus.NO_CONTENT)

--- a/deal-api-owner/src/main/kotlin/com/chaltteok/owner/comment/dto/OwnerCommentPageResponse.kt
+++ b/deal-api-owner/src/main/kotlin/com/chaltteok/owner/comment/dto/OwnerCommentPageResponse.kt
@@ -1,0 +1,9 @@
+package com.chaltteok.owner.comment.dto
+
+class OwnerCommentPageResponse(
+    val content: List<OwnerCommentResponse>,
+    val totalElements: Long,
+    val totalPages: Int,
+    val currentPage: Int,
+    val pageSize: Int,
+)

--- a/deal-api-owner/src/main/kotlin/com/chaltteok/owner/comment/dto/OwnerCommentResponse.kt
+++ b/deal-api-owner/src/main/kotlin/com/chaltteok/owner/comment/dto/OwnerCommentResponse.kt
@@ -14,6 +14,7 @@ class OwnerCommentResponse(
     val isSecret: Boolean,
     val isOwnerReply: Boolean,
     val parentId: Long?,
+    val replies: List<OwnerCommentResponse>,
     val createdAt: LocalDateTime,
 ) {
     companion object {
@@ -28,6 +29,22 @@ class OwnerCommentResponse(
             isSecret = comment.isSecret,
             isOwnerReply = comment.isOwnerReply,
             parentId = comment.parentId,
+            replies = emptyList(),
+            createdAt = comment.createdAt,
+        )
+
+        fun fromWithReplies(comment: Comment, replies: List<Comment>) = OwnerCommentResponse(
+            commentId = comment.id!!,
+            commentUuid = comment.commentUuid,
+            productUuid = comment.product.productUuid,
+            productName = comment.product.name,
+            userId = comment.userId,
+            content = comment.content,
+            rating = comment.rating,
+            isSecret = comment.isSecret,
+            isOwnerReply = comment.isOwnerReply,
+            parentId = comment.parentId,
+            replies = replies.map { from(it) },
             createdAt = comment.createdAt,
         )
     }

--- a/deal-api-owner/src/main/kotlin/com/chaltteok/owner/comment/service/OwnerCommentService.kt
+++ b/deal-api-owner/src/main/kotlin/com/chaltteok/owner/comment/service/OwnerCommentService.kt
@@ -1,10 +1,11 @@
 package com.chaltteok.owner.comment.service
 
+import com.chaltteok.owner.comment.dto.OwnerCommentPageResponse
 import com.chaltteok.owner.comment.dto.OwnerCommentResponse
 import com.chaltteok.owner.comment.dto.OwnerReplyRequest
 
 interface OwnerCommentService {
-    fun getAll(): List<OwnerCommentResponse>
+    fun getAll(page: Int, size: Int): OwnerCommentPageResponse
     fun delete(commentUuid: String)
     fun reply(commentUuid: String, request: OwnerReplyRequest): OwnerCommentResponse
 }

--- a/deal-api-owner/src/main/kotlin/com/chaltteok/owner/comment/service/OwnerCommentServiceImpl.kt
+++ b/deal-api-owner/src/main/kotlin/com/chaltteok/owner/comment/service/OwnerCommentServiceImpl.kt
@@ -3,9 +3,12 @@ package com.chaltteok.owner.comment.service
 import com.chaltteok.common.exception.BusinessException
 import com.chaltteok.core.domain.Comment
 import com.chaltteok.core.repository.comment.CommentRepository
+import com.chaltteok.owner.comment.dto.OwnerCommentPageResponse
 import com.chaltteok.owner.comment.dto.OwnerCommentResponse
 import com.chaltteok.owner.comment.dto.OwnerReplyRequest
 import com.chaltteok.owner.comment.enums.OwnerCommentErrorCode
+import org.springframework.data.domain.PageRequest
+import org.springframework.data.domain.Sort
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
@@ -15,8 +18,19 @@ class OwnerCommentServiceImpl(
 ) : OwnerCommentService {
 
     @Transactional(readOnly = true)
-    override fun getAll(): List<OwnerCommentResponse> =
-        commentRepository.findAllOrderByCreatedAtDesc().map { OwnerCommentResponse.from(it) }
+    override fun getAll(page: Int, size: Int): OwnerCommentPageResponse {
+        val pageable = PageRequest.of(page, size, Sort.by("createdAt").descending())
+        val rootPage = commentRepository.findRootCommentsPagedForOwner(pageable)
+        val roots = rootPage.content
+        val replies = if (roots.isNotEmpty())
+            commentRepository.findRepliesByParentIds(roots.mapNotNull { it.id })
+        else emptyList()
+        val replyMap = replies.groupBy { it.parentId }
+        val content = roots.map { root ->
+            OwnerCommentResponse.fromWithReplies(root, replyMap[root.id] ?: emptyList())
+        }
+        return OwnerCommentPageResponse(content, rootPage.totalElements, rootPage.totalPages, page, size)
+    }
 
     @Transactional
     override fun delete(commentUuid: String) {

--- a/deal-api-owner/src/main/kotlin/com/chaltteok/owner/inquiry/controller/OwnerInquiryController.kt
+++ b/deal-api-owner/src/main/kotlin/com/chaltteok/owner/inquiry/controller/OwnerInquiryController.kt
@@ -2,7 +2,7 @@ package com.chaltteok.owner.inquiry.controller
 
 import com.chaltteok.common.dto.ResponseDTO
 import com.chaltteok.owner.inquiry.dto.AnswerRequest
-import com.chaltteok.owner.inquiry.dto.OwnerInquiryResponse
+import com.chaltteok.owner.inquiry.dto.OwnerInquiryPageResponse
 import com.chaltteok.owner.inquiry.service.OwnerInquiryService
 import jakarta.validation.Valid
 import org.springframework.web.bind.annotation.*
@@ -12,8 +12,11 @@ import org.springframework.web.bind.annotation.*
 class OwnerInquiryController(private val ownerInquiryService: OwnerInquiryService) {
 
     @GetMapping
-    fun getAll(): ResponseDTO<List<OwnerInquiryResponse>> =
-        ResponseDTO.success(ownerInquiryService.getAll())
+    fun getAll(
+        @RequestParam(defaultValue = "0") page: Int,
+        @RequestParam(defaultValue = "10") size: Int,
+    ): ResponseDTO<OwnerInquiryPageResponse> =
+        ResponseDTO.success(ownerInquiryService.getAll(page, size))
 
     @PutMapping("/{inquiryUuid}/answer")
     fun answer(

--- a/deal-api-owner/src/main/kotlin/com/chaltteok/owner/inquiry/dto/OwnerInquiryPageResponse.kt
+++ b/deal-api-owner/src/main/kotlin/com/chaltteok/owner/inquiry/dto/OwnerInquiryPageResponse.kt
@@ -1,0 +1,9 @@
+package com.chaltteok.owner.inquiry.dto
+
+class OwnerInquiryPageResponse(
+    val content: List<OwnerInquiryResponse>,
+    val totalElements: Long,
+    val totalPages: Int,
+    val currentPage: Int,
+    val pageSize: Int,
+)

--- a/deal-api-owner/src/main/kotlin/com/chaltteok/owner/inquiry/service/OwnerInquiryService.kt
+++ b/deal-api-owner/src/main/kotlin/com/chaltteok/owner/inquiry/service/OwnerInquiryService.kt
@@ -1,9 +1,9 @@
 package com.chaltteok.owner.inquiry.service
 
 import com.chaltteok.owner.inquiry.dto.AnswerRequest
-import com.chaltteok.owner.inquiry.dto.OwnerInquiryResponse
+import com.chaltteok.owner.inquiry.dto.OwnerInquiryPageResponse
 
 interface OwnerInquiryService {
-    fun getAll(): List<OwnerInquiryResponse>
+    fun getAll(page: Int, size: Int): OwnerInquiryPageResponse
     fun answer(inquiryUuid: String, request: AnswerRequest)
 }

--- a/deal-api-owner/src/main/kotlin/com/chaltteok/owner/inquiry/service/OwnerInquiryServiceImpl.kt
+++ b/deal-api-owner/src/main/kotlin/com/chaltteok/owner/inquiry/service/OwnerInquiryServiceImpl.kt
@@ -3,8 +3,11 @@ package com.chaltteok.owner.inquiry.service
 import com.chaltteok.common.exception.BusinessException
 import com.chaltteok.core.repository.inquiry.InquiryRepository
 import com.chaltteok.owner.inquiry.dto.AnswerRequest
+import com.chaltteok.owner.inquiry.dto.OwnerInquiryPageResponse
 import com.chaltteok.owner.inquiry.dto.OwnerInquiryResponse
 import com.chaltteok.owner.inquiry.enums.InquiryErrorCode
+import org.springframework.data.domain.PageRequest
+import org.springframework.data.domain.Sort
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.time.LocalDateTime
@@ -15,8 +18,17 @@ class OwnerInquiryServiceImpl(
 ) : OwnerInquiryService {
 
     @Transactional(readOnly = true)
-    override fun getAll(): List<OwnerInquiryResponse> =
-        inquiryRepository.findAllByOrderByCreatedAtDesc().map { OwnerInquiryResponse.from(it) }
+    override fun getAll(page: Int, size: Int): OwnerInquiryPageResponse {
+        val pageable = PageRequest.of(page, size, Sort.by("createdAt").descending())
+        val inquiryPage = inquiryRepository.findAllByOrderByCreatedAtDesc(pageable)
+        return OwnerInquiryPageResponse(
+            content = inquiryPage.content.map { OwnerInquiryResponse.from(it) },
+            totalElements = inquiryPage.totalElements,
+            totalPages = inquiryPage.totalPages,
+            currentPage = page,
+            pageSize = size,
+        )
+    }
 
     @Transactional
     override fun answer(inquiryUuid: String, request: AnswerRequest) {

--- a/deal-api-user/src/main/kotlin/com/chaltteok/user/auth/controller/AuthController.kt
+++ b/deal-api-user/src/main/kotlin/com/chaltteok/user/auth/controller/AuthController.kt
@@ -11,10 +11,7 @@ import com.chaltteok.common.security.jwt.JwtTokenProvider
 import com.chaltteok.user.auth.dto.RegisterRequest
 import com.chaltteok.user.auth.service.UserAuthService
 import jakarta.validation.Valid
-import org.springframework.web.bind.annotation.PostMapping
-import org.springframework.web.bind.annotation.RequestBody
-import org.springframework.web.bind.annotation.RequestMapping
-import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.bind.annotation.*
 
 @RestController
 @RequestMapping("/api/v1/user/auth")
@@ -32,6 +29,10 @@ class AuthController(
         userAuthService.register(request)
         return ResponseDTO.success(Unit)
     }
+
+    @GetMapping("/check-email")
+    fun checkEmail(@RequestParam email: String): ResponseDTO<Map<String, Boolean>> =
+        ResponseDTO.success(mapOf("duplicate" to userAuthService.existsByEmail(email)))
 
     @PostMapping("/reissue")
     fun reissue(@RequestBody request: ReissueRequest): ResponseDTO<TokenDto> {

--- a/deal-api-user/src/main/kotlin/com/chaltteok/user/auth/service/UserAuthService.kt
+++ b/deal-api-user/src/main/kotlin/com/chaltteok/user/auth/service/UserAuthService.kt
@@ -6,4 +6,5 @@ import com.chaltteok.user.auth.dto.RegisterRequest
 interface UserAuthService {
     fun login(email: String, password: String): LoginResponseDto
     fun register(request: RegisterRequest)
+    fun existsByEmail(email: String): Boolean
 }

--- a/deal-api-user/src/main/kotlin/com/chaltteok/user/auth/service/UserAuthServiceImpl.kt
+++ b/deal-api-user/src/main/kotlin/com/chaltteok/user/auth/service/UserAuthServiceImpl.kt
@@ -58,4 +58,7 @@ class UserAuthServiceImpl(
         user.password = passwordEncoder.encode(request.password)
         userRepository.save(user)
     }
+
+    @Transactional(readOnly = true)
+    override fun existsByEmail(email: String): Boolean = userRepository.existsByEmail(email)
 }

--- a/deal-api-user/src/main/kotlin/com/chaltteok/user/comment/controller/CommentController.kt
+++ b/deal-api-user/src/main/kotlin/com/chaltteok/user/comment/controller/CommentController.kt
@@ -1,6 +1,7 @@
 package com.chaltteok.user.comment.controller
 
 import com.chaltteok.common.dto.ResponseDTO
+import com.chaltteok.user.comment.dto.CommentPageResponse
 import com.chaltteok.user.comment.dto.CommentRequest
 import com.chaltteok.user.comment.dto.CommentResponse
 import com.chaltteok.user.comment.dto.ReplyRequest
@@ -17,8 +18,10 @@ class CommentController(private val userCommentService: UserCommentService) {
     fun getComments(
         @PathVariable productUuid: String,
         @RequestHeader(value = "X-User-Id", required = false) userId: Long?,
-    ): ResponseDTO<List<CommentResponse>> =
-        ResponseDTO.success(userCommentService.getComments(productUuid, userId))
+        @RequestParam(defaultValue = "0") page: Int,
+        @RequestParam(defaultValue = "10") size: Int,
+    ): ResponseDTO<CommentPageResponse> =
+        ResponseDTO.success(userCommentService.getComments(productUuid, userId, page, size))
 
     @PostMapping("/products/{productUuid}/comments")
     @ResponseStatus(HttpStatus.CREATED)

--- a/deal-api-user/src/main/kotlin/com/chaltteok/user/comment/dto/CommentPageResponse.kt
+++ b/deal-api-user/src/main/kotlin/com/chaltteok/user/comment/dto/CommentPageResponse.kt
@@ -1,0 +1,9 @@
+package com.chaltteok.user.comment.dto
+
+class CommentPageResponse(
+    val content: List<CommentResponse>,
+    val totalElements: Long,
+    val totalPages: Int,
+    val currentPage: Int,
+    val pageSize: Int,
+)

--- a/deal-api-user/src/main/kotlin/com/chaltteok/user/comment/service/UserCommentService.kt
+++ b/deal-api-user/src/main/kotlin/com/chaltteok/user/comment/service/UserCommentService.kt
@@ -1,11 +1,12 @@
 package com.chaltteok.user.comment.service
 
+import com.chaltteok.user.comment.dto.CommentPageResponse
 import com.chaltteok.user.comment.dto.CommentRequest
 import com.chaltteok.user.comment.dto.CommentResponse
 import com.chaltteok.user.comment.dto.ReplyRequest
 
 interface UserCommentService {
-    fun getComments(productUuid: String, requestingUserId: Long?): List<CommentResponse>
+    fun getComments(productUuid: String, requestingUserId: Long?, page: Int, size: Int): CommentPageResponse
     fun create(productUuid: String, userId: Long, request: CommentRequest): CommentResponse
     fun reply(commentUuid: String, userId: Long, request: ReplyRequest): CommentResponse
     fun update(commentUuid: String, userId: Long, request: CommentRequest): CommentResponse

--- a/deal-api-user/src/main/kotlin/com/chaltteok/user/comment/service/UserCommentServiceImpl.kt
+++ b/deal-api-user/src/main/kotlin/com/chaltteok/user/comment/service/UserCommentServiceImpl.kt
@@ -5,10 +5,13 @@ import com.chaltteok.core.domain.Comment
 import com.chaltteok.core.repository.comment.CommentRepository
 import com.chaltteok.core.repository.product.ProductRepository
 import com.chaltteok.core.repository.user.UserRepository
+import com.chaltteok.user.comment.dto.CommentPageResponse
 import com.chaltteok.user.comment.dto.CommentRequest
 import com.chaltteok.user.comment.dto.CommentResponse
 import com.chaltteok.user.comment.dto.ReplyRequest
 import com.chaltteok.user.comment.enums.CommentErrorCode
+import org.springframework.data.domain.PageRequest
+import org.springframework.data.domain.Sort
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
@@ -20,17 +23,20 @@ class UserCommentServiceImpl(
 ) : UserCommentService {
 
     @Transactional(readOnly = true)
-    override fun getComments(productUuid: String, requestingUserId: Long?): List<CommentResponse> {
-        val roots = commentRepository.findRootCommentsByProductUuid(productUuid)
-        if (roots.isEmpty()) return emptyList()
+    override fun getComments(productUuid: String, requestingUserId: Long?, page: Int, size: Int): CommentPageResponse {
+        val pageable = PageRequest.of(page, size, Sort.by("createdAt").ascending())
+        val rootPage = commentRepository.findRootCommentsByProductUuidPaged(productUuid, pageable)
+        val roots = rootPage.content
+        if (roots.isEmpty()) return CommentPageResponse(emptyList(), rootPage.totalElements, rootPage.totalPages, page, size)
         val replies = commentRepository.findRepliesByParentIds(roots.mapNotNull { it.id })
         val allComments = roots + replies
         val userIds = allComments.filter { !it.isOwnerReply }.map { it.userId }.distinct()
         val nicknameMap = userRepository.findAllById(userIds).associate { it.id!! to it.nickname }
         val replyMap = replies.groupBy { it.parentId }
-        return roots.map { root ->
+        val content = roots.map { root ->
             CommentResponse.from(root, replyMap[root.id] ?: emptyList(), requestingUserId, nicknameMap)
         }
+        return CommentPageResponse(content, rootPage.totalElements, rootPage.totalPages, page, size)
     }
 
     @Transactional

--- a/deal-core/src/main/kotlin/com/chaltteok/core/repository/comment/CommentRepository.kt
+++ b/deal-core/src/main/kotlin/com/chaltteok/core/repository/comment/CommentRepository.kt
@@ -1,6 +1,8 @@
 package com.chaltteok.core.repository.comment
 
 import com.chaltteok.core.domain.Comment
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
 import org.springframework.data.repository.query.Param
@@ -30,9 +32,24 @@ interface CommentRepository : JpaRepository<Comment, Long> {
 
     @Query("""
         SELECT c FROM Comment c
+        WHERE c.product.productUuid = :productUuid
+        AND c.parentId IS NULL
+        ORDER BY c.createdAt ASC
+    """)
+    fun findRootCommentsByProductUuidPaged(@Param("productUuid") productUuid: String, pageable: Pageable): Page<Comment>
+
+    @Query("""
+        SELECT c FROM Comment c
         ORDER BY c.createdAt DESC
     """)
     fun findAllOrderByCreatedAtDesc(): List<Comment>
+
+    @Query(value = """
+        SELECT c FROM Comment c
+        WHERE c.parentId IS NULL
+        ORDER BY c.createdAt DESC
+    """, countQuery = "SELECT COUNT(c) FROM Comment c WHERE c.parentId IS NULL")
+    fun findRootCommentsPagedForOwner(pageable: Pageable): Page<Comment>
 
     @Query("""
         SELECT c.product.id AS productId, COUNT(c) AS cnt

--- a/deal-core/src/main/kotlin/com/chaltteok/core/repository/inquiry/InquiryRepository.kt
+++ b/deal-core/src/main/kotlin/com/chaltteok/core/repository/inquiry/InquiryRepository.kt
@@ -1,10 +1,13 @@
 package com.chaltteok.core.repository.inquiry
 
 import com.chaltteok.core.domain.Inquiry
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.JpaRepository
 
 interface InquiryRepository : JpaRepository<Inquiry, Long> {
     fun findByInquiryUuid(uuid: String): Inquiry?
     fun findByUserIdOrderByCreatedAtDesc(userId: Long): List<Inquiry>
     fun findAllByOrderByCreatedAtDesc(): List<Inquiry>
+    fun findAllByOrderByCreatedAtDesc(pageable: Pageable): Page<Inquiry>
 }


### PR DESCRIPTION
## Summary
- 댓글 API 페이징 처리: `GET /api/v1/user/products/{uuid}/comments?page=0&size=10`으로 변경, `CommentPageResponse` 도입
- 이메일 중복확인 API 추가: `GET /api/v1/user/auth/check-email?email=xxx` → `{ duplicate: Boolean }`
- 점주 댓글관리 페이징: `OwnerCommentResponse`에 `replies` 필드 추가, 루트 댓글 기준 Page 반환
- 점주 문의 페이징: `OwnerInquiryPageResponse` 도입, `Page<OwnerInquiryResponse>` 반환

## Changes
- `CommentRepository`: `findRootCommentsByProductUuidPaged`, `findRootCommentsPagedForOwner` 쿼리 추가
- `InquiryRepository`: `findAllByOrderByCreatedAtDesc(Pageable)` 오버로드 추가
- `deal-api-user`: `UserCommentService.getComments()` 페이징 반환, `AuthController.checkEmail()` 신규
- `deal-api-owner`: `OwnerCommentService.getAll()`, `OwnerInquiryService.getAll()` 페이징 반환

Resolves #47