### PR TITLE
[FEAT] 유저 상품 응답에 recommended 필드 추가

### DIFF
--- a/deal-api-user/src/main/kotlin/com/chaltteok/user/product/dto/ProductResponse.kt
+++ b/deal-api-user/src/main/kotlin/com/chaltteok/user/product/dto/ProductResponse.kt
@@ -10,7 +10,7 @@ data class ProductResponse(
     val description: String?,
     val thumbnailUrl: String?,
     val soldOut: Boolean,
-    val recommended: Boolean,
+    val recommended: Boolean = false,
     val commentCount: Int = 0,
     val averageRating: Double? = null,
 ) {

--- a/deal-api-user/src/main/kotlin/com/chaltteok/user/product/dto/ProductResponse.kt
+++ b/deal-api-user/src/main/kotlin/com/chaltteok/user/product/dto/ProductResponse.kt
@@ -10,6 +10,7 @@ data class ProductResponse(
     val description: String?,
     val thumbnailUrl: String?,
     val soldOut: Boolean,
+    val recommended: Boolean,
     val commentCount: Int = 0,
     val averageRating: Double? = null,
 ) {
@@ -22,6 +23,7 @@ data class ProductResponse(
             description = product.description?.ifBlank { null },
             thumbnailUrl = product.imageUrl,
             soldOut = product.isSoldOut,
+            recommended = product.isRecommended,
             commentCount = commentCount,
             averageRating = averageRating,
         )


### PR DESCRIPTION
## Summary
유저 앱 상품 목록 추천 태그 표시를 위해 `ProductResponse`에 `recommended` 필드 추가

## Changes
| 파일 | 변경 내용 |
|------|----------|
| `ProductResponse.kt` | `recommended: Boolean` 필드 추가, `from()`에서 `product.isRecommended` 매핑 |

## Test plan
- [ ] `GET /api/v1/user/products` 응답에 `recommended` 필드 포함 확인
- [ ] 추천 상품은 `true`, 일반 상품은 `false` 반환 확인

Resolves #69
🤖 Generated with Claude Code