### PR TITLE
[FIX] 유저 배너/팝업 공개 API 인증 제거

### DIFF
--- a/deal-common-api/src/main/kotlin/com/chaltteok/common/security/config/SecurityConfig.kt
+++ b/deal-common-api/src/main/kotlin/com/chaltteok/common/security/config/SecurityConfig.kt
@@ -37,6 +37,8 @@ class SecurityConfig(
                     .requestMatchers("/api/v1/user/notices/**").permitAll()
                     .requestMatchers(HttpMethod.GET, "/api/v1/user/daily-stocks/open").permitAll()
                     .requestMatchers(HttpMethod.GET, "/api/v1/user/products/**").permitAll()
+                    .requestMatchers(HttpMethod.GET, "/api/v1/user/banners/**").permitAll()
+                    .requestMatchers(HttpMethod.GET, "/api/v1/user/popups/**").permitAll()
                     // 정적 이미지 파일 공개 접근
                     .requestMatchers(HttpMethod.GET, "/images/**").permitAll()
                     .anyRequest().authenticated()


### PR DESCRIPTION
## Summary
- 유저 배너/팝업 조회 API를 비로그인 사용자도 접근 가능하도록 수정

## Changes
| 파일 | 변경 내용 |
|------|----------|
| `SecurityConfig.kt` | GET /api/v1/user/banners/**, GET /api/v1/user/popups/** permitAll() 추가 |

## Test plan
- [ ] 비로그인 상태에서 GET /api/v1/user/banners 호출 시 200 응답 확인
- [ ] 비로그인 상태에서 GET /api/v1/user/popups 호출 시 200 응답 확인
- [ ] 기존 인증 필요 API는 여전히 401 응답 확인

Resolves #63

🤖 Generated with Claude Code