### PR TITLE
[FEAT] OwnerCommentResponse·OwnerInquiryResponse userId → userUuid 교체

### DIFF
--- a/deal-api-owner/src/main/kotlin/com/chaltteok/owner/comment/dto/OwnerCommentResponse.kt
+++ b/deal-api-owner/src/main/kotlin/com/chaltteok/owner/comment/dto/OwnerCommentResponse.kt
@@ -9,7 +9,7 @@ class OwnerCommentResponse(
     val commentUuid: String,
     val productUuid: String,
     val productName: String,
-    val userId: Long,
+    val userUuid: String,
     val content: String,
     val rating: Int?,
     @get:JsonProperty("isSecret") val isSecret: Boolean,
@@ -19,12 +19,12 @@ class OwnerCommentResponse(
     val createdAt: LocalDateTime,
 ) {
     companion object {
-        fun from(comment: Comment) = OwnerCommentResponse(
+        fun from(comment: Comment, userUuid: String = "") = OwnerCommentResponse(
             commentId = comment.id!!,
             commentUuid = comment.commentUuid,
             productUuid = comment.product.productUuid,
             productName = comment.product.name,
-            userId = comment.userId,
+            userUuid = userUuid,
             content = comment.content,
             rating = comment.rating,
             isSecret = comment.isSecret,
@@ -34,18 +34,22 @@ class OwnerCommentResponse(
             createdAt = comment.createdAt,
         )
 
-        fun fromWithReplies(comment: Comment, replies: List<Comment>) = OwnerCommentResponse(
+        fun fromWithReplies(
+            comment: Comment,
+            replies: List<Comment>,
+            uuidMap: Map<Long, String>,
+        ) = OwnerCommentResponse(
             commentId = comment.id!!,
             commentUuid = comment.commentUuid,
             productUuid = comment.product.productUuid,
             productName = comment.product.name,
-            userId = comment.userId,
+            userUuid = uuidMap[comment.userId] ?: "",
             content = comment.content,
             rating = comment.rating,
             isSecret = comment.isSecret,
             isOwnerReply = comment.isOwnerReply,
             parentId = comment.parentId,
-            replies = replies.map { from(it) },
+            replies = replies.map { from(it, if (it.isOwnerReply) "" else uuidMap[it.userId] ?: "") },
             createdAt = comment.createdAt,
         )
     }

--- a/deal-api-owner/src/main/kotlin/com/chaltteok/owner/comment/service/OwnerCommentServiceImpl.kt
+++ b/deal-api-owner/src/main/kotlin/com/chaltteok/owner/comment/service/OwnerCommentServiceImpl.kt
@@ -3,6 +3,7 @@ package com.chaltteok.owner.comment.service
 import com.chaltteok.common.exception.BusinessException
 import com.chaltteok.core.domain.Comment
 import com.chaltteok.core.repository.comment.CommentRepository
+import com.chaltteok.core.repository.user.UserRepository
 import com.chaltteok.owner.comment.dto.OwnerCommentPageResponse
 import com.chaltteok.owner.comment.dto.OwnerCommentResponse
 import com.chaltteok.owner.comment.dto.OwnerReplyRequest
@@ -15,6 +16,7 @@ import org.springframework.transaction.annotation.Transactional
 @Service
 class OwnerCommentServiceImpl(
     private val commentRepository: CommentRepository,
+    private val userRepository: UserRepository,
 ) : OwnerCommentService {
 
     @Transactional(readOnly = true)
@@ -25,9 +27,16 @@ class OwnerCommentServiceImpl(
         val replies = if (roots.isNotEmpty())
             commentRepository.findRepliesByParentIds(roots.mapNotNull { it.id })
         else emptyList()
+
+        val userIds = (roots + replies)
+            .filter { !it.isOwnerReply }
+            .map { it.userId }
+            .distinct()
+        val uuidMap = userRepository.findAllById(userIds).associate { it.id!! to it.userUuid }
+
         val replyMap = replies.groupBy { it.parentId }
         val content = roots.map { root ->
-            OwnerCommentResponse.fromWithReplies(root, replyMap[root.id] ?: emptyList())
+            OwnerCommentResponse.fromWithReplies(root, replyMap[root.id] ?: emptyList(), uuidMap)
         }
         return OwnerCommentPageResponse(content, rootPage.totalElements, rootPage.totalPages, page, size)
     }

--- a/deal-api-owner/src/main/kotlin/com/chaltteok/owner/inquiry/dto/OwnerInquiryResponse.kt
+++ b/deal-api-owner/src/main/kotlin/com/chaltteok/owner/inquiry/dto/OwnerInquiryResponse.kt
@@ -5,7 +5,7 @@ import java.time.LocalDateTime
 
 class OwnerInquiryResponse(
     val inquiryUuid: String,
-    val userId: Long,
+    val userUuid: String,
     val title: String,
     val content: String,
     val status: String,
@@ -14,9 +14,9 @@ class OwnerInquiryResponse(
     val createdAt: LocalDateTime,
 ) {
     companion object {
-        fun from(inquiry: Inquiry) = OwnerInquiryResponse(
+        fun from(inquiry: Inquiry, userUuid: String) = OwnerInquiryResponse(
             inquiryUuid = inquiry.inquiryUuid,
-            userId = inquiry.userId,
+            userUuid = userUuid,
             title = inquiry.title,
             content = inquiry.content,
             status = inquiry.status,

--- a/deal-api-owner/src/main/kotlin/com/chaltteok/owner/inquiry/service/OwnerInquiryServiceImpl.kt
+++ b/deal-api-owner/src/main/kotlin/com/chaltteok/owner/inquiry/service/OwnerInquiryServiceImpl.kt
@@ -2,6 +2,7 @@ package com.chaltteok.owner.inquiry.service
 
 import com.chaltteok.common.exception.BusinessException
 import com.chaltteok.core.repository.inquiry.InquiryRepository
+import com.chaltteok.core.repository.user.UserRepository
 import com.chaltteok.owner.inquiry.dto.AnswerRequest
 import com.chaltteok.owner.inquiry.dto.OwnerInquiryPageResponse
 import com.chaltteok.owner.inquiry.dto.OwnerInquiryResponse
@@ -15,14 +16,19 @@ import java.time.LocalDateTime
 @Service
 class OwnerInquiryServiceImpl(
     private val inquiryRepository: InquiryRepository,
+    private val userRepository: UserRepository,
 ) : OwnerInquiryService {
 
     @Transactional(readOnly = true)
     override fun getAll(page: Int, size: Int): OwnerInquiryPageResponse {
         val pageable = PageRequest.of(page, size, Sort.by("createdAt").descending())
         val inquiryPage = inquiryRepository.findAllByOrderByCreatedAtDesc(pageable)
+
+        val userIds = inquiryPage.content.map { it.userId }.distinct()
+        val uuidMap = userRepository.findAllById(userIds).associate { it.id!! to it.userUuid }
+
         return OwnerInquiryPageResponse(
-            content = inquiryPage.content.map { OwnerInquiryResponse.from(it) },
+            content = inquiryPage.content.map { OwnerInquiryResponse.from(it, uuidMap[it.userId] ?: "") },
             totalElements = inquiryPage.totalElements,
             totalPages = inquiryPage.totalPages,
             currentPage = page,


### PR DESCRIPTION
## Summary
오너 화면에 노출되는 댓글·문의 응답 DTO의 내부 PK(`userId: Long`)를 `userUuid: String`으로 교체합니다.

## 변경 내용
| 파일 | 변경 |
|------|------|
| `OwnerCommentResponse.kt` | `userId: Long` → `userUuid: String` / factory 메서드에 `uuidMap` 파라미터 추가 |
| `OwnerInquiryResponse.kt` | `userId: Long` → `userUuid: String` / `from()` 에 `userUuid` 파라미터 추가 |
| `OwnerCommentServiceImpl.kt` | `UserRepository` 주입, 댓글·답글 userId 배치 조회 후 uuid 매핑 |
| `OwnerInquiryServiceImpl.kt` | `UserRepository` 주입, 문의 userId 배치 조회 후 uuid 매핑 |

## 설계 포인트
- 오너 답글(`isOwnerReply = true`)은 userId=0이므로 `userUuid = ""`로 처리
- `UserRepository.findAllById()`로 N+1 없이 단일 배치 조회

## Test plan
- [ ] `GET /api/v1/owner/comments` 응답에 `userUuid` 포함, `userId` 미포함 확인
- [ ] `GET /api/v1/owner/inquiries` 응답에 `userUuid` 포함 확인
- [ ] 오너 답글의 `userUuid`가 빈 문자열인지 확인

Resolves #57

🤖 Generated with [Claude Code](https://claude.com/claude-code)