### PR TITLE
[FEAT] 로그인 응답 userId→userUuid 교체 및 IDOR 취약점 제거

### DIFF
--- a/deal-api-user/src/main/kotlin/com/chaltteok/user/auth/controller/AuthController.kt
+++ b/deal-api-user/src/main/kotlin/com/chaltteok/user/auth/controller/AuthController.kt
@@ -8,6 +8,7 @@ import com.chaltteok.common.security.dto.ReissueRequest
 import com.chaltteok.common.security.dto.TokenDto
 import com.chaltteok.common.security.enums.AuthErrorCode
 import com.chaltteok.common.security.jwt.JwtTokenProvider
+import com.chaltteok.core.repository.user.UserRepository
 import com.chaltteok.user.auth.dto.RegisterRequest
 import com.chaltteok.user.auth.service.UserAuthService
 import jakarta.validation.Valid
@@ -18,6 +19,7 @@ import org.springframework.web.bind.annotation.*
 class AuthController(
     private val userAuthService: UserAuthService,
     private val jwtTokenProvider: JwtTokenProvider,
+    private val userRepository: UserRepository,
 ) {
 
     @PostMapping("/login")
@@ -48,6 +50,9 @@ class AuthController(
 
         val newAccess = jwtTokenProvider.generateAccessToken(id, storedRole)
         val newRefresh = jwtTokenProvider.generateRefreshToken(id, storedRole)
-        return ResponseDTO.success(TokenDto(newAccess, newRefresh, id))
+        val userUuid = userRepository.findById(id)
+            .orElseThrow { BusinessException(AuthErrorCode.INVALID_TOKEN) }
+            .userUuid
+        return ResponseDTO.success(TokenDto(newAccess, newRefresh, userUuid))
     }
 }

--- a/deal-api-user/src/main/kotlin/com/chaltteok/user/auth/service/UserAuthServiceImpl.kt
+++ b/deal-api-user/src/main/kotlin/com/chaltteok/user/auth/service/UserAuthServiceImpl.kt
@@ -40,7 +40,7 @@ class UserAuthServiceImpl(
 
         val accessToken = jwtTokenProvider.generateAccessToken(user.id!!, ROLE)
         val refreshToken = jwtTokenProvider.generateRefreshToken(user.id!!, ROLE)
-        return LoginResponseDto(accessToken, refreshToken, user.id!!, requirePasswordChange)
+        return LoginResponseDto(accessToken, refreshToken, user.userUuid, requirePasswordChange)
     }
 
     @Transactional

--- a/deal-api-user/src/main/kotlin/com/chaltteok/user/checkout/controller/CheckoutController.kt
+++ b/deal-api-user/src/main/kotlin/com/chaltteok/user/checkout/controller/CheckoutController.kt
@@ -5,6 +5,7 @@ import com.chaltteok.user.checkout.dto.CheckoutRequest
 import com.chaltteok.user.checkout.dto.CheckoutResponse
 import com.chaltteok.user.checkout.service.CheckoutService
 import jakarta.validation.Valid
+import org.springframework.security.core.Authentication
 import org.springframework.web.bind.annotation.*
 
 @RestController
@@ -14,8 +15,10 @@ class CheckoutController(
 ) {
     @PostMapping
     fun checkout(
-        @RequestHeader("X-User-Id") userId: Long,
+        authentication: Authentication,
         @Valid @RequestBody request: CheckoutRequest,
-    ): ResponseDTO<CheckoutResponse> =
-        ResponseDTO.success(checkoutService.checkout(userId, request))
+    ): ResponseDTO<CheckoutResponse> {
+        val userId = authentication.principal as Long
+        return ResponseDTO.success(checkoutService.checkout(userId, request))
+    }
 }

--- a/deal-api-user/src/main/kotlin/com/chaltteok/user/comment/controller/CommentController.kt
+++ b/deal-api-user/src/main/kotlin/com/chaltteok/user/comment/controller/CommentController.kt
@@ -8,6 +8,7 @@ import com.chaltteok.user.comment.dto.ReplyRequest
 import com.chaltteok.user.comment.service.UserCommentService
 import jakarta.validation.Valid
 import org.springframework.http.HttpStatus
+import org.springframework.security.core.Authentication
 import org.springframework.web.bind.annotation.*
 
 @RestController
@@ -17,44 +18,53 @@ class CommentController(private val userCommentService: UserCommentService) {
     @GetMapping("/products/{productUuid}/comments")
     fun getComments(
         @PathVariable productUuid: String,
-        @RequestHeader(value = "X-User-Id", required = false) userId: Long?,
+        authentication: Authentication?,
         @RequestParam(defaultValue = "0") page: Int,
         @RequestParam(defaultValue = "10") size: Int,
-    ): ResponseDTO<CommentPageResponse> =
-        ResponseDTO.success(userCommentService.getComments(productUuid, userId, page, size))
+    ): ResponseDTO<CommentPageResponse> {
+        val userId = authentication?.principal as? Long
+        return ResponseDTO.success(userCommentService.getComments(productUuid, userId, page, size))
+    }
 
     @PostMapping("/products/{productUuid}/comments")
     @ResponseStatus(HttpStatus.CREATED)
     fun createComment(
         @PathVariable productUuid: String,
-        @RequestHeader("X-User-Id") userId: Long,
+        authentication: Authentication,
         @Valid @RequestBody request: CommentRequest,
-    ): ResponseDTO<CommentResponse> =
-        ResponseDTO.success(userCommentService.create(productUuid, userId, request))
+    ): ResponseDTO<CommentResponse> {
+        val userId = authentication.principal as Long
+        return ResponseDTO.success(userCommentService.create(productUuid, userId, request))
+    }
 
     @PostMapping("/comments/{commentUuid}/reply")
     @ResponseStatus(HttpStatus.CREATED)
     fun replyComment(
         @PathVariable commentUuid: String,
-        @RequestHeader("X-User-Id") userId: Long,
+        authentication: Authentication,
         @Valid @RequestBody request: ReplyRequest,
-    ): ResponseDTO<CommentResponse> =
-        ResponseDTO.success(userCommentService.reply(commentUuid, userId, request))
+    ): ResponseDTO<CommentResponse> {
+        val userId = authentication.principal as Long
+        return ResponseDTO.success(userCommentService.reply(commentUuid, userId, request))
+    }
 
     @PutMapping("/comments/{commentUuid}")
     fun updateComment(
         @PathVariable commentUuid: String,
-        @RequestHeader("X-User-Id") userId: Long,
+        authentication: Authentication,
         @Valid @RequestBody request: CommentRequest,
-    ): ResponseDTO<CommentResponse> =
-        ResponseDTO.success(userCommentService.update(commentUuid, userId, request))
+    ): ResponseDTO<CommentResponse> {
+        val userId = authentication.principal as Long
+        return ResponseDTO.success(userCommentService.update(commentUuid, userId, request))
+    }
 
     @DeleteMapping("/comments/{commentUuid}")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     fun deleteComment(
         @PathVariable commentUuid: String,
-        @RequestHeader("X-User-Id") userId: Long,
+        authentication: Authentication,
     ): ResponseDTO<Unit> {
+        val userId = authentication.principal as Long
         userCommentService.delete(commentUuid, userId)
         return ResponseDTO.success(Unit)
     }

--- a/deal-api-user/src/main/kotlin/com/chaltteok/user/dailystock/controller/DailyStockQueryController.kt
+++ b/deal-api-user/src/main/kotlin/com/chaltteok/user/dailystock/controller/DailyStockQueryController.kt
@@ -3,8 +3,8 @@ package com.chaltteok.user.dailystock.controller
 import com.chaltteok.common.dto.ResponseDTO
 import com.chaltteok.user.dailystock.dto.OpenDailyStockResponse
 import com.chaltteok.user.dailystock.service.DailyStockQueryService
+import org.springframework.security.core.Authentication
 import org.springframework.web.bind.annotation.GetMapping
-import org.springframework.web.bind.annotation.RequestHeader
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 
@@ -18,8 +18,8 @@ class DailyStockQueryController(
         ResponseDTO.success(dailyStockQueryService.getOpenDailyStocks())
 
     @GetMapping("/participated")
-    fun getParticipatedStockIds(
-        @RequestHeader("X-User-Id") userId: Long,
-    ): ResponseDTO<List<Long>> =
-        ResponseDTO.success(dailyStockQueryService.getParticipatedStockIds(userId))
+    fun getParticipatedStockIds(authentication: Authentication): ResponseDTO<List<Long>> {
+        val userId = authentication.principal as Long
+        return ResponseDTO.success(dailyStockQueryService.getParticipatedStockIds(userId))
+    }
 }

--- a/deal-api-user/src/main/kotlin/com/chaltteok/user/inquiry/controller/UserInquiryController.kt
+++ b/deal-api-user/src/main/kotlin/com/chaltteok/user/inquiry/controller/UserInquiryController.kt
@@ -6,6 +6,7 @@ import com.chaltteok.user.inquiry.dto.InquiryResponse
 import com.chaltteok.user.inquiry.service.UserInquiryService
 import jakarta.validation.Valid
 import org.springframework.http.HttpStatus
+import org.springframework.security.core.Authentication
 import org.springframework.web.bind.annotation.*
 
 @RestController
@@ -13,16 +14,18 @@ import org.springframework.web.bind.annotation.*
 class UserInquiryController(private val userInquiryService: UserInquiryService) {
 
     @GetMapping
-    fun getMyInquiries(
-        @RequestHeader("X-User-Id") userId: Long,
-    ): ResponseDTO<List<InquiryResponse>> =
-        ResponseDTO.success(userInquiryService.getMyInquiries(userId))
+    fun getMyInquiries(authentication: Authentication): ResponseDTO<List<InquiryResponse>> {
+        val userId = authentication.principal as Long
+        return ResponseDTO.success(userInquiryService.getMyInquiries(userId))
+    }
 
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
     fun create(
-        @RequestHeader("X-User-Id") userId: Long,
+        authentication: Authentication,
         @Valid @RequestBody request: InquiryRequest,
-    ): ResponseDTO<InquiryResponse> =
-        ResponseDTO.success(userInquiryService.create(userId, request))
+    ): ResponseDTO<InquiryResponse> {
+        val userId = authentication.principal as Long
+        return ResponseDTO.success(userInquiryService.create(userId, request))
+    }
 }

--- a/deal-api-user/src/main/kotlin/com/chaltteok/user/order/controller/OrderController.kt
+++ b/deal-api-user/src/main/kotlin/com/chaltteok/user/order/controller/OrderController.kt
@@ -4,6 +4,7 @@ import com.chaltteok.common.dto.ResponseDTO
 import com.chaltteok.user.order.dto.OrderRequest
 import com.chaltteok.user.order.service.OrderService
 import jakarta.validation.Valid
+import org.springframework.security.core.Authentication
 import org.springframework.web.bind.annotation.*
 
 @RestController
@@ -13,18 +14,20 @@ class OrderController(
 ) {
     @PostMapping
     fun placeOrder(
-        @RequestHeader("X-User-Id") userId: Long,
+        authentication: Authentication,
         @RequestBody @Valid request: OrderRequest,
     ): ResponseDTO<String> {
+        val userId = authentication.principal as Long
         orderService.placeOrder(userId, request)
         return ResponseDTO.success("주문 요청이 접수되었습니다.")
     }
 
     @PostMapping("/{orderNumber}/cancel")
     fun cancelOrder(
-        @RequestHeader("X-User-Id") userId: Long,
+        authentication: Authentication,
         @PathVariable orderNumber: String,
     ): ResponseDTO<String> {
+        val userId = authentication.principal as Long
         orderService.cancelOrder(userId, orderNumber)
         return ResponseDTO.success("주문이 취소되었습니다.")
     }

--- a/deal-api-user/src/main/kotlin/com/chaltteok/user/order/controller/OrderQueryController.kt
+++ b/deal-api-user/src/main/kotlin/com/chaltteok/user/order/controller/OrderQueryController.kt
@@ -5,6 +5,7 @@ import com.chaltteok.user.order.dto.OrderHistoryPageResponse
 import com.chaltteok.user.order.dto.OrderHistoryResponse
 import com.chaltteok.user.order.service.OrderQueryService
 import org.springframework.data.domain.PageRequest
+import org.springframework.security.core.Authentication
 import org.springframework.web.bind.annotation.*
 
 @RestController
@@ -14,7 +15,7 @@ class OrderQueryController(
 ) {
     @GetMapping
     fun getOrderHistory(
-        @RequestHeader("X-User-Id") userId: Long,
+        authentication: Authentication,
         @RequestParam(defaultValue = "0") page: Int,
         @RequestParam(defaultValue = "10") size: Int,
         @RequestParam(required = false) keyword: String?,
@@ -23,6 +24,7 @@ class OrderQueryController(
         @RequestParam(required = false) toDate: String?,
         @RequestParam(required = false) paymentStatus: String?,
     ): ResponseDTO<OrderHistoryPageResponse> {
+        val userId = authentication.principal as Long
         val pageable = PageRequest.of(page, size.coerceIn(1, 50))
         return ResponseDTO.success(
             orderQueryService.getOrderHistory(userId, keyword, status, fromDate, toDate, paymentStatus, pageable)
@@ -31,8 +33,10 @@ class OrderQueryController(
 
     @GetMapping("/{orderNumber}")
     fun getOrderDetail(
-        @RequestHeader("X-User-Id") userId: Long,
+        authentication: Authentication,
         @PathVariable orderNumber: String,
-    ): ResponseDTO<OrderHistoryResponse> =
-        ResponseDTO.success(orderQueryService.getOrderDetail(userId, orderNumber))
+    ): ResponseDTO<OrderHistoryResponse> {
+        val userId = authentication.principal as Long
+        return ResponseDTO.success(orderQueryService.getOrderDetail(userId, orderNumber))
+    }
 }

--- a/deal-api-user/src/main/kotlin/com/chaltteok/user/profile/controller/UserProfileController.kt
+++ b/deal-api-user/src/main/kotlin/com/chaltteok/user/profile/controller/UserProfileController.kt
@@ -6,6 +6,7 @@ import com.chaltteok.user.profile.dto.UpdateNicknameRequest
 import com.chaltteok.user.profile.dto.UserProfileResponse
 import com.chaltteok.user.profile.service.UserProfileService
 import jakarta.validation.Valid
+import org.springframework.security.core.Authentication
 import org.springframework.web.bind.annotation.*
 
 @RestController
@@ -14,23 +15,26 @@ class UserProfileController(
     private val userProfileService: UserProfileService,
 ) {
     @GetMapping
-    fun getProfile(
-        @RequestHeader("X-User-Id") userId: Long,
-    ): ResponseDTO<UserProfileResponse> =
-        ResponseDTO.success(userProfileService.getProfile(userId))
+    fun getProfile(authentication: Authentication): ResponseDTO<UserProfileResponse> {
+        val userId = authentication.principal as Long
+        return ResponseDTO.success(userProfileService.getProfile(userId))
+    }
 
     @PatchMapping
     fun updateNickname(
-        @RequestHeader("X-User-Id") userId: Long,
+        authentication: Authentication,
         @Valid @RequestBody request: UpdateNicknameRequest,
-    ): ResponseDTO<UserProfileResponse> =
-        ResponseDTO.success(userProfileService.updateNickname(userId, request))
+    ): ResponseDTO<UserProfileResponse> {
+        val userId = authentication.principal as Long
+        return ResponseDTO.success(userProfileService.updateNickname(userId, request))
+    }
 
     @PatchMapping("/password")
     fun changePassword(
-        @RequestHeader("X-User-Id") userId: Long,
+        authentication: Authentication,
         @Valid @RequestBody request: ChangePasswordRequest,
     ): ResponseDTO<Unit> {
+        val userId = authentication.principal as Long
         userProfileService.changePassword(userId, request)
         return ResponseDTO.success(Unit)
     }

--- a/deal-common-api/src/main/kotlin/com/chaltteok/common/security/dto/LoginResponseDto.kt
+++ b/deal-common-api/src/main/kotlin/com/chaltteok/common/security/dto/LoginResponseDto.kt
@@ -3,6 +3,6 @@ package com.chaltteok.common.security.dto
 class LoginResponseDto(
     val accessToken: String,
     val refreshToken: String,
-    val userId: Long,
+    val userUuid: String,
     val requirePasswordChange: Boolean = false,
 )

--- a/deal-common-api/src/main/kotlin/com/chaltteok/common/security/dto/TokenDto.kt
+++ b/deal-common-api/src/main/kotlin/com/chaltteok/common/security/dto/TokenDto.kt
@@ -3,5 +3,5 @@ package com.chaltteok.common.security.dto
 data class TokenDto(
     val accessToken: String,
     val refreshToken: String,
-    val userId: Long,
+    val userUuid: String,
 )


### PR DESCRIPTION
## Summary
- 로그인·재발급 응답 DTO의 내부 PK(`userId: Long`)를 외부 노출 안전한 `userUuid: String`으로 교체합니다.
- 모든 컨트롤러에서 `@RequestHeader("X-User-Id")` 의존을 제거하고, JWT SecurityContext(`Authentication.principal`)에서 userId를 추출하도록 수정하여 IDOR 취약점을 제거합니다.

## 변경 내용
| 파일 | 변경 |
|------|------|
| `LoginResponseDto.kt` | `userId: Long` → `userUuid: String` |
| `TokenDto.kt` | `userId: Long` → `userUuid: String` |
| `UserAuthServiceImpl.kt` | `user.id!!` → `user.userUuid` 반환 |
| `AuthController.kt` | reissue 시 UserRepository로 userUuid 조회 |
| 7개 컨트롤러 | `@RequestHeader("X-User-Id")` → `Authentication` 파라미터 |

## 보안 개선
- **Before**: 클라이언트가 임의의 `X-User-Id` 헤더를 보내면 서버가 신뢰 → IDOR 가능
- **After**: JWT 서명 검증 후 SecurityContext에서만 userId 추출 → 위변조 불가

## Test plan
- [ ] `POST /api/v1/user/auth/login` 응답에 `userUuid` 포함, `userId` 미포함 확인
- [ ] `POST /api/v1/user/auth/reissue` 응답에 `userUuid` 포함 확인
- [ ] 유효 JWT로 주문/댓글/프로필 API 정상 동작 확인
- [ ] `X-User-Id` 헤더 임의 설정 후 요청 시 무시됨 확인

Resolves #53

🤖 Generated with [Claude Code](https://claude.com/claude-code)