### PR TITLE
fix: 코드 리뷰 p2 이슈 수정 (PK 노출/salesCount 누락/매직 넘버)

### DIFF
--- a/db/migration/add_product_display_order.sql
+++ b/db/migration/add_product_display_order.sql
@@ -1,0 +1,2 @@
+ALTER TABLE tb_products
+    ADD COLUMN IF NOT EXISTS display_order INT NOT NULL DEFAULT 0 COMMENT '노출 우선순위 (낮을수록 먼저 표시)';

--- a/db/migration/add_product_display_order.sql
+++ b/db/migration/add_product_display_order.sql
@@ -1,2 +1,5 @@
 ALTER TABLE tb_products
     ADD COLUMN IF NOT EXISTS display_order INT NOT NULL DEFAULT 0 COMMENT '노출 우선순위 (낮을수록 먼저 표시)';
+
+CREATE INDEX IF NOT EXISTS idx_products_active_order_name
+    ON tb_products (is_active, display_order, name);

--- a/deal-api-owner/src/main/kotlin/com/chaltteok/owner/product/dto/ProductListResponse.kt
+++ b/deal-api-owner/src/main/kotlin/com/chaltteok/owner/product/dto/ProductListResponse.kt
@@ -15,6 +15,7 @@ class ProductListResponse(
     val isRecommended: Boolean,
     val stockQuantity: Int?,
     val currentStock: Int?,
+    val displayOrder: Int,
 ) {
     companion object {
         fun from(row: ProductWithOptionRow) = ProductListResponse(
@@ -30,6 +31,7 @@ class ProductListResponse(
             isRecommended = row.isRecommended,
             stockQuantity = row.stockQuantity,
             currentStock = row.currentStock,
+            displayOrder = row.displayOrder,
         )
     }
 }

--- a/deal-api-owner/src/main/kotlin/com/chaltteok/owner/product/dto/ProductRegisterRequest.kt
+++ b/deal-api-owner/src/main/kotlin/com/chaltteok/owner/product/dto/ProductRegisterRequest.kt
@@ -3,6 +3,7 @@ package com.chaltteok.owner.product.dto
 import com.chaltteok.core.domain.Product
 import com.chaltteok.core.domain.ProductOption
 import com.chaltteok.owner.product.enums.StockType
+import jakarta.validation.constraints.Max
 import jakarta.validation.constraints.Min
 import jakarta.validation.constraints.NotNull
 
@@ -20,6 +21,8 @@ class ProductRegisterRequest(
     val isRecommended: Boolean = false,
     @field:Min(value = 0, message = "stock quantity must be 0 or more")
     val stockQuantity: Int? = null,
+    @field:Min(value = 0, message = "display order must be 0 or more")
+    @field:Max(value = 9999, message = "display order must be 9999 or less")
     val displayOrder: Int = 0,
 ) {
     fun toProduct(imageUrl: String?): Product {

--- a/deal-api-owner/src/main/kotlin/com/chaltteok/owner/product/dto/ProductRegisterRequest.kt
+++ b/deal-api-owner/src/main/kotlin/com/chaltteok/owner/product/dto/ProductRegisterRequest.kt
@@ -20,6 +20,7 @@ class ProductRegisterRequest(
     val isRecommended: Boolean = false,
     @field:Min(value = 0, message = "stock quantity must be 0 or more")
     val stockQuantity: Int? = null,
+    val displayOrder: Int = 0,
 ) {
     fun toProduct(imageUrl: String?): Product {
         val soldOut = isSoldOut || stockQuantity == 0
@@ -33,6 +34,7 @@ class ProductRegisterRequest(
             isRecommended = isRecommended,
             stockQuantity = stockQuantity,
             currentStock = stockQuantity,
+            displayOrder = displayOrder,
         )
     }
 

--- a/deal-api-owner/src/main/kotlin/com/chaltteok/owner/product/dto/ProductRegisterRequest.kt
+++ b/deal-api-owner/src/main/kotlin/com/chaltteok/owner/product/dto/ProductRegisterRequest.kt
@@ -1,6 +1,7 @@
 package com.chaltteok.owner.product.dto
 
 import com.chaltteok.core.domain.Product
+import com.chaltteok.core.domain.ProductConstants
 import com.chaltteok.core.domain.ProductOption
 import com.chaltteok.owner.product.enums.StockType
 import jakarta.validation.constraints.Max
@@ -22,7 +23,7 @@ class ProductRegisterRequest(
     @field:Min(value = 0, message = "stock quantity must be 0 or more")
     val stockQuantity: Int? = null,
     @field:Min(value = 0, message = "display order must be 0 or more")
-    @field:Max(value = 9999, message = "display order must be 9999 or less")
+    @field:Max(value = ProductConstants.DISPLAY_ORDER_MAX, message = "display order must be ${ProductConstants.DISPLAY_ORDER_MAX} or less")
     val displayOrder: Int = 0,
 ) {
     fun toProduct(imageUrl: String?): Product {

--- a/deal-api-owner/src/main/kotlin/com/chaltteok/owner/product/dto/ProductUpdateRequest.kt
+++ b/deal-api-owner/src/main/kotlin/com/chaltteok/owner/product/dto/ProductUpdateRequest.kt
@@ -1,5 +1,6 @@
 package com.chaltteok.owner.product.dto
 
+import jakarta.validation.constraints.Max
 import jakarta.validation.constraints.Min
 import jakarta.validation.constraints.NotNull
 
@@ -19,5 +20,7 @@ class ProductUpdateRequest(
     val stockQuantity: Int? = null,
     @field:Min(value = 0, message = "current stock must be 0 or more")
     val currentStock: Int? = null,
-    val displayOrder: Int = 0,
+    @field:Min(value = 0, message = "display order must be 0 or more")
+    @field:Max(value = 9999, message = "display order must be 9999 or less")
+    val displayOrder: Int? = null,
 )

--- a/deal-api-owner/src/main/kotlin/com/chaltteok/owner/product/dto/ProductUpdateRequest.kt
+++ b/deal-api-owner/src/main/kotlin/com/chaltteok/owner/product/dto/ProductUpdateRequest.kt
@@ -19,4 +19,5 @@ class ProductUpdateRequest(
     val stockQuantity: Int? = null,
     @field:Min(value = 0, message = "current stock must be 0 or more")
     val currentStock: Int? = null,
+    val displayOrder: Int = 0,
 )

--- a/deal-api-owner/src/main/kotlin/com/chaltteok/owner/product/dto/ProductUpdateRequest.kt
+++ b/deal-api-owner/src/main/kotlin/com/chaltteok/owner/product/dto/ProductUpdateRequest.kt
@@ -1,5 +1,6 @@
 package com.chaltteok.owner.product.dto
 
+import com.chaltteok.core.domain.ProductConstants
 import jakarta.validation.constraints.Max
 import jakarta.validation.constraints.Min
 import jakarta.validation.constraints.NotNull
@@ -21,6 +22,6 @@ class ProductUpdateRequest(
     @field:Min(value = 0, message = "current stock must be 0 or more")
     val currentStock: Int? = null,
     @field:Min(value = 0, message = "display order must be 0 or more")
-    @field:Max(value = 9999, message = "display order must be 9999 or less")
+    @field:Max(value = ProductConstants.DISPLAY_ORDER_MAX, message = "display order must be ${ProductConstants.DISPLAY_ORDER_MAX} or less")
     val displayOrder: Int? = null,
 )

--- a/deal-api-owner/src/main/kotlin/com/chaltteok/owner/product/service/ProductServiceImpl.kt
+++ b/deal-api-owner/src/main/kotlin/com/chaltteok/owner/product/service/ProductServiceImpl.kt
@@ -51,7 +51,7 @@ class ProductServiceImpl(
         product.isRecommended = request.isRecommended
         if (newImageUrl != null) product.imageUrl = newImageUrl
 
-        product.displayOrder = request.displayOrder
+        if (request.displayOrder != null) product.displayOrder = request.displayOrder
 
         val effectiveStockQuantity = request.stockQuantity ?: product.stockQuantity
         if (request.currentStock != null && effectiveStockQuantity != null

--- a/deal-api-owner/src/main/kotlin/com/chaltteok/owner/product/service/ProductServiceImpl.kt
+++ b/deal-api-owner/src/main/kotlin/com/chaltteok/owner/product/service/ProductServiceImpl.kt
@@ -51,6 +51,8 @@ class ProductServiceImpl(
         product.isRecommended = request.isRecommended
         if (newImageUrl != null) product.imageUrl = newImageUrl
 
+        product.displayOrder = request.displayOrder
+
         val effectiveStockQuantity = request.stockQuantity ?: product.stockQuantity
         if (request.currentStock != null && effectiveStockQuantity != null
             && request.currentStock > effectiveStockQuantity

--- a/deal-api-user/src/main/kotlin/com/chaltteok/user/checkout/dto/CheckoutItemRequest.kt
+++ b/deal-api-user/src/main/kotlin/com/chaltteok/user/checkout/dto/CheckoutItemRequest.kt
@@ -4,7 +4,7 @@ import jakarta.validation.constraints.Min
 import jakarta.validation.constraints.NotNull
 
 data class CheckoutItemRequest(
-    @field:NotNull val productId: Long,
+    @field:NotNull val productUuid: String,
     @field:Min(1) val quantity: Int,
     @field:NotNull val price: Long,
 )

--- a/deal-api-user/src/main/kotlin/com/chaltteok/user/checkout/service/CheckoutServiceImpl.kt
+++ b/deal-api-user/src/main/kotlin/com/chaltteok/user/checkout/service/CheckoutServiceImpl.kt
@@ -36,12 +36,12 @@ class CheckoutServiceImpl(
         val order = Order(user = user, totalPrice = request.totalAmount.toInt(), status = OrderStatus.PENDING)
         val savedOrder = orderRepository.save(order)
 
-        val productIds = request.items.map { it.productId }
-        val productMap = productRepository.findAllByIdInWithLock(productIds)
-            .associateBy { it.id!! }
+        val productUuids = request.items.map { it.productUuid }
+        val productMap = productRepository.findAllByProductUuidInWithLock(productUuids)
+            .associateBy { it.productUuid }
 
         val orderItems = request.items.map { item ->
-            val product = productMap[item.productId]
+            val product = productMap[item.productUuid]
                 ?: throw BusinessException(CheckoutErrorCode.PRODUCT_NOT_FOUND)
             if (product.currentStock != null) {
                 if (product.currentStock!! < item.quantity) {

--- a/deal-api-user/src/main/kotlin/com/chaltteok/user/product/dto/ProductResponse.kt
+++ b/deal-api-user/src/main/kotlin/com/chaltteok/user/product/dto/ProductResponse.kt
@@ -3,7 +3,6 @@ package com.chaltteok.user.product.dto
 import com.chaltteok.core.domain.Product
 
 data class ProductResponse(
-    val id: Long,
     val productUuid: String,
     val name: String,
     val price: Long,
@@ -17,7 +16,6 @@ data class ProductResponse(
 ) {
     companion object {
         fun from(product: Product, commentCount: Int = 0, averageRating: Double? = null, salesCount: Long = 0) = ProductResponse(
-            id = product.id!!,
             productUuid = product.productUuid,
             name = product.name,
             price = product.price.toLong(),

--- a/deal-api-user/src/main/kotlin/com/chaltteok/user/product/dto/ProductResponse.kt
+++ b/deal-api-user/src/main/kotlin/com/chaltteok/user/product/dto/ProductResponse.kt
@@ -13,9 +13,10 @@ data class ProductResponse(
     val recommended: Boolean = false,
     val commentCount: Int = 0,
     val averageRating: Double? = null,
+    val salesCount: Long = 0,
 ) {
     companion object {
-        fun from(product: Product, commentCount: Int = 0, averageRating: Double? = null) = ProductResponse(
+        fun from(product: Product, commentCount: Int = 0, averageRating: Double? = null, salesCount: Long = 0) = ProductResponse(
             id = product.id!!,
             productUuid = product.productUuid,
             name = product.name,
@@ -26,6 +27,7 @@ data class ProductResponse(
             recommended = product.isRecommended,
             commentCount = commentCount,
             averageRating = averageRating,
+            salesCount = salesCount,
         )
     }
 }

--- a/deal-api-user/src/main/kotlin/com/chaltteok/user/product/service/ProductQueryServiceImpl.kt
+++ b/deal-api-user/src/main/kotlin/com/chaltteok/user/product/service/ProductQueryServiceImpl.kt
@@ -28,12 +28,7 @@ class ProductQueryServiceImpl(
     override fun getProductByUuid(productUuid: String): ProductResponse {
         val product = productRepository.findByProductUuid(productUuid)
             ?: throw ResponseStatusException(HttpStatus.NOT_FOUND, "Product not found: $productUuid")
-        val id = product.id!!
-        val commentCount = commentRepository.countRootCommentsByProductIds(listOf(id))
-            .firstOrNull()?.cnt?.toInt() ?: 0
-        val averageRating = commentRepository.avgRatingByProductIds(listOf(id))
-            .firstOrNull()?.avg
-        return ProductResponse.from(product, commentCount, averageRating)
+        return buildResponses(listOf(product)).first()
     }
 
     @Transactional(readOnly = true)

--- a/deal-api-user/src/main/kotlin/com/chaltteok/user/product/service/ProductQueryServiceImpl.kt
+++ b/deal-api-user/src/main/kotlin/com/chaltteok/user/product/service/ProductQueryServiceImpl.kt
@@ -1,5 +1,6 @@
 package com.chaltteok.user.product.service
 
+import com.chaltteok.core.domain.enums.OrderStatus
 import com.chaltteok.core.repository.comment.CommentRepository
 import com.chaltteok.core.repository.orderitem.OrderItemRepository
 import com.chaltteok.core.repository.product.ProductRepository
@@ -54,7 +55,7 @@ class ProductQueryServiceImpl(
             .associate { it.productId to it.cnt.toInt() }
         val ratingMap = commentRepository.avgRatingByProductIds(ids)
             .associate { it.productId to it.avg }
-        val salesMap = orderItemRepository.sumQuantityByProductIds(ids)
+        val salesMap = orderItemRepository.sumQuantityByProductIds(ids, OrderStatus.COMPLETED)
             .associate { it.productId to it.totalQty }
         return products.map {
             ProductResponse.from(it, countMap[it.id!!] ?: 0, ratingMap[it.id!!], salesMap[it.id!!] ?: 0L)

--- a/deal-api-user/src/main/kotlin/com/chaltteok/user/product/service/ProductQueryServiceImpl.kt
+++ b/deal-api-user/src/main/kotlin/com/chaltteok/user/product/service/ProductQueryServiceImpl.kt
@@ -1,6 +1,7 @@
 package com.chaltteok.user.product.service
 
 import com.chaltteok.core.repository.comment.CommentRepository
+import com.chaltteok.core.repository.orderitem.OrderItemRepository
 import com.chaltteok.core.repository.product.ProductRepository
 import com.chaltteok.core.domain.Product
 import com.chaltteok.user.product.dto.ProductResponse
@@ -13,11 +14,12 @@ import org.springframework.web.server.ResponseStatusException
 class ProductQueryServiceImpl(
     private val productRepository: ProductRepository,
     private val commentRepository: CommentRepository,
+    private val orderItemRepository: OrderItemRepository,
 ) : ProductQueryService {
 
     @Transactional(readOnly = true)
     override fun getProducts(): List<ProductResponse> {
-        val products = productRepository.findAllByIsActiveTrue()
+        val products = productRepository.findAllByIsActiveTrueOrderByDisplayOrderAscNameAsc()
         return buildResponses(products)
     }
 
@@ -52,8 +54,10 @@ class ProductQueryServiceImpl(
             .associate { it.productId to it.cnt.toInt() }
         val ratingMap = commentRepository.avgRatingByProductIds(ids)
             .associate { it.productId to it.avg }
+        val salesMap = orderItemRepository.sumQuantityByProductIds(ids)
+            .associate { it.productId to it.totalQty }
         return products.map {
-            ProductResponse.from(it, countMap[it.id!!] ?: 0, ratingMap[it.id!!])
+            ProductResponse.from(it, countMap[it.id!!] ?: 0, ratingMap[it.id!!], salesMap[it.id!!] ?: 0L)
         }
     }
 }

--- a/deal-core/src/main/kotlin/com/chaltteok/core/domain/Product.kt
+++ b/deal-core/src/main/kotlin/com/chaltteok/core/domain/Product.kt
@@ -38,6 +38,9 @@ class Product(
     @Column(name = "current_stock")
     var currentStock: Int? = null,
 
+    @Column(name = "display_order", nullable = false)
+    var displayOrder: Int = 0,
+
 ) : BaseEntity() {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/deal-core/src/main/kotlin/com/chaltteok/core/domain/ProductConstants.kt
+++ b/deal-core/src/main/kotlin/com/chaltteok/core/domain/ProductConstants.kt
@@ -1,0 +1,5 @@
+package com.chaltteok.core.domain
+
+object ProductConstants {
+    const val DISPLAY_ORDER_MAX = 9999L
+}

--- a/deal-core/src/main/kotlin/com/chaltteok/core/repository/orderitem/OrderItemRepository.kt
+++ b/deal-core/src/main/kotlin/com/chaltteok/core/repository/orderitem/OrderItemRepository.kt
@@ -1,6 +1,7 @@
 package com.chaltteok.core.repository.orderitem
 
 import com.chaltteok.core.domain.OrderItem
+import com.chaltteok.core.domain.enums.OrderStatus
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
 import org.springframework.data.repository.query.Param
@@ -18,7 +19,11 @@ interface OrderItemRepository : JpaRepository<OrderItem, Long>, OrderItemReposit
         SELECT oi.product.id AS productId, SUM(oi.quantity) AS totalQty
         FROM OrderItem oi
         WHERE oi.product.id IN :productIds
+        AND oi.order.status = :status
         GROUP BY oi.product.id
     """)
-    fun sumQuantityByProductIds(@Param("productIds") productIds: List<Long>): List<SalesCountProjection>
+    fun sumQuantityByProductIds(
+        @Param("productIds") productIds: List<Long>,
+        @Param("status") status: OrderStatus,
+    ): List<SalesCountProjection>
 }

--- a/deal-core/src/main/kotlin/com/chaltteok/core/repository/orderitem/OrderItemRepository.kt
+++ b/deal-core/src/main/kotlin/com/chaltteok/core/repository/orderitem/OrderItemRepository.kt
@@ -3,8 +3,22 @@ package com.chaltteok.core.repository.orderitem
 import com.chaltteok.core.domain.OrderItem
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
+
+interface SalesCountProjection {
+    val productId: Long
+    val totalQty: Long
+}
 
 interface OrderItemRepository : JpaRepository<OrderItem, Long>, OrderItemRepositoryCustom {
     @Query("SELECT oi FROM OrderItem oi JOIN FETCH oi.product WHERE oi.order.id IN :orderIds")
     fun findByOrderIdsWithProduct(orderIds: List<Long>): List<OrderItem>
+
+    @Query("""
+        SELECT oi.product.id AS productId, SUM(oi.quantity) AS totalQty
+        FROM OrderItem oi
+        WHERE oi.product.id IN :productIds
+        GROUP BY oi.product.id
+    """)
+    fun sumQuantityByProductIds(@Param("productIds") productIds: List<Long>): List<SalesCountProjection>
 }

--- a/deal-core/src/main/kotlin/com/chaltteok/core/repository/product/ProductRepository.kt
+++ b/deal-core/src/main/kotlin/com/chaltteok/core/repository/product/ProductRepository.kt
@@ -18,6 +18,10 @@ interface ProductRepository : JpaRepository<Product, Long>, ProductRepositoryCus
     @Query("SELECT p FROM Product p WHERE p.id IN :ids")
     fun findAllByIdInWithLock(@Param("ids") ids: Collection<Long>): List<Product>
 
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT p FROM Product p WHERE p.productUuid IN :uuids")
+    fun findAllByProductUuidInWithLock(@Param("uuids") uuids: Collection<String>): List<Product>
+
     @Modifying
     @Query("UPDATE Product p SET p.currentStock = p.stockQuantity, p.isSoldOut = false WHERE p.stockQuantity IS NOT NULL AND p.stockQuantity > 0")
     fun resetDailyStockForActiveProducts(): Int

--- a/deal-core/src/main/kotlin/com/chaltteok/core/repository/product/ProductRepository.kt
+++ b/deal-core/src/main/kotlin/com/chaltteok/core/repository/product/ProductRepository.kt
@@ -10,6 +10,7 @@ import org.springframework.data.repository.query.Param
 
 interface ProductRepository : JpaRepository<Product, Long>, ProductRepositoryCustom {
     fun findAllByIsActiveTrue(): List<Product>
+    fun findAllByIsActiveTrueOrderByDisplayOrderAscNameAsc(): List<Product>
     fun findAllByIsActiveTrueAndIsRecommendedTrue(): List<Product>
     fun findByProductUuid(productUuid: String): Product?
 

--- a/deal-core/src/main/kotlin/com/chaltteok/core/repository/product/ProductRepositoryImpl.kt
+++ b/deal-core/src/main/kotlin/com/chaltteok/core/repository/product/ProductRepositoryImpl.kt
@@ -29,13 +29,14 @@ class ProductRepositoryImpl(private val jpaQueryFactory: JPAQueryFactory) : Prod
                     qProduct.isRecommended,
                     qProduct.stockQuantity,
                     qProduct.currentStock,
+                    qProduct.displayOrder,
                     qOption.optionUuid,
                     qOption.price,
                 )
             )
             .from(qProduct)
             .join(qOption).on(qOption.product.id.eq(qProduct.id))
-            .orderBy(qProduct.id.desc())
+            .orderBy(qProduct.displayOrder.asc(), qProduct.id.asc())
             .fetch()
     }
 

--- a/deal-core/src/main/kotlin/com/chaltteok/core/repository/product/dto/ProductWithOptionRow.kt
+++ b/deal-core/src/main/kotlin/com/chaltteok/core/repository/product/dto/ProductWithOptionRow.kt
@@ -12,6 +12,7 @@ class ProductWithOptionRow(
     val isRecommended: Boolean,
     val stockQuantity: Int?,
     val currentStock: Int?,
+    val displayOrder: Int,
     val optionUuid: String,
     val optionPrice: Int,
 )


### PR DESCRIPTION
## Summary
- `ProductResponse`에서 내부 PK(`id`) 제거 → `productUuid`만 외부 식별자로 사용 (IDOR 방어)
- `CheckoutItemRequest` `productId → productUuid` 변경, 결제 서비스를 UUID 기반 조회로 전환
- `getProductByUuid`가 `buildResponses`를 재사용하도록 수정 (단건 조회 `salesCount=0` 고정 버그 수정)
- `ProductConstants.DISPLAY_ORDER_MAX` 상수 도입으로 `9999` 매직 넘버 DRY 위반 해소

## 변경 파일
| 파일 | 변경 내용 |
|------|---------|
| `ProductConstants.kt` | 신규: `DISPLAY_ORDER_MAX = 9999` |
| `ProductResponse.kt` | `id` 필드 제거 |
| `ProductQueryServiceImpl.kt` | `getProductByUuid` → `buildResponses` 재사용 |
| `CheckoutItemRequest.kt` | `productId: Long` → `productUuid: String` |
| `CheckoutServiceImpl.kt` | UUID 기반 상품 조회로 전환 |
| `ProductRepository.kt` | `findAllByProductUuidInWithLock` 추가 |
| `ProductRegisterRequest.kt` | `@Max` 값 상수 참조 |
| `ProductUpdateRequest.kt` | `@Max` 값 상수 참조 |

## Test plan
- [ ] 상품 목록/단건 조회 응답에 `id` 필드 없음 확인
- [ ] 단건 조회 `salesCount` 정상 반환 확인
- [ ] 결제 API 정상 동작 확인 (productUuid 기반)
- [ ] `displayOrder` 0/9999 경계값 검증 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)