### PR TITLE
[FEAT] 점주 배너 CRUD API 추가

### DIFF
--- a/deal-api-owner/src/main/kotlin/com/chaltteok/owner/banner/controller/BannerController.kt
+++ b/deal-api-owner/src/main/kotlin/com/chaltteok/owner/banner/controller/BannerController.kt
@@ -1,0 +1,46 @@
+package com.chaltteok.owner.banner.controller
+
+import com.chaltteok.common.dto.ResponseDTO
+import com.chaltteok.owner.banner.dto.BannerRequest
+import com.chaltteok.owner.banner.dto.BannerResponse
+import com.chaltteok.owner.banner.service.OwnerBannerService
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.DeleteMapping
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.PutMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/v1/owner/banners")
+class BannerController(private val ownerBannerService: OwnerBannerService) {
+
+    @GetMapping
+    fun getAll(): ResponseDTO<List<BannerResponse>> =
+        ResponseDTO.success(ownerBannerService.getAll())
+
+    @PostMapping
+    fun create(@RequestBody request: BannerRequest): ResponseEntity<ResponseDTO<Any>> {
+        ownerBannerService.create(request)
+        return ResponseEntity.status(HttpStatus.CREATED).body(ResponseDTO.success())
+    }
+
+    @PutMapping("/{bannerUuid}")
+    fun update(
+        @PathVariable bannerUuid: String,
+        @RequestBody request: BannerRequest,
+    ): ResponseDTO<Any> {
+        ownerBannerService.update(bannerUuid, request)
+        return ResponseDTO.success()
+    }
+
+    @DeleteMapping("/{bannerUuid}")
+    fun delete(@PathVariable bannerUuid: String): ResponseDTO<Any> {
+        ownerBannerService.delete(bannerUuid)
+        return ResponseDTO.success()
+    }
+}

--- a/deal-api-owner/src/main/kotlin/com/chaltteok/owner/banner/controller/BannerController.kt
+++ b/deal-api-owner/src/main/kotlin/com/chaltteok/owner/banner/controller/BannerController.kt
@@ -4,6 +4,7 @@ import com.chaltteok.common.dto.ResponseDTO
 import com.chaltteok.owner.banner.dto.BannerRequest
 import com.chaltteok.owner.banner.dto.BannerResponse
 import com.chaltteok.owner.banner.service.OwnerBannerService
