### PR TITLE
[FEAT] 점주 배너 이미지 파일 업로드 지원

### DIFF
--- a/deal-api-owner/src/main/kotlin/com/chaltteok/owner/banner/controller/BannerController.kt
+++ b/deal-api-owner/src/main/kotlin/com/chaltteok/owner/banner/controller/BannerController.kt
@@ -6,15 +6,17 @@ import com.chaltteok.owner.banner.dto.BannerResponse
 import com.chaltteok.owner.banner.service.OwnerBannerService
 import jakarta.validation.Valid
 import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.PutMapping
-import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.multipart.MultipartFile
+import org.springframework.web.bind.annotation.RequestPart
 
 @RestController
 @RequestMapping("/api/v1/owner/banners")
@@ -24,18 +26,22 @@ class BannerController(private val ownerBannerService: OwnerBannerService) {
     fun getAll(): ResponseDTO<List<BannerResponse>> =
         ResponseDTO.success(ownerBannerService.getAll())
 
-    @PostMapping
-    fun create(@Valid @RequestBody request: BannerRequest): ResponseEntity<ResponseDTO<Any>> {
-        ownerBannerService.create(request)
+    @PostMapping(consumes = [MediaType.MULTIPART_FORM_DATA_VALUE])
+    fun create(
+        @RequestPart("image", required = false) image: MultipartFile?,
+        @Valid @RequestPart("data") request: BannerRequest,
+    ): ResponseEntity<ResponseDTO<Any>> {
+        ownerBannerService.create(request, image)
         return ResponseEntity.status(HttpStatus.CREATED).body(ResponseDTO.success())
     }
 
-    @PutMapping("/{bannerUuid}")
+    @PutMapping("/{bannerUuid}", consumes = [MediaType.MULTIPART_FORM_DATA_VALUE])
     fun update(
         @PathVariable bannerUuid: String,
-        @Valid @RequestBody request: BannerRequest,
+        @RequestPart("image", required = false) image: MultipartFile?,
+        @Valid @RequestPart("data") request: BannerRequest,
     ): ResponseDTO<Any> {
-        ownerBannerService.update(bannerUuid, request)
+        ownerBannerService.update(bannerUuid, request, image)
         return ResponseDTO.success()
     }
 

--- a/deal-api-owner/src/main/kotlin/com/chaltteok/owner/banner/dto/BannerRequest.kt
+++ b/deal-api-owner/src/main/kotlin/com/chaltteok/owner/banner/dto/BannerRequest.kt
@@ -8,7 +8,6 @@ import java.time.LocalDate
 class BannerRequest(
     @field:Size(max = 200) val title: String? = null,
     @field:Size(max = 400) val subtitle: String? = null,
-    @field:Pattern(regexp = "^(https?://.*)?$") val imageUrl: String? = null,
     @field:Pattern(regexp = "^(https?://.*)?$") val linkUrl: String? = null,
     @field:Pattern(regexp = "^(#[0-9A-Fa-f]{3,6})?$") val backgroundColor: String? = null,
     @field:Min(0) val sortOrder: Int = 0,

--- a/deal-api-owner/src/main/kotlin/com/chaltteok/owner/banner/service/OwnerBannerService.kt
+++ b/deal-api-owner/src/main/kotlin/com/chaltteok/owner/banner/service/OwnerBannerService.kt
@@ -2,10 +2,11 @@ package com.chaltteok.owner.banner.service
 
 import com.chaltteok.owner.banner.dto.BannerRequest
 import com.chaltteok.owner.banner.dto.BannerResponse
+import org.springframework.web.multipart.MultipartFile
 
 interface OwnerBannerService {
     fun getAll(): List<BannerResponse>
-    fun create(request: BannerRequest)
-    fun update(bannerUuid: String, request: BannerRequest)
+    fun create(request: BannerRequest, image: MultipartFile?)
+    fun update(bannerUuid: String, request: BannerRequest, image: MultipartFile?)
     fun delete(bannerUuid: String)
 }

--- a/deal-api-owner/src/main/kotlin/com/chaltteok/owner/banner/service/OwnerBannerServiceImpl.kt
+++ b/deal-api-owner/src/main/kotlin/com/chaltteok/owner/banner/service/OwnerBannerServiceImpl.kt
@@ -45,8 +45,9 @@ class OwnerBannerServiceImpl(
         val banner = bannerRepository.findByBannerUuid(bannerUuid)
             ?: throw BusinessException(BannerErrorCode.BANNER_NOT_FOUND)
         val newImageUrl = image?.takeIf { !it.isEmpty }?.let { newImage ->
+            val uploaded = localFileUploader.uploadFile(newImage)
             banner.imageUrl?.let { localFileUploader.deleteFile(it) }
-            localFileUploader.uploadFile(newImage)
+            uploaded
         }
         banner.title = request.title
         banner.subtitle = request.subtitle

--- a/deal-api-owner/src/main/kotlin/com/chaltteok/owner/banner/service/OwnerBannerServiceImpl.kt
+++ b/deal-api-owner/src/main/kotlin/com/chaltteok/owner/banner/service/OwnerBannerServiceImpl.kt
@@ -6,13 +6,16 @@ import com.chaltteok.core.repository.banner.BannerRepository
 import com.chaltteok.owner.banner.dto.BannerRequest
 import com.chaltteok.owner.banner.dto.BannerResponse
 import com.chaltteok.owner.banner.enums.BannerErrorCode
+import com.chaltteok.owner.product.util.LocalFileUploader
 import org.springframework.data.domain.Sort
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import org.springframework.web.multipart.MultipartFile
 
 @Service
 class OwnerBannerServiceImpl(
     private val bannerRepository: BannerRepository,
+    private val localFileUploader: LocalFileUploader,
 ) : OwnerBannerService {
 
     @Transactional(readOnly = true)
@@ -21,11 +24,12 @@ class OwnerBannerServiceImpl(
             .map { BannerResponse.from(it) }
 
     @Transactional
-    override fun create(request: BannerRequest) {
+    override fun create(request: BannerRequest, image: MultipartFile?) {
+        val imageUrl = image?.takeIf { !it.isEmpty }?.let { localFileUploader.uploadFile(it) }
         val banner = Banner(
             title = request.title,
             subtitle = request.subtitle,
-            imageUrl = request.imageUrl,
+            imageUrl = imageUrl,
             linkUrl = request.linkUrl,
             backgroundColor = request.backgroundColor,
             sortOrder = request.sortOrder,
@@ -37,12 +41,16 @@ class OwnerBannerServiceImpl(
     }
 
     @Transactional
-    override fun update(bannerUuid: String, request: BannerRequest) {
+    override fun update(bannerUuid: String, request: BannerRequest, image: MultipartFile?) {
         val banner = bannerRepository.findByBannerUuid(bannerUuid)
             ?: throw BusinessException(BannerErrorCode.BANNER_NOT_FOUND)
+        val newImageUrl = image?.takeIf { !it.isEmpty }?.let { newImage ->
+            banner.imageUrl?.let { localFileUploader.deleteFile(it) }
+            localFileUploader.uploadFile(newImage)
+        }
         banner.title = request.title
         banner.subtitle = request.subtitle
-        banner.imageUrl = request.imageUrl
+        if (newImageUrl != null) banner.imageUrl = newImageUrl
         banner.linkUrl = request.linkUrl
         banner.backgroundColor = request.backgroundColor
         banner.sortOrder = request.sortOrder
@@ -55,6 +63,7 @@ class OwnerBannerServiceImpl(
     override fun delete(bannerUuid: String) {
         val banner = bannerRepository.findByBannerUuid(bannerUuid)
             ?: throw BusinessException(BannerErrorCode.BANNER_NOT_FOUND)
+        banner.imageUrl?.let { localFileUploader.deleteFile(it) }
         bannerRepository.delete(banner)
     }
 }


### PR DESCRIPTION
## Summary
- 점주 배너 이미지 입력을 URL 문자열에서 파일 업로드 방식으로 변경
- 기존 상품(Product) 이미지 업로드와 동일한 `LocalFileUploader` 패턴 적용

## Changes
| 파일 | 변경 내용 |
|------|----------|
| `BannerRequest.kt` | `imageUrl` 필드 제거 (파일로 분리) |
| `BannerController.kt` | POST/PUT 엔드포인트를 `MULTIPART_FORM_DATA`로 변경, `@RequestPart image: MultipartFile?` 추가 |
| `OwnerBannerService.kt` | `create/update` 시그니처에 `image: MultipartFile?` 추가 |
| `OwnerBannerServiceImpl.kt` | `LocalFileUploader` 주입, 업로드·삭제 로직 구현 |

## Test plan
- [ ] 이미지 없이 배너 등록 시 imageUrl null로 저장 확인
- [ ] 이미지 포함 배너 등록 시 /images/ 경로로 저장 및 응답 확인
- [ ] 배너 수정 시 새 이미지 업로드 → 기존 파일 삭제, 신규 파일 저장 확인
- [ ] 배너 삭제 시 연결 파일도 함께 삭제 확인
- [ ] JPEG/PNG 이외 파일 업로드 시 에러 응답 확인

Resolves #64

🤖 Generated with Claude Code