### PR TITLE
[FEAT] 상품 일별 재고 수량 관리 및 자동 품절 처리

### DIFF
--- a/db/migration/add_product_stock.sql
+++ b/db/migration/add_product_stock.sql
@@ -1,0 +1,4 @@
+-- tb_products 테이블에 일별 재고 수량 컬럼 추가
+ALTER TABLE tb_products
+    ADD COLUMN IF NOT EXISTS stock_quantity INT NULL COMMENT '일별 재고 설정 수량 (null=무제한)',
+    ADD COLUMN IF NOT EXISTS current_stock  INT NULL COMMENT '오늘 남은 재고 (null=무제한)';

--- a/deal-api-owner/src/main/kotlin/com/chaltteok/DealOwnerApplication.kt
+++ b/deal-api-owner/src/main/kotlin/com/chaltteok/DealOwnerApplication.kt
@@ -4,6 +4,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.autoconfigure.domain.EntityScan
 import org.springframework.boot.runApplication
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories
+import org.springframework.scheduling.annotation.EnableScheduling
 
 
 @SpringBootApplication(
@@ -15,6 +16,7 @@ import org.springframework.data.jpa.repository.config.EnableJpaRepositories
 @EnableJpaRepositories(
     basePackages = ["com.chaltteok.core.repository"]
 )
+@EnableScheduling
 class DealOwnerApplication
 
 fun main(args: Array<String>) {

--- a/deal-api-owner/src/main/kotlin/com/chaltteok/owner/product/dto/ProductListResponse.kt
+++ b/deal-api-owner/src/main/kotlin/com/chaltteok/owner/product/dto/ProductListResponse.kt
@@ -13,6 +13,8 @@ class ProductListResponse(
     val isActive: Boolean,
     val isSoldOut: Boolean,
     val isRecommended: Boolean,
+    val stockQuantity: Int?,
+    val currentStock: Int?,
 ) {
     companion object {
         fun from(row: ProductWithOptionRow) = ProductListResponse(
@@ -26,6 +28,8 @@ class ProductListResponse(
             isActive = row.isActive,
             isSoldOut = row.isSoldOut,
             isRecommended = row.isRecommended,
+            stockQuantity = row.stockQuantity,
+            currentStock = row.currentStock,
         )
     }
 }

--- a/deal-api-owner/src/main/kotlin/com/chaltteok/owner/product/dto/ProductRegisterRequest.kt
+++ b/deal-api-owner/src/main/kotlin/com/chaltteok/owner/product/dto/ProductRegisterRequest.kt
@@ -18,16 +18,21 @@ class ProductRegisterRequest(
     val isActive: Boolean = true,
     val isSoldOut: Boolean = false,
     val isRecommended: Boolean = false,
+    @field:Min(value = 0, message = "stock quantity must be 0 or more")
+    val stockQuantity: Int? = null,
 ) {
     fun toProduct(imageUrl: String?): Product {
+        val soldOut = isSoldOut || stockQuantity == 0
         return Product(
             name = name,
             description = descp,
             imageUrl = imageUrl,
             price = price,
             isActive = isActive,
-            isSoldOut = isSoldOut,
+            isSoldOut = soldOut,
             isRecommended = isRecommended,
+            stockQuantity = stockQuantity,
+            currentStock = stockQuantity,
         )
     }
 

--- a/deal-api-owner/src/main/kotlin/com/chaltteok/owner/product/dto/ProductUpdateRequest.kt
+++ b/deal-api-owner/src/main/kotlin/com/chaltteok/owner/product/dto/ProductUpdateRequest.kt
@@ -15,4 +15,6 @@ class ProductUpdateRequest(
     val isActive: Boolean = true,
     val isSoldOut: Boolean = false,
     val isRecommended: Boolean = false,
+    @field:Min(value = 0, message = "stock quantity must be 0 or more")
+    val stockQuantity: Int? = null,
 )

--- a/deal-api-owner/src/main/kotlin/com/chaltteok/owner/product/scheduler/ProductStockScheduler.kt
+++ b/deal-api-owner/src/main/kotlin/com/chaltteok/owner/product/scheduler/ProductStockScheduler.kt
@@ -1,0 +1,27 @@
+package com.chaltteok.owner.product.scheduler
+
+import com.chaltteok.core.repository.product.ProductRepository
+import io.github.oshai.kotlinlogging.KotlinLogging
+import org.springframework.scheduling.annotation.Scheduled
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
+
+private val logger = KotlinLogging.logger {}
+
+@Component
+class ProductStockScheduler(
+    private val productRepository: ProductRepository,
+) {
+    @Scheduled(cron = "0 0 0 * * *")
+    @Transactional
+    fun resetDailyStock() {
+        val products = productRepository.findAllByStockQuantityIsNotNull()
+        products.forEach { product ->
+            product.currentStock = product.stockQuantity
+            if ((product.stockQuantity ?: 0) > 0) {
+                product.isSoldOut = false
+            }
+        }
+        logger.info { "Daily stock reset completed: ${products.size} products" }
+    }
+}

--- a/deal-api-owner/src/main/kotlin/com/chaltteok/owner/product/scheduler/ProductStockScheduler.kt
+++ b/deal-api-owner/src/main/kotlin/com/chaltteok/owner/product/scheduler/ProductStockScheduler.kt
@@ -12,16 +12,11 @@ private val logger = KotlinLogging.logger {}
 class ProductStockScheduler(
     private val productRepository: ProductRepository,
 ) {
-    @Scheduled(cron = "0 0 0 * * *")
+    @Scheduled(cron = "0 0 0 * * *", zone = "Asia/Seoul")
     @Transactional
     fun resetDailyStock() {
-        val products = productRepository.findAllByStockQuantityIsNotNull()
-        products.forEach { product ->
-            product.currentStock = product.stockQuantity
-            if ((product.stockQuantity ?: 0) > 0) {
-                product.isSoldOut = false
-            }
-        }
-        logger.info { "Daily stock reset completed: ${products.size} products" }
+        val reset = productRepository.resetDailyStockForActiveProducts()
+        productRepository.markZeroStockAsSoldOut()
+        logger.info { "Daily stock reset completed: $reset products restored" }
     }
 }

--- a/deal-api-owner/src/main/kotlin/com/chaltteok/owner/product/service/ProductServiceImpl.kt
+++ b/deal-api-owner/src/main/kotlin/com/chaltteok/owner/product/service/ProductServiceImpl.kt
@@ -48,9 +48,13 @@ class ProductServiceImpl(
         product.description = request.descp
         product.price = request.price
         product.isActive = request.isActive
-        product.isSoldOut = request.isSoldOut
+        product.isSoldOut = request.isSoldOut || request.stockQuantity == 0
         product.isRecommended = request.isRecommended
         if (newImageUrl != null) product.imageUrl = newImageUrl
+        if (request.stockQuantity != null) {
+            product.stockQuantity = request.stockQuantity
+            product.currentStock = request.stockQuantity
+        }
     }
 
     @Transactional

--- a/deal-api-owner/src/main/kotlin/com/chaltteok/owner/product/service/ProductServiceImpl.kt
+++ b/deal-api-owner/src/main/kotlin/com/chaltteok/owner/product/service/ProductServiceImpl.kt
@@ -51,9 +51,11 @@ class ProductServiceImpl(
         product.isSoldOut = request.isSoldOut || request.stockQuantity == 0
         product.isRecommended = request.isRecommended
         if (newImageUrl != null) product.imageUrl = newImageUrl
-        if (request.stockQuantity != null) {
+        if (request.stockQuantity != null && request.stockQuantity != product.stockQuantity) {
             product.stockQuantity = request.stockQuantity
             product.currentStock = request.stockQuantity
+        } else if (request.stockQuantity != null) {
+            product.stockQuantity = request.stockQuantity
         }
     }
 

--- a/deal-api-user/src/main/kotlin/com/chaltteok/user/checkout/enums/CheckoutErrorCode.kt
+++ b/deal-api-user/src/main/kotlin/com/chaltteok/user/checkout/enums/CheckoutErrorCode.kt
@@ -10,4 +10,5 @@ enum class CheckoutErrorCode(
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다."),
     PRODUCT_NOT_FOUND(HttpStatus.NOT_FOUND, "상품을 찾을 수 없습니다."),
     EMPTY_CART(HttpStatus.BAD_REQUEST, "주문 상품이 없습니다."),
+    INSUFFICIENT_STOCK(HttpStatus.CONFLICT, "재고가 부족합니다."),
 }

--- a/deal-api-user/src/main/kotlin/com/chaltteok/user/checkout/service/CheckoutServiceImpl.kt
+++ b/deal-api-user/src/main/kotlin/com/chaltteok/user/checkout/service/CheckoutServiceImpl.kt
@@ -39,6 +39,11 @@ class CheckoutServiceImpl(
         val orderItems = request.items.map { item ->
             val product = productRepository.findById(item.productId)
                 .orElseThrow { BusinessException(CheckoutErrorCode.PRODUCT_NOT_FOUND) }
+            if (product.currentStock != null) {
+                val remaining = (product.currentStock!! - item.quantity).coerceAtLeast(0)
+                product.currentStock = remaining
+                if (remaining == 0) product.isSoldOut = true
+            }
             OrderItem(order = savedOrder, product = product, quantity = item.quantity, price = item.price.toInt())
         }
         orderItemRepository.saveAll(orderItems)

--- a/deal-api-user/src/main/kotlin/com/chaltteok/user/checkout/service/CheckoutServiceImpl.kt
+++ b/deal-api-user/src/main/kotlin/com/chaltteok/user/checkout/service/CheckoutServiceImpl.kt
@@ -36,13 +36,19 @@ class CheckoutServiceImpl(
         val order = Order(user = user, totalPrice = request.totalAmount.toInt(), status = OrderStatus.PENDING)
         val savedOrder = orderRepository.save(order)
 
+        val productIds = request.items.map { it.productId }
+        val productMap = productRepository.findAllByIdInWithLock(productIds)
+            .associateBy { it.id!! }
+
         val orderItems = request.items.map { item ->
-            val product = productRepository.findById(item.productId)
-                .orElseThrow { BusinessException(CheckoutErrorCode.PRODUCT_NOT_FOUND) }
+            val product = productMap[item.productId]
+                ?: throw BusinessException(CheckoutErrorCode.PRODUCT_NOT_FOUND)
             if (product.currentStock != null) {
-                val remaining = (product.currentStock!! - item.quantity).coerceAtLeast(0)
-                product.currentStock = remaining
-                if (remaining == 0) product.isSoldOut = true
+                if (product.currentStock!! < item.quantity) {
+                    throw BusinessException(CheckoutErrorCode.INSUFFICIENT_STOCK)
+                }
+                product.currentStock = product.currentStock!! - item.quantity
+                if (product.currentStock == 0) product.isSoldOut = true
             }
             OrderItem(order = savedOrder, product = product, quantity = item.quantity, price = item.price.toInt())
         }

--- a/deal-core/src/main/kotlin/com/chaltteok/core/domain/Product.kt
+++ b/deal-core/src/main/kotlin/com/chaltteok/core/domain/Product.kt
@@ -32,6 +32,12 @@ class Product(
     @Column(name = "is_recommended")
     var isRecommended: Boolean = false,
 
+    @Column(name = "stock_quantity")
+    var stockQuantity: Int? = null,
+
+    @Column(name = "current_stock")
+    var currentStock: Int? = null,
+
 ) : BaseEntity() {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/deal-core/src/main/kotlin/com/chaltteok/core/repository/product/ProductRepository.kt
+++ b/deal-core/src/main/kotlin/com/chaltteok/core/repository/product/ProductRepository.kt
@@ -7,4 +7,5 @@ interface ProductRepository : JpaRepository<Product, Long>, ProductRepositoryCus
     fun findAllByIsActiveTrue(): List<Product>
     fun findAllByIsActiveTrueAndIsRecommendedTrue(): List<Product>
     fun findByProductUuid(productUuid: String): Product?
+    fun findAllByStockQuantityIsNotNull(): List<Product>
 }

--- a/deal-core/src/main/kotlin/com/chaltteok/core/repository/product/ProductRepository.kt
+++ b/deal-core/src/main/kotlin/com/chaltteok/core/repository/product/ProductRepository.kt
@@ -1,11 +1,27 @@
 package com.chaltteok.core.repository.product
 
 import com.chaltteok.core.domain.Product
+import jakarta.persistence.LockModeType
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Lock
+import org.springframework.data.jpa.repository.Modifying
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
 
 interface ProductRepository : JpaRepository<Product, Long>, ProductRepositoryCustom {
     fun findAllByIsActiveTrue(): List<Product>
     fun findAllByIsActiveTrueAndIsRecommendedTrue(): List<Product>
     fun findByProductUuid(productUuid: String): Product?
-    fun findAllByStockQuantityIsNotNull(): List<Product>
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT p FROM Product p WHERE p.id IN :ids")
+    fun findAllByIdInWithLock(@Param("ids") ids: Collection<Long>): List<Product>
+
+    @Modifying
+    @Query("UPDATE Product p SET p.currentStock = p.stockQuantity, p.isSoldOut = false WHERE p.stockQuantity IS NOT NULL AND p.stockQuantity > 0")
+    fun resetDailyStockForActiveProducts(): Int
+
+    @Modifying
+    @Query("UPDATE Product p SET p.currentStock = 0, p.isSoldOut = true WHERE p.stockQuantity = 0")
+    fun markZeroStockAsSoldOut(): Int
 }

--- a/deal-core/src/main/kotlin/com/chaltteok/core/repository/product/ProductRepositoryImpl.kt
+++ b/deal-core/src/main/kotlin/com/chaltteok/core/repository/product/ProductRepositoryImpl.kt
@@ -27,6 +27,8 @@ class ProductRepositoryImpl(private val jpaQueryFactory: JPAQueryFactory) : Prod
                     qProduct.isActive,
                     qProduct.isSoldOut,
                     qProduct.isRecommended,
+                    qProduct.stockQuantity,
+                    qProduct.currentStock,
                     qOption.optionUuid,
                     qOption.price,
                 )

--- a/deal-core/src/main/kotlin/com/chaltteok/core/repository/product/dto/ProductWithOptionRow.kt
+++ b/deal-core/src/main/kotlin/com/chaltteok/core/repository/product/dto/ProductWithOptionRow.kt
@@ -10,6 +10,8 @@ class ProductWithOptionRow(
     val isActive: Boolean,
     val isSoldOut: Boolean,
     val isRecommended: Boolean,
+    val stockQuantity: Int?,
+    val currentStock: Int?,
     val optionUuid: String,
     val optionPrice: Int,
 )


### PR DESCRIPTION
## Summary
- 점주가 상품에 일별 재고 수량(`stockQuantity`)을 설정하면 매일 자정 자동 초기화
- 체크아웃 시 재고(`currentStock`) 감소, 0이 되면 자동 품절 처리

## Changes
| 파일 | 변경 내용 |
|------|----------|
| `Product.kt` | `stockQuantity`, `currentStock` 컬럼 추가 |
| `add_product_stock.sql` | DB 마이그레이션 |
| `ProductWithOptionRow.kt` | stock 필드 추가 |
| `ProductRepositoryImpl.kt` | QueryDSL projection에 stock 필드 추가 |
| `ProductRepository.kt` | `findAllByStockQuantityIsNotNull()` 추가 |
| `ProductRegisterRequest.kt` | `stockQuantity` 필드 추가, 0이면 isSoldOut=true |
| `ProductUpdateRequest.kt` | `stockQuantity` 필드 추가 |
| `ProductListResponse.kt` | `stockQuantity`, `currentStock` 노출 |
| `ProductServiceImpl.kt` | 등록/수정 시 currentStock 초기화, 0 품절 처리 |
| `ProductStockScheduler.kt` | 매일 자정 재고 리셋 스케줄러 |
| `CheckoutServiceImpl.kt` | 체크아웃 시 currentStock 감소 → 0시 품절 |
| `DealOwnerApplication.kt` | `@EnableScheduling` 추가 |

## Test plan
- [ ] DB 마이그레이션 실행 후 컬럼 추가 확인
- [ ] stockQuantity=10 설정 후 10회 주문 시 자동 품절 확인
- [ ] stockQuantity=0 설정 시 즉시 isSoldOut=true 확인
- [ ] 자정 스케줄러 실행 후 currentStock 리셋, isSoldOut=false 확인

Resolves #71
🤖 Generated with Claude Code