### PR TITLE
[FEAT] 상품 노출 우선순위(displayOrder) 및 판매량/정렬 API

### DIFF
--- a/db/migration/add_product_display_order.sql
+++ b/db/migration/add_product_display_order.sql
@@ -1,0 +1,2 @@
+ALTER TABLE tb_products
+    ADD COLUMN IF NOT EXISTS display_order INT NOT NULL DEFAULT 0 COMMENT '노출 우선순위 (낮을수록 먼저 표시)';

--- a/db/migration/add_product_display_order.sql
+++ b/db/migration/add_product_display_order.sql
@@ -1,2 +1,5 @@
 ALTER TABLE tb_products
     ADD COLUMN IF NOT EXISTS display_order INT NOT NULL DEFAULT 0 COMMENT '노출 우선순위 (낮을수록 먼저 표시)';
+
+CREATE INDEX IF NOT EXISTS idx_products_active_order_name
+    ON tb_products (is_active, display_order, name);

--- a/deal-api-owner/src/main/kotlin/com/chaltteok/owner/product/dto/ProductListResponse.kt
+++ b/deal-api-owner/src/main/kotlin/com/chaltteok/owner/product/dto/ProductListResponse.kt
@@ -15,6 +15,7 @@ class ProductListResponse(
     val isRecommended: Boolean,
     val stockQuantity: Int?,
     val currentStock: Int?,
+    val displayOrder: Int,
 ) {
     companion object {
         fun from(row: ProductWithOptionRow) = ProductListResponse(
@@ -30,6 +31,7 @@ class ProductListResponse(
             isRecommended = row.isRecommended,
             stockQuantity = row.stockQuantity,
             currentStock = row.currentStock,
+            displayOrder = row.displayOrder,
         )
     }
 }

--- a/deal-api-owner/src/main/kotlin/com/chaltteok/owner/product/dto/ProductRegisterRequest.kt
+++ b/deal-api-owner/src/main/kotlin/com/chaltteok/owner/product/dto/ProductRegisterRequest.kt
@@ -3,6 +3,7 @@ package com.chaltteok.owner.product.dto
 import com.chaltteok.core.domain.Product
 import com.chaltteok.core.domain.ProductOption
 import com.chaltteok.owner.product.enums.StockType
+import jakarta.validation.constraints.Max
 import jakarta.validation.constraints.Min
 import jakarta.validation.constraints.NotNull
 
@@ -20,6 +21,8 @@ class ProductRegisterRequest(
     val isRecommended: Boolean = false,
     @field:Min(value = 0, message = "stock quantity must be 0 or more")
     val stockQuantity: Int? = null,
+    @field:Min(value = 0, message = "display order must be 0 or more")
+    @field:Max(value = 9999, message = "display order must be 9999 or less")
     val displayOrder: Int = 0,
 ) {
     fun toProduct(imageUrl: String?): Product {

--- a/deal-api-owner/src/main/kotlin/com/chaltteok/owner/product/dto/ProductRegisterRequest.kt
+++ b/deal-api-owner/src/main/kotlin/com/chaltteok/owner/product/dto/ProductRegisterRequest.kt
@@ -20,6 +20,7 @@ class ProductRegisterRequest(
     val isRecommended: Boolean = false,
     @field:Min(value = 0, message = "stock quantity must be 0 or more")
     val stockQuantity: Int? = null,
+    val displayOrder: Int = 0,
 ) {
     fun toProduct(imageUrl: String?): Product {
         val soldOut = isSoldOut || stockQuantity == 0
@@ -33,6 +34,7 @@ class ProductRegisterRequest(
             isRecommended = isRecommended,
             stockQuantity = stockQuantity,
             currentStock = stockQuantity,
+            displayOrder = displayOrder,
         )
     }
 

--- a/deal-api-owner/src/main/kotlin/com/chaltteok/owner/product/dto/ProductUpdateRequest.kt
+++ b/deal-api-owner/src/main/kotlin/com/chaltteok/owner/product/dto/ProductUpdateRequest.kt
@@ -1,5 +1,6 @@
 package com.chaltteok.owner.product.dto
 
+import jakarta.validation.constraints.Max
 import jakarta.validation.constraints.Min
 import jakarta.validation.constraints.NotNull
 
@@ -19,5 +20,7 @@ class ProductUpdateRequest(
     val stockQuantity: Int? = null,
     @field:Min(value = 0, message = "current stock must be 0 or more")
     val currentStock: Int? = null,
-    val displayOrder: Int = 0,
+    @field:Min(value = 0, message = "display order must be 0 or more")
+    @field:Max(value = 9999, message = "display order must be 9999 or less")
+    val displayOrder: Int? = null,
 )

--- a/deal-api-owner/src/main/kotlin/com/chaltteok/owner/product/dto/ProductUpdateRequest.kt
+++ b/deal-api-owner/src/main/kotlin/com/chaltteok/owner/product/dto/ProductUpdateRequest.kt
@@ -19,4 +19,5 @@ class ProductUpdateRequest(
     val stockQuantity: Int? = null,
     @field:Min(value = 0, message = "current stock must be 0 or more")
     val currentStock: Int? = null,
+    val displayOrder: Int = 0,
 )

--- a/deal-api-owner/src/main/kotlin/com/chaltteok/owner/product/service/ProductServiceImpl.kt
+++ b/deal-api-owner/src/main/kotlin/com/chaltteok/owner/product/service/ProductServiceImpl.kt
@@ -51,7 +51,7 @@ class ProductServiceImpl(
         product.isRecommended = request.isRecommended
         if (newImageUrl != null) product.imageUrl = newImageUrl
 
-        product.displayOrder = request.displayOrder
+        if (request.displayOrder != null) product.displayOrder = request.displayOrder
 
         val effectiveStockQuantity = request.stockQuantity ?: product.stockQuantity
         if (request.currentStock != null && effectiveStockQuantity != null

--- a/deal-api-owner/src/main/kotlin/com/chaltteok/owner/product/service/ProductServiceImpl.kt
+++ b/deal-api-owner/src/main/kotlin/com/chaltteok/owner/product/service/ProductServiceImpl.kt
@@ -51,6 +51,8 @@ class ProductServiceImpl(
         product.isRecommended = request.isRecommended
         if (newImageUrl != null) product.imageUrl = newImageUrl
 
+        product.displayOrder = request.displayOrder
+
         val effectiveStockQuantity = request.stockQuantity ?: product.stockQuantity
         if (request.currentStock != null && effectiveStockQuantity != null
             && request.currentStock > effectiveStockQuantity

--- a/deal-api-user/src/main/kotlin/com/chaltteok/user/product/dto/ProductResponse.kt
+++ b/deal-api-user/src/main/kotlin/com/chaltteok/user/product/dto/ProductResponse.kt
@@ -13,9 +13,10 @@ data class ProductResponse(
     val recommended: Boolean = false,
     val commentCount: Int = 0,
     val averageRating: Double? = null,
+    val salesCount: Long = 0,
 ) {
     companion object {
-        fun from(product: Product, commentCount: Int = 0, averageRating: Double? = null) = ProductResponse(
+        fun from(product: Product, commentCount: Int = 0, averageRating: Double? = null, salesCount: Long = 0) = ProductResponse(
             id = product.id!!,
             productUuid = product.productUuid,
             name = product.name,
@@ -26,6 +27,7 @@ data class ProductResponse(
             recommended = product.isRecommended,
             commentCount = commentCount,
             averageRating = averageRating,
+            salesCount = salesCount,
         )
     }
 }

--- a/deal-api-user/src/main/kotlin/com/chaltteok/user/product/service/ProductQueryServiceImpl.kt
+++ b/deal-api-user/src/main/kotlin/com/chaltteok/user/product/service/ProductQueryServiceImpl.kt
@@ -1,5 +1,6 @@
 package com.chaltteok.user.product.service
 
+import com.chaltteok.core.domain.enums.OrderStatus
 import com.chaltteok.core.repository.comment.CommentRepository
 import com.chaltteok.core.repository.orderitem.OrderItemRepository
 import com.chaltteok.core.repository.product.ProductRepository
@@ -54,7 +55,7 @@ class ProductQueryServiceImpl(
             .associate { it.productId to it.cnt.toInt() }
         val ratingMap = commentRepository.avgRatingByProductIds(ids)
             .associate { it.productId to it.avg }
-        val salesMap = orderItemRepository.sumQuantityByProductIds(ids)
+        val salesMap = orderItemRepository.sumQuantityByProductIds(ids, OrderStatus.COMPLETED)
             .associate { it.productId to it.totalQty }
         return products.map {
             ProductResponse.from(it, countMap[it.id!!] ?: 0, ratingMap[it.id!!], salesMap[it.id!!] ?: 0L)

--- a/deal-api-user/src/main/kotlin/com/chaltteok/user/product/service/ProductQueryServiceImpl.kt
+++ b/deal-api-user/src/main/kotlin/com/chaltteok/user/product/service/ProductQueryServiceImpl.kt
@@ -1,6 +1,7 @@
 package com.chaltteok.user.product.service
 
 import com.chaltteok.core.repository.comment.CommentRepository
+import com.chaltteok.core.repository.orderitem.OrderItemRepository
 import com.chaltteok.core.repository.product.ProductRepository
 import com.chaltteok.core.domain.Product
 import com.chaltteok.user.product.dto.ProductResponse
@@ -13,11 +14,12 @@ import org.springframework.web.server.ResponseStatusException
 class ProductQueryServiceImpl(
     private val productRepository: ProductRepository,
     private val commentRepository: CommentRepository,
+    private val orderItemRepository: OrderItemRepository,
 ) : ProductQueryService {
 
     @Transactional(readOnly = true)
     override fun getProducts(): List<ProductResponse> {
-        val products = productRepository.findAllByIsActiveTrue()
+        val products = productRepository.findAllByIsActiveTrueOrderByDisplayOrderAscNameAsc()
         return buildResponses(products)
     }
 
@@ -52,8 +54,10 @@ class ProductQueryServiceImpl(
             .associate { it.productId to it.cnt.toInt() }
         val ratingMap = commentRepository.avgRatingByProductIds(ids)
             .associate { it.productId to it.avg }
+        val salesMap = orderItemRepository.sumQuantityByProductIds(ids)
+            .associate { it.productId to it.totalQty }
         return products.map {
-            ProductResponse.from(it, countMap[it.id!!] ?: 0, ratingMap[it.id!!])
+            ProductResponse.from(it, countMap[it.id!!] ?: 0, ratingMap[it.id!!], salesMap[it.id!!] ?: 0L)
         }
     }
 }

--- a/deal-core/src/main/kotlin/com/chaltteok/core/domain/Product.kt
+++ b/deal-core/src/main/kotlin/com/chaltteok/core/domain/Product.kt
@@ -38,6 +38,9 @@ class Product(
     @Column(name = "current_stock")
     var currentStock: Int? = null,
 
+    @Column(name = "display_order", nullable = false)
+    var displayOrder: Int = 0,
+
 ) : BaseEntity() {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/deal-core/src/main/kotlin/com/chaltteok/core/repository/orderitem/OrderItemRepository.kt
+++ b/deal-core/src/main/kotlin/com/chaltteok/core/repository/orderitem/OrderItemRepository.kt
@@ -1,6 +1,7 @@
 package com.chaltteok.core.repository.orderitem
 
 import com.chaltteok.core.domain.OrderItem
+import com.chaltteok.core.domain.enums.OrderStatus
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
 import org.springframework.data.repository.query.Param
@@ -18,7 +19,11 @@ interface OrderItemRepository : JpaRepository<OrderItem, Long>, OrderItemReposit
         SELECT oi.product.id AS productId, SUM(oi.quantity) AS totalQty
         FROM OrderItem oi
         WHERE oi.product.id IN :productIds
+        AND oi.order.status = :status
         GROUP BY oi.product.id
     """)
-    fun sumQuantityByProductIds(@Param("productIds") productIds: List<Long>): List<SalesCountProjection>
+    fun sumQuantityByProductIds(
+        @Param("productIds") productIds: List<Long>,
+        @Param("status") status: OrderStatus,
+    ): List<SalesCountProjection>
 }

--- a/deal-core/src/main/kotlin/com/chaltteok/core/repository/orderitem/OrderItemRepository.kt
+++ b/deal-core/src/main/kotlin/com/chaltteok/core/repository/orderitem/OrderItemRepository.kt
@@ -3,8 +3,22 @@ package com.chaltteok.core.repository.orderitem
 import com.chaltteok.core.domain.OrderItem
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
+
+interface SalesCountProjection {
+    val productId: Long
+    val totalQty: Long
+}
 
 interface OrderItemRepository : JpaRepository<OrderItem, Long>, OrderItemRepositoryCustom {
     @Query("SELECT oi FROM OrderItem oi JOIN FETCH oi.product WHERE oi.order.id IN :orderIds")
     fun findByOrderIdsWithProduct(orderIds: List<Long>): List<OrderItem>
+
+    @Query("""
+        SELECT oi.product.id AS productId, SUM(oi.quantity) AS totalQty
+        FROM OrderItem oi
+        WHERE oi.product.id IN :productIds
+        GROUP BY oi.product.id
+    """)
+    fun sumQuantityByProductIds(@Param("productIds") productIds: List<Long>): List<SalesCountProjection>
 }

--- a/deal-core/src/main/kotlin/com/chaltteok/core/repository/product/ProductRepository.kt
+++ b/deal-core/src/main/kotlin/com/chaltteok/core/repository/product/ProductRepository.kt
@@ -10,6 +10,7 @@ import org.springframework.data.repository.query.Param
 
 interface ProductRepository : JpaRepository<Product, Long>, ProductRepositoryCustom {
     fun findAllByIsActiveTrue(): List<Product>
+    fun findAllByIsActiveTrueOrderByDisplayOrderAscNameAsc(): List<Product>
     fun findAllByIsActiveTrueAndIsRecommendedTrue(): List<Product>
     fun findByProductUuid(productUuid: String): Product?
 

--- a/deal-core/src/main/kotlin/com/chaltteok/core/repository/product/ProductRepositoryImpl.kt
+++ b/deal-core/src/main/kotlin/com/chaltteok/core/repository/product/ProductRepositoryImpl.kt
@@ -29,13 +29,14 @@ class ProductRepositoryImpl(private val jpaQueryFactory: JPAQueryFactory) : Prod
                     qProduct.isRecommended,
                     qProduct.stockQuantity,
                     qProduct.currentStock,
+                    qProduct.displayOrder,
                     qOption.optionUuid,
                     qOption.price,
                 )
             )
             .from(qProduct)
             .join(qOption).on(qOption.product.id.eq(qProduct.id))
-            .orderBy(qProduct.id.desc())
+            .orderBy(qProduct.displayOrder.asc(), qProduct.id.asc())
             .fetch()
     }
 

--- a/deal-core/src/main/kotlin/com/chaltteok/core/repository/product/dto/ProductWithOptionRow.kt
+++ b/deal-core/src/main/kotlin/com/chaltteok/core/repository/product/dto/ProductWithOptionRow.kt
@@ -12,6 +12,7 @@ class ProductWithOptionRow(
     val isRecommended: Boolean,
     val stockQuantity: Int?,
     val currentStock: Int?,
+    val displayOrder: Int,
     val optionUuid: String,
     val optionPrice: Int,
 )


### PR DESCRIPTION
## Summary
- 상품 노출 우선순위(displayOrder) 필드 추가 — 점주가 설정한 순서대로 유저 목록 정렬
- 유저 상품 응답에 salesCount(누적 판매량) 추가 — FE 판매량순 정렬에 활용

## Changes
| 파일 | 변경 내용 |
|------|----------|
| `db/migration/add_product_display_order.sql` | display_order 컬럼 추가 |
| `Product.kt` | displayOrder: Int = 0 필드 추가 |
| `ProductWithOptionRow.kt` | displayOrder 필드 추가 |
| `ProductRepositoryImpl.kt` | displayOrder 포함, 정렬 displayOrder ASC/id ASC |
| `ProductRepository.kt` | findAllByIsActiveTrueOrderByDisplayOrderAscNameAsc() 추가 |
| `OrderItemRepository.kt` | SalesCountProjection + sumQuantityByProductIds() 추가 |
| `ProductResponse.kt` | salesCount: Long 추가 |
| `ProductQueryServiceImpl.kt` | OrderItemRepository 주입, salesMap 조회 반영 |
| `ProductListResponse.kt` | displayOrder 추가 |
| `ProductRegisterRequest.kt` | displayOrder 추가, toProduct() 반영 |
| `ProductUpdateRequest.kt` | displayOrder 추가 |
| `ProductServiceImpl.kt` | updateProduct()에 displayOrder 업데이트 |

## Test plan
- [ ] DB migration 실행 후 기존 상품 display_order=0으로 설정 확인
- [ ] 점주 상품 등록 시 displayOrder 반영 확인
- [ ] 유저 상품 목록이 displayOrder ASC 순으로 반환 확인
- [ ] salesCount가 주문 수량 합산으로 정확히 반환 확인

Resolves #75

🤖 Generated with Claude Code