### PR TITLE
[FIX] HttpMediaTypeNotSupportedException 예외처리 추가

### DIFF
--- a/deal-common-api/src/main/kotlin/com/chaltteok/common/advice/GlobalExceptionHandler.kt
+++ b/deal-common-api/src/main/kotlin/com/chaltteok/common/advice/GlobalExceptionHandler.kt
@@ -8,6 +8,7 @@ import io.github.oshai.kotlinlogging.KotlinLogging
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.http.converter.HttpMessageNotReadableException
+import org.springframework.web.HttpMediaTypeNotSupportedException
 import org.springframework.web.HttpRequestMethodNotSupportedException
 import org.springframework.web.bind.MethodArgumentNotValidException
 import org.springframework.web.bind.annotation.ExceptionHandler
@@ -71,6 +72,14 @@ class GlobalExceptionHandler {
         return ResponseEntity
             .status(GlobalErrorCode.INVALID_TYPE_VALUE.status)
             .body(ResponseDTO.error(GlobalErrorCode.INVALID_TYPE_VALUE))
+    }
+
+    @ExceptionHandler(HttpMediaTypeNotSupportedException::class)
+    fun handleHttpMediaTypeNotSupported(e: HttpMediaTypeNotSupportedException): ResponseEntity<ResponseDTO<Any>> {
+        logger.warn { "Media Type Not Supported: ${e.contentType}" }
+        return ResponseEntity
+            .status(GlobalErrorCode.UNSUPPORTED_MEDIA_TYPE.status)
+            .body(ResponseDTO.error(GlobalErrorCode.UNSUPPORTED_MEDIA_TYPE))
     }
 
     @ExceptionHandler(HttpRequestMethodNotSupportedException::class)

--- a/deal-common-api/src/main/kotlin/com/chaltteok/common/enums/GlobalErrorCode.kt
+++ b/deal-common-api/src/main/kotlin/com/chaltteok/common/enums/GlobalErrorCode.kt
@@ -14,6 +14,7 @@ enum class GlobalErrorCode(
     INVALID_INPUT_VALUE("Invalid input value", HttpStatus.BAD_REQUEST),
     INVALID_TYPE_VALUE("The input value type is not valid", HttpStatus.BAD_REQUEST),
     METHOD_NOT_ALLOWED("Unsupported HTTP method", HttpStatus.METHOD_NOT_ALLOWED),
+    UNSUPPORTED_MEDIA_TYPE("Unsupported media type", HttpStatus.UNSUPPORTED_MEDIA_TYPE),
     FILE_TOO_LARGE("File size cannot exceed", HttpStatus.PAYLOAD_TOO_LARGE),
     URL_NOT_FOUND("The URL you requested could not be found", HttpStatus.NOT_FOUND);
 }


### PR DESCRIPTION
## Summary
- `GlobalErrorCode`에 `UNSUPPORTED_MEDIA_TYPE`(415) 에러 코드 추가
- `GlobalExceptionHandler`에 `HttpMediaTypeNotSupportedException` 핸들러 추가
- multipart/form-data 요청 시 Content-Type 불일치로 발생하던 500 → 415 응답으로 변경

## Changes
| 파일 | 변경 내용 |
|------|----------|
| `GlobalErrorCode.kt` | `UNSUPPORTED_MEDIA_TYPE` 항목 추가 |
| `GlobalExceptionHandler.kt` | `HttpMediaTypeNotSupportedException` 핸들러 추가, import 추가 |

## Test plan
- [ ] `Content-Type: application/json`으로 multipart 엔드포인트 호출 시 415 응답 반환 확인
- [ ] 정상 multipart 요청은 기존과 동일하게 동작 확인

Resolves #67

🤖 Generated with Claude Code