### PR TITLE
[FEAT] Owner 로그인 응답 ownerId→ownerUuid 교체 및 X-Owner-Id 헤더 제거

### DIFF
--- a/deal-api-owner/src/main/kotlin/com/chaltteok/owner/auth/controller/AuthController.kt
+++ b/deal-api-owner/src/main/kotlin/com/chaltteok/owner/auth/controller/AuthController.kt
@@ -8,6 +8,7 @@ import com.chaltteok.common.security.dto.ReissueRequest
 import com.chaltteok.common.security.dto.TokenDto
 import com.chaltteok.common.security.enums.AuthErrorCode
 import com.chaltteok.common.security.jwt.JwtTokenProvider
+import com.chaltteok.core.repository.owner.OwnerRepository
 import com.chaltteok.owner.auth.service.OwnerAuthService
 import jakarta.validation.Valid
 import org.springframework.web.bind.annotation.PostMapping
@@ -20,6 +21,7 @@ import org.springframework.web.bind.annotation.RestController
 class AuthController(
     private val ownerAuthService: OwnerAuthService,
     private val jwtTokenProvider: JwtTokenProvider,
+    private val ownerRepository: OwnerRepository,
 ) {
     @PostMapping("/login")
     fun login(@Valid @RequestBody request: LoginRequest): ResponseDTO<LoginResponseDto> =
@@ -39,6 +41,9 @@ class AuthController(
 
         val newAccess = jwtTokenProvider.generateAccessToken(userId, role)
         val newRefresh = jwtTokenProvider.generateRefreshToken(userId, role)
-        return ResponseDTO.success(TokenDto(newAccess, newRefresh, userId))
+        val ownerUuid = ownerRepository.findById(userId)
+            .orElseThrow { BusinessException(AuthErrorCode.INVALID_TOKEN) }
+            .ownerUuid
+        return ResponseDTO.success(TokenDto(newAccess, newRefresh, ownerUuid))
     }
 }

--- a/deal-api-owner/src/main/kotlin/com/chaltteok/owner/auth/service/OwnerAuthServiceImpl.kt
+++ b/deal-api-owner/src/main/kotlin/com/chaltteok/owner/auth/service/OwnerAuthServiceImpl.kt
@@ -30,13 +30,13 @@ class OwnerAuthServiceImpl(
             throw BusinessException(AuthErrorCode.INVALID_CREDENTIALS)
         }
 
-        val userId = owner.id ?: throw BusinessException(AuthErrorCode.INVALID_CREDENTIALS)
+        val ownerId = owner.id ?: throw BusinessException(AuthErrorCode.INVALID_CREDENTIALS)
 
         val requirePasswordChange = owner.passwordChangedAt == null ||
             owner.passwordChangedAt!!.isBefore(LocalDateTime.now().minusDays(90))
 
-        val accessToken = jwtTokenProvider.generateAccessToken(userId, ROLE)
-        val refreshToken = jwtTokenProvider.generateRefreshToken(userId, ROLE)
-        return LoginResponseDto(accessToken, refreshToken, userId, requirePasswordChange)
+        val accessToken = jwtTokenProvider.generateAccessToken(ownerId, ROLE)
+        val refreshToken = jwtTokenProvider.generateRefreshToken(ownerId, ROLE)
+        return LoginResponseDto(accessToken, refreshToken, owner.ownerUuid, requirePasswordChange)
     }
 }

--- a/deal-api-owner/src/main/kotlin/com/chaltteok/owner/profile/controller/OwnerProfileController.kt
+++ b/deal-api-owner/src/main/kotlin/com/chaltteok/owner/profile/controller/OwnerProfileController.kt
@@ -4,9 +4,9 @@ import com.chaltteok.common.dto.ResponseDTO
 import com.chaltteok.owner.profile.dto.ChangeOwnerPasswordRequest
 import com.chaltteok.owner.profile.service.OwnerProfileService
 import jakarta.validation.Valid
+import org.springframework.security.core.Authentication
 import org.springframework.web.bind.annotation.PatchMapping
 import org.springframework.web.bind.annotation.RequestBody
-import org.springframework.web.bind.annotation.RequestHeader
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 
@@ -16,9 +16,10 @@ class OwnerProfileController(private val ownerProfileService: OwnerProfileServic
 
     @PatchMapping("/password")
     fun changePassword(
-        @RequestHeader("X-Owner-Id") ownerId: Long,
+        authentication: Authentication,
         @Valid @RequestBody request: ChangeOwnerPasswordRequest,
     ): ResponseDTO<Unit> {
+        val ownerId = authentication.principal as Long
         ownerProfileService.changePassword(ownerId, request)
         return ResponseDTO.success(Unit)
     }


### PR DESCRIPTION
## Summary
User API(PR #54)와 동일한 패턴을 Owner API에 적용합니다.

- 로그인·재발급 응답의 내부 PK(`ownerId: Long`)를 `ownerUuid: String`으로 교체합니다.
- `OwnerProfileController`에서 `@RequestHeader("X-Owner-Id")` 의존을 제거하고 JWT SecurityContext에서 ownerId를 추출합니다.

## 변경 내용
| 파일 | 변경 |
|------|------|
| `OwnerAuthServiceImpl.kt` | `owner.id!!` → `owner.ownerUuid` 반환 |
| `owner/AuthController.kt` | reissue 시 OwnerRepository로 ownerUuid 조회 |
| `OwnerProfileController.kt` | `@RequestHeader("X-Owner-Id")` → `Authentication` |

## Test plan
- [ ] `POST /api/v1/owner/auth/login` 응답에 `userUuid`(ownerUuid) 포함, `userId` 미포함 확인
- [ ] `POST /api/v1/owner/auth/reissue` 응답에 `userUuid` 포함 확인
- [ ] `PATCH /api/v1/owner/me/password` 유효 JWT로 정상 동작 확인

Resolves #55

🤖 Generated with [Claude Code](https://claude.com/claude-code)