### PR TITLE
[FEAT] 점주 상품 현재 잔고(currentStock) 직접 수정 및 0→양수 시 품절 자동 해제

### DIFF
--- a/deal-api-owner/src/main/kotlin/com/chaltteok/owner/product/dto/ProductUpdateRequest.kt
+++ b/deal-api-owner/src/main/kotlin/com/chaltteok/owner/product/dto/ProductUpdateRequest.kt
@@ -17,4 +17,6 @@ class ProductUpdateRequest(
     val isRecommended: Boolean = false,
     @field:Min(value = 0, message = "stock quantity must be 0 or more")
     val stockQuantity: Int? = null,
+    @field:Min(value = 0, message = "current stock must be 0 or more")
+    val currentStock: Int? = null,
 )

--- a/deal-api-owner/src/main/kotlin/com/chaltteok/owner/product/enums/ProductErrorCode.kt
+++ b/deal-api-owner/src/main/kotlin/com/chaltteok/owner/product/enums/ProductErrorCode.kt
@@ -11,4 +11,5 @@ enum class ProductErrorCode(
     FILE_EMPTY("File is empty", HttpStatus.BAD_REQUEST),
     INVALID_FILE_TYPE("This is an unsupported file type", HttpStatus.BAD_REQUEST),
     FILE_UPLOAD_ERROR("Error uploading file", HttpStatus.INTERNAL_SERVER_ERROR),
+    INVALID_STOCK("현재 잔고는 일별 재고 수량을 초과할 수 없습니다.", HttpStatus.BAD_REQUEST),
 }

--- a/deal-api-owner/src/main/kotlin/com/chaltteok/owner/product/service/ProductServiceImpl.kt
+++ b/deal-api-owner/src/main/kotlin/com/chaltteok/owner/product/service/ProductServiceImpl.kt
@@ -51,7 +51,13 @@ class ProductServiceImpl(
         product.isRecommended = request.isRecommended
         if (newImageUrl != null) product.imageUrl = newImageUrl
 
-        // stockQuantity 처리: 값이 변경된 경우에만 currentStock 리셋 (currentStock 미지정 시)
+        val effectiveStockQuantity = request.stockQuantity ?: product.stockQuantity
+        if (request.currentStock != null && effectiveStockQuantity != null
+            && request.currentStock > effectiveStockQuantity
+        ) {
+            throw BusinessException(ProductErrorCode.INVALID_STOCK)
+        }
+
         if (request.stockQuantity != null && request.stockQuantity != product.stockQuantity) {
             product.stockQuantity = request.stockQuantity
             if (request.currentStock == null) {
@@ -59,18 +65,17 @@ class ProductServiceImpl(
             }
         }
 
-        // currentStock 직접 수정 처리
+        val prevStock = product.currentStock ?: 0
         if (request.currentStock != null) {
-            val prevStock = product.currentStock ?: 0
             product.currentStock = request.currentStock
-            product.isSoldOut = when {
-                request.currentStock > 0 && prevStock == 0 -> false   // 0 → 양수: 품절 자동 해제
-                request.currentStock == 0 -> true                      // 0: 품절 처리
-                else -> request.isSoldOut || request.stockQuantity == 0
-            }
-        } else {
-            product.isSoldOut = request.isSoldOut || request.stockQuantity == 0
         }
+        product.isSoldOut = resolveSoldOut(request, prevStock)
+    }
+
+    private fun resolveSoldOut(request: ProductUpdateRequest, prevStock: Int): Boolean = when {
+        request.currentStock != null && request.currentStock > 0 && prevStock == 0 -> false
+        request.currentStock != null && request.currentStock == 0 -> true
+        else -> request.isSoldOut || request.stockQuantity == 0
     }
 
     @Transactional

--- a/deal-api-owner/src/main/kotlin/com/chaltteok/owner/product/service/ProductServiceImpl.kt
+++ b/deal-api-owner/src/main/kotlin/com/chaltteok/owner/product/service/ProductServiceImpl.kt
@@ -48,14 +48,28 @@ class ProductServiceImpl(
         product.description = request.descp
         product.price = request.price
         product.isActive = request.isActive
-        product.isSoldOut = request.isSoldOut || request.stockQuantity == 0
         product.isRecommended = request.isRecommended
         if (newImageUrl != null) product.imageUrl = newImageUrl
+
+        // stockQuantity 처리: 값이 변경된 경우에만 currentStock 리셋 (currentStock 미지정 시)
         if (request.stockQuantity != null && request.stockQuantity != product.stockQuantity) {
             product.stockQuantity = request.stockQuantity
-            product.currentStock = request.stockQuantity
-        } else if (request.stockQuantity != null) {
-            product.stockQuantity = request.stockQuantity
+            if (request.currentStock == null) {
+                product.currentStock = request.stockQuantity
+            }
+        }
+
+        // currentStock 직접 수정 처리
+        if (request.currentStock != null) {
+            val prevStock = product.currentStock ?: 0
+            product.currentStock = request.currentStock
+            product.isSoldOut = when {
+                request.currentStock > 0 && prevStock == 0 -> false   // 0 → 양수: 품절 자동 해제
+                request.currentStock == 0 -> true                      // 0: 품절 처리
+                else -> request.isSoldOut || request.stockQuantity == 0
+            }
+        } else {
+            product.isSoldOut = request.isSoldOut || request.stockQuantity == 0
         }
     }
 


### PR DESCRIPTION
## Summary
- 점주가 상품 수정 시 현재 잔고(`currentStock`)를 직접 입력 가능
- `stockQuantity`(일별 초기화 기준)와 `currentStock`(현재 남은 수량)을 독립적으로 수정
- `currentStock` 0→양수 전환 시 `isSoldOut` 자동 false 처리

## Changes
| 파일 | 변경 내용 |
|------|----------|
| `ProductUpdateRequest.kt` | `currentStock: Int?` 필드 추가 (`@Min(0)` 검증) |
| `ProductServiceImpl.kt` | currentStock 직접 수정 로직 추가, 0↔양수 전환 시 isSoldOut 자동 처리 |

## Test plan
- [ ] currentStock을 직접 0으로 설정 → isSoldOut=true 확인
- [ ] currentStock을 0→5로 변경 → isSoldOut=false 자동 해제 확인
- [ ] stockQuantity만 변경 시 currentStock도 리셋 확인
- [ ] stockQuantity + currentStock 동시 지정 시 currentStock 우선 확인

Resolves #73

🤖 Generated with Claude Code