+import jakarta.validation.Valid
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.DeleteMapping
@@ -24,7 +25,7 @@ class BannerController(private val ownerBannerService: OwnerBannerService) {
         ResponseDTO.success(ownerBannerService.getAll())
 
     @PostMapping
-    fun create(@RequestBody request: BannerRequest): ResponseEntity<ResponseDTO<Any>> {
+    fun create(@Valid @RequestBody request: BannerRequest): ResponseEntity<ResponseDTO<Any>> {
         ownerBannerService.create(request)
         return ResponseEntity.status(HttpStatus.CREATED).body(ResponseDTO.success())
     }
@@ -32,7 +33,7 @@ class BannerController(private val ownerBannerService: OwnerBannerService) {
     @PutMapping("/{bannerUuid}")
     fun update(
         @PathVariable bannerUuid: String,
-        @RequestBody request: BannerRequest,
+        @Valid @RequestBody request: BannerRequest,
     ): ResponseDTO<Any> {
         ownerBannerService.update(bannerUuid, request)
         return ResponseDTO.success()

--- a/deal-api-owner/src/main/kotlin/com/chaltteok/owner/banner/dto/BannerRequest.kt
+++ b/deal-api-owner/src/main/kotlin/com/chaltteok/owner/banner/dto/BannerRequest.kt
@@ -1,14 +1,17 @@
 package com.chaltteok.owner.banner.dto
 
+import jakarta.validation.constraints.Min
+import jakarta.validation.constraints.Pattern
+import jakarta.validation.constraints.Size
 import java.time.LocalDate
 
 class BannerRequest(
-    val title: String? = null,
-    val subtitle: String? = null,
-    val imageUrl: String? = null,
-    val linkUrl: String? = null,
-    val backgroundColor: String? = null,
-    val sortOrder: Int = 0,
+    @field:Size(max = 200) val title: String? = null,
+    @field:Size(max = 400) val subtitle: String? = null,
+    @field:Pattern(regexp = "^(https?://.*)?$") val imageUrl: String? = null,
+    @field:Pattern(regexp = "^(https?://.*)?$") val linkUrl: String? = null,
+    @field:Pattern(regexp = "^(#[0-9A-Fa-f]{3,6})?$") val backgroundColor: String? = null,
+    @field:Min(0) val sortOrder: Int = 0,
     val isVisible: Boolean = true,
     val startDate: LocalDate? = null,
     val endDate: LocalDate? = null,

--- a/deal-api-owner/src/main/kotlin/com/chaltteok/owner/banner/dto/BannerRequest.kt
+++ b/deal-api-owner/src/main/kotlin/com/chaltteok/owner/banner/dto/BannerRequest.kt
@@ -1,0 +1,15 @@
+package com.chaltteok.owner.banner.dto
+
+import java.time.LocalDate
+
+class BannerRequest(
+    val title: String? = null,
+    val subtitle: String? = null,
+    val imageUrl: String? = null,
+    val linkUrl: String? = null,
+    val backgroundColor: String? = null,
+    val sortOrder: Int = 0,
+    val isVisible: Boolean = true,
+    val startDate: LocalDate? = null,
+    val endDate: LocalDate? = null,
+)

--- a/deal-api-owner/src/main/kotlin/com/chaltteok/owner/banner/dto/BannerResponse.kt
+++ b/deal-api-owner/src/main/kotlin/com/chaltteok/owner/banner/dto/BannerResponse.kt
@@ -1,0 +1,36 @@
+package com.chaltteok.owner.banner.dto
+
+import com.chaltteok.core.domain.Banner
+import com.fasterxml.jackson.annotation.JsonProperty
+import java.time.LocalDate
+import java.time.LocalDateTime
+
+class BannerResponse(
+    val bannerUuid: String,
+    val title: String?,
+    val subtitle: String?,
+    val imageUrl: String?,
+    val linkUrl: String?,
+    val backgroundColor: String?,
+    val sortOrder: Int,
+    @get:JsonProperty("isVisible") val isVisible: Boolean,
+    val startDate: LocalDate?,
+    val endDate: LocalDate?,
+    val createdAt: LocalDateTime,
+) {
+    companion object {
+        fun from(banner: Banner) = BannerResponse(
+            bannerUuid = banner.bannerUuid,
+            title = banner.title,
+            subtitle = banner.subtitle,
+            imageUrl = banner.imageUrl,
+            linkUrl = banner.linkUrl,
+            backgroundColor = banner.backgroundColor,
+            sortOrder = banner.sortOrder,
+            isVisible = banner.isVisible,
+            startDate = banner.startDate,
+            endDate = banner.endDate,
+            createdAt = banner.createdAt,
+        )
+    }
+}

--- a/deal-api-owner/src/main/kotlin/com/chaltteok/owner/banner/enums/BannerErrorCode.kt
+++ b/deal-api-owner/src/main/kotlin/com/chaltteok/owner/banner/enums/BannerErrorCode.kt
@@ -1,0 +1,11 @@
+package com.chaltteok.owner.banner.enums
+
+import com.chaltteok.common.enums.ErrorCode
+import org.springframework.http.HttpStatus
+
+enum class BannerErrorCode(
+    override val status: HttpStatus,
+    override val message: String,
+) : ErrorCode {
+    BANNER_NOT_FOUND(HttpStatus.NOT_FOUND, "배너를 찾을 수 없습니다."),
+}

--- a/deal-api-owner/src/main/kotlin/com/chaltteok/owner/banner/service/OwnerBannerService.kt
+++ b/deal-api-owner/src/main/kotlin/com/chaltteok/owner/banner/service/OwnerBannerService.kt
@@ -1,0 +1,11 @@
+package com.chaltteok.owner.banner.service
+
+import com.chaltteok.owner.banner.dto.BannerRequest
+import com.chaltteok.owner.banner.dto.BannerResponse
+
+interface OwnerBannerService {
+    fun getAll(): List<BannerResponse>
+    fun create(request: BannerRequest)
+    fun update(bannerUuid: String, request: BannerRequest)
+    fun delete(bannerUuid: String)
+}

--- a/deal-api-owner/src/main/kotlin/com/chaltteok/owner/banner/service/OwnerBannerServiceImpl.kt
+++ b/deal-api-owner/src/main/kotlin/com/chaltteok/owner/banner/service/OwnerBannerServiceImpl.kt
@@ -1,0 +1,60 @@
+package com.chaltteok.owner.banner.service
+
+import com.chaltteok.common.exception.BusinessException
+import com.chaltteok.core.domain.Banner
+import com.chaltteok.core.repository.banner.BannerRepository
+import com.chaltteok.owner.banner.dto.BannerRequest
+import com.chaltteok.owner.banner.dto.BannerResponse
+import com.chaltteok.owner.banner.enums.BannerErrorCode
+import org.springframework.data.domain.Sort
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class OwnerBannerServiceImpl(
+    private val bannerRepository: BannerRepository,
+) : OwnerBannerService {
+
+    @Transactional(readOnly = true)
+    override fun getAll(): List<BannerResponse> =
+        bannerRepository.findAll(Sort.by(Sort.Direction.ASC, "sortOrder").and(Sort.by(Sort.Direction.DESC, "createdAt")))
+            .map { BannerResponse.from(it) }
+
+    @Transactional
+    override fun create(request: BannerRequest) {
+        val banner = Banner(
+            title = request.title,
+            subtitle = request.subtitle,
+            imageUrl = request.imageUrl,
+            linkUrl = request.linkUrl,
+            backgroundColor = request.backgroundColor,
+            sortOrder = request.sortOrder,
+            isVisible = request.isVisible,
+            startDate = request.startDate,
+            endDate = request.endDate,
+        )
+        bannerRepository.save(banner)
+    }
+
+    @Transactional
+    override fun update(bannerUuid: String, request: BannerRequest) {
+        val banner = bannerRepository.findByBannerUuid(bannerUuid)
+            ?: throw BusinessException(BannerErrorCode.BANNER_NOT_FOUND)
+        banner.title = request.title
+        banner.subtitle = request.subtitle
+        banner.imageUrl = request.imageUrl
+        banner.linkUrl = request.linkUrl
+        banner.backgroundColor = request.backgroundColor
+        banner.sortOrder = request.sortOrder
+        banner.isVisible = request.isVisible
+        banner.startDate = request.startDate
+        banner.endDate = request.endDate
+    }
+
+    @Transactional
+    override fun delete(bannerUuid: String) {
+        val banner = bannerRepository.findByBannerUuid(bannerUuid)
+            ?: throw BusinessException(BannerErrorCode.BANNER_NOT_FOUND)
+        bannerRepository.delete(banner)
+    }
+}

--- a/deal-core/src/main/kotlin/com/chaltteok/core/repository/banner/BannerRepository.kt
+++ b/deal-core/src/main/kotlin/com/chaltteok/core/repository/banner/BannerRepository.kt
@@ -8,6 +8,8 @@ import java.time.LocalDate
 
 interface BannerRepository : JpaRepository<Banner, Long> {
 
+    fun findByBannerUuid(bannerUuid: String): Banner?
+
     @Query("""
         SELECT b FROM Banner b
         WHERE b.isVisible = true


### PR DESCRIPTION
## Summary
- 점주가 배너를 직접 등록/수정/삭제할 수 있는 CRUD API 구현

## Changes
| 파일 | 변경 내용 |
|------|----------|
| `BannerRequest.kt` | 배너 등록/수정 요청 DTO |
| `BannerResponse.kt` | 배너 응답 DTO (bannerUuid, title, subtitle, imageUrl, linkUrl, backgroundColor, sortOrder, isVisible, startDate, endDate, createdAt) |
| `OwnerBannerService.kt` | 서비스 인터페이스 |
| `OwnerBannerServiceImpl.kt` | CRUD 구현체 (findByBannerUuid 기반 조회/수정/삭제) |
| `BannerController.kt` | GET/POST/PUT/DELETE /api/v1/owner/banners |
| `BannerErrorCode.kt` | BANNER_NOT_FOUND (404) |
| `BannerRepository.kt` | findByBannerUuid 메서드 추가 |

## Test plan
- [ ] GET /api/v1/owner/banners 전체 조회 (sortOrder ASC, createdAt DESC)
- [ ] POST /api/v1/owner/banners 배너 등록 (201 Created)
- [ ] PUT /api/v1/owner/banners/{bannerUuid} 배너 수정
- [ ] DELETE /api/v1/owner/banners/{bannerUuid} 배너 삭제
- [ ] 존재하지 않는 UUID 요청 시 404 응답 확인

Resolves #61

🤖 Generated with Claude Code