### PR TITLE
[FEAT] 상품 상세 조회 API 구현

### DIFF
--- a/deal-api-user/src/main/kotlin/com/chaltteok/user/product/controller/ProductQueryController.kt
+++ b/deal-api-user/src/main/kotlin/com/chaltteok/user/product/controller/ProductQueryController.kt
@@ -3,12 +3,13 @@ package com.chaltteok.user.product.controller
 import com.chaltteok.common.dto.ResponseDTO
 import com.chaltteok.user.product.dto.ProductResponse
 import com.chaltteok.user.product.service.ProductQueryService
+import org.springframework.http.HttpStatus
 import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 import org.springframework.web.server.ResponseStatusException
-import org.springframework.http.HttpStatus
 
 @RestController
 @RequestMapping("/api/v1/user/products")
@@ -18,6 +19,10 @@ class ProductQueryController(
     @GetMapping
     fun getProducts(): ResponseDTO<List<ProductResponse>> =
         ResponseDTO.success(productQueryService.getProducts())
+
+    @GetMapping("/{productUuid}")
+    fun getProduct(@PathVariable productUuid: String): ResponseDTO<ProductResponse> =
+        ResponseDTO.success(productQueryService.getProductByUuid(productUuid))
 
     @GetMapping("/recommended")
     fun getRecommendedProducts(): ResponseDTO<List<ProductResponse>> =

--- a/deal-api-user/src/main/kotlin/com/chaltteok/user/product/service/ProductQueryService.kt
+++ b/deal-api-user/src/main/kotlin/com/chaltteok/user/product/service/ProductQueryService.kt
@@ -4,6 +4,7 @@ import com.chaltteok.user.product.dto.ProductResponse
 
 interface ProductQueryService {
     fun getProducts(): List<ProductResponse>
+    fun getProductByUuid(productUuid: String): ProductResponse
     fun getRecommendedProducts(): List<ProductResponse>
     fun searchProducts(keyword: String): List<ProductResponse>
 }

--- a/deal-api-user/src/main/kotlin/com/chaltteok/user/product/service/ProductQueryServiceImpl.kt
+++ b/deal-api-user/src/main/kotlin/com/chaltteok/user/product/service/ProductQueryServiceImpl.kt
@@ -4,8 +4,10 @@ import com.chaltteok.core.repository.comment.CommentRepository
 import com.chaltteok.core.repository.product.ProductRepository
 import com.chaltteok.core.domain.Product
 import com.chaltteok.user.product.dto.ProductResponse
+import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import org.springframework.web.server.ResponseStatusException
 
 @Service
 class ProductQueryServiceImpl(
@@ -17,6 +19,18 @@ class ProductQueryServiceImpl(
     override fun getProducts(): List<ProductResponse> {
         val products = productRepository.findAllByIsActiveTrue()
         return buildResponses(products)
+    }
+
+    @Transactional(readOnly = true)
+    override fun getProductByUuid(productUuid: String): ProductResponse {
+        val product = productRepository.findByProductUuid(productUuid)
+            ?: throw ResponseStatusException(HttpStatus.NOT_FOUND, "Product not found: $productUuid")
+        val id = product.id!!
+        val commentCount = commentRepository.countRootCommentsByProductIds(listOf(id))
+            .firstOrNull()?.cnt?.toInt() ?: 0
+        val averageRating = commentRepository.avgRatingByProductIds(listOf(id))
+            .firstOrNull()?.avg
+        return ProductResponse.from(product, commentCount, averageRating)
     }
 
     @Transactional(readOnly = true)


### PR DESCRIPTION
## Summary
- `GET /api/v1/user/products/{productUuid}` 엔드포인트를 신규 구현합니다.
- 프론트엔드 상품 상세 페이지(`/products/[uuid]`)에서 호출하는 미구현 API를 완성합니다.
- 존재하지 않는 UUID 조회 시 `404 Not Found`를 반환합니다.

## 변경 파일
| 파일 | 변경 내용 |
|------|-----------|
| `ProductQueryService.kt` | `getProductByUuid` 메서드 추가 |
| `ProductQueryServiceImpl.kt` | 구현체 추가 (404 처리 포함) |
| `ProductQueryController.kt` | `@GetMapping("/{productUuid}")` 핸들러 추가 |

## Test plan
- [ ] `GET /api/v1/user/products/{유효한UUID}` → 200 + 상품 정보 반환 확인
- [ ] `GET /api/v1/user/products/{존재하지않는UUID}` → 404 반환 확인
- [ ] `/recommended`, `/search` 기존 엔드포인트 정상 동작 확인 (경로 충돌 없음)

Resolves #51

🤖 Generated with [Claude Code](https://claude.com/claude-code)