### PR TITLE
[FIX] CommentResponse isXxx 직렬화 수정, 댓글수 전체 계산, 별점 평균 추가

### DIFF
--- a/deal-api-owner/src/main/kotlin/com/chaltteok/owner/comment/dto/OwnerCommentResponse.kt
+++ b/deal-api-owner/src/main/kotlin/com/chaltteok/owner/comment/dto/OwnerCommentResponse.kt
@@ -1,6 +1,7 @@
 package com.chaltteok.owner.comment.dto
 
 import com.chaltteok.core.domain.Comment
+import com.fasterxml.jackson.annotation.JsonProperty
 import java.time.LocalDateTime
 
 class OwnerCommentResponse(
@@ -11,8 +12,8 @@ class OwnerCommentResponse(
     val userId: Long,
     val content: String,
     val rating: Int?,
-    val isSecret: Boolean,
-    val isOwnerReply: Boolean,
+    @get:JsonProperty("isSecret") val isSecret: Boolean,
+    @get:JsonProperty("isOwnerReply") val isOwnerReply: Boolean,
     val parentId: Long?,
     val replies: List<OwnerCommentResponse>,
     val createdAt: LocalDateTime,

--- a/deal-api-user/src/main/kotlin/com/chaltteok/user/comment/dto/CommentResponse.kt
+++ b/deal-api-user/src/main/kotlin/com/chaltteok/user/comment/dto/CommentResponse.kt
@@ -1,6 +1,7 @@
 package com.chaltteok.user.comment.dto
 
 import com.chaltteok.core.domain.Comment
+import com.fasterxml.jackson.annotation.JsonProperty
 import java.time.LocalDateTime
 
 class CommentResponse(
@@ -8,11 +9,11 @@ class CommentResponse(
     val nickname: String?,
     val content: String,
     val rating: Int?,
-    val isSecret: Boolean,
-    val isOwnerReply: Boolean,
+    @get:JsonProperty("isSecret") val isSecret: Boolean,
+    @get:JsonProperty("isOwnerReply") val isOwnerReply: Boolean,
     val replies: List<CommentResponse>,
     val createdAt: LocalDateTime,
-    val isMine: Boolean,
+    @get:JsonProperty("isMine") val isMine: Boolean,
 ) {
     companion object {
         fun from(

--- a/deal-api-user/src/main/kotlin/com/chaltteok/user/product/dto/ProductResponse.kt
+++ b/deal-api-user/src/main/kotlin/com/chaltteok/user/product/dto/ProductResponse.kt
@@ -11,9 +11,10 @@ data class ProductResponse(
     val thumbnailUrl: String?,
     val soldOut: Boolean,
     val commentCount: Int = 0,
+    val averageRating: Double? = null,
 ) {
     companion object {
-        fun from(product: Product, commentCount: Int = 0) = ProductResponse(
+        fun from(product: Product, commentCount: Int = 0, averageRating: Double? = null) = ProductResponse(
             id = product.id!!,
             productUuid = product.productUuid,
             name = product.name,
@@ -22,6 +23,7 @@ data class ProductResponse(
             thumbnailUrl = product.imageUrl,
             soldOut = product.isSoldOut,
             commentCount = commentCount,
+            averageRating = averageRating,
         )
     }
 }

--- a/deal-api-user/src/main/kotlin/com/chaltteok/user/product/service/ProductQueryServiceImpl.kt
+++ b/deal-api-user/src/main/kotlin/com/chaltteok/user/product/service/ProductQueryServiceImpl.kt
@@ -2,6 +2,7 @@ package com.chaltteok.user.product.service
 
 import com.chaltteok.core.repository.comment.CommentRepository
 import com.chaltteok.core.repository.product.ProductRepository
+import com.chaltteok.core.domain.Product
 import com.chaltteok.user.product.dto.ProductResponse
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -15,27 +16,30 @@ class ProductQueryServiceImpl(
     @Transactional(readOnly = true)
     override fun getProducts(): List<ProductResponse> {
         val products = productRepository.findAllByIsActiveTrue()
-        if (products.isEmpty()) return emptyList()
-        val countMap = commentRepository.countRootCommentsByProductIds(products.mapNotNull { it.id })
-            .associate { it.productId to it.cnt.toInt() }
-        return products.map { ProductResponse.from(it, countMap[it.id!!] ?: 0) }
+        return buildResponses(products)
     }
 
     @Transactional(readOnly = true)
     override fun getRecommendedProducts(): List<ProductResponse> {
         val products = productRepository.findAllByIsActiveTrueAndIsRecommendedTrue()
-        if (products.isEmpty()) return emptyList()
-        val countMap = commentRepository.countRootCommentsByProductIds(products.mapNotNull { it.id })
-            .associate { it.productId to it.cnt.toInt() }
-        return products.map { ProductResponse.from(it, countMap[it.id!!] ?: 0) }
+        return buildResponses(products)
     }
 
     @Transactional(readOnly = true)
     override fun searchProducts(keyword: String): List<ProductResponse> {
         val products = productRepository.searchByKeyword(keyword)
+        return buildResponses(products)
+    }
+
+    private fun buildResponses(products: List<Product>): List<ProductResponse> {
         if (products.isEmpty()) return emptyList()
-        val countMap = commentRepository.countRootCommentsByProductIds(products.mapNotNull { it.id })
+        val ids = products.mapNotNull { it.id }
+        val countMap = commentRepository.countRootCommentsByProductIds(ids)
             .associate { it.productId to it.cnt.toInt() }
-        return products.map { ProductResponse.from(it, countMap[it.id!!] ?: 0) }
+        val ratingMap = commentRepository.avgRatingByProductIds(ids)
+            .associate { it.productId to it.avg }
+        return products.map {
+            ProductResponse.from(it, countMap[it.id!!] ?: 0, ratingMap[it.id!!])
+        }
     }
 }

--- a/deal-core/src/main/kotlin/com/chaltteok/core/repository/comment/CommentRepository.kt
+++ b/deal-core/src/main/kotlin/com/chaltteok/core/repository/comment/CommentRepository.kt
@@ -12,6 +12,11 @@ interface CommentCountProjection {
     val cnt: Long
 }
 
+interface AverageRatingProjection {
+    val productId: Long
+    val avg: Double?
+}
+
 interface CommentRepository : JpaRepository<Comment, Long> {
     fun findByCommentUuid(uuid: String): Comment?
 
@@ -56,8 +61,17 @@ interface CommentRepository : JpaRepository<Comment, Long> {
         FROM Comment c
         WHERE c.product.id IN :productIds
         AND c.parentId IS NULL
-        AND c.isSecret = false
         GROUP BY c.product.id
     """)
     fun countRootCommentsByProductIds(@Param("productIds") productIds: List<Long>): List<CommentCountProjection>
+
+    @Query("""
+        SELECT c.product.id AS productId, AVG(CAST(c.rating AS double)) AS avg
+        FROM Comment c
+        WHERE c.product.id IN :productIds
+        AND c.parentId IS NULL
+        AND c.rating IS NOT NULL
+        GROUP BY c.product.id
+    """)
+    fun avgRatingByProductIds(@Param("productIds") productIds: List<Long>): List<AverageRatingProjection>
 }


### PR DESCRIPTION
## 원인 및 수정
Kotlin non-data class의 `isXxx: Boolean` 필드는 Jackson이 getter `isXxx()`를 JavaBean 규약으로 해석해 `xxx`로 직렬화함.
`@get:JsonProperty` 어노테이션 누락으로 프론트에서 `isSecret`, `isOwnerReply`, `isMine`이 모두 `undefined`가 되어 마스킹/수정삭제 불동작.

## 변경 사항
- `CommentResponse`: `@get:JsonProperty` 추가 (isSecret, isOwnerReply, isMine)
- `OwnerCommentResponse`: `@get:JsonProperty` 추가 (isSecret, isOwnerReply)
- `CommentRepository.countRootCommentsByProductIds`: `isSecret = false` 필터 제거 (비밀댓글도 카운트)
- `CommentRepository.avgRatingByProductIds`: 상품별 평균별점 쿼리 추가
- `ProductResponse`: `averageRating: Double?` 필드 추가
- `ProductQueryServiceImpl`: `buildResponses()` 공통화 + 평균별점 계산 포함

Resolves #49