### PR TITLE
fix: 코드 리뷰 p2 이슈 수정 (PK 노출/salesCount 누락/매직 넘버)

### DIFF
--- a/deal-api-owner/src/main/kotlin/com/chaltteok/owner/product/dto/ProductRegisterRequest.kt
+++ b/deal-api-owner/src/main/kotlin/com/chaltteok/owner/product/dto/ProductRegisterRequest.kt
@@ -1,6 +1,7 @@
 package com.chaltteok.owner.product.dto
 
 import com.chaltteok.core.domain.Product
+import com.chaltteok.core.domain.ProductConstants
 import com.chaltteok.core.domain.ProductOption
 import com.chaltteok.owner.product.enums.StockType
 import jakarta.validation.constraints.Max
@@ -22,7 +23,7 @@ class ProductRegisterRequest(
     @field:Min(value = 0, message = "stock quantity must be 0 or more")
     val stockQuantity: Int? = null,
     @field:Min(value = 0, message = "display order must be 0 or more")
-    @field:Max(value = 9999, message = "display order must be 9999 or less")
+    @field:Max(value = ProductConstants.DISPLAY_ORDER_MAX, message = "display order must be ${ProductConstants.DISPLAY_ORDER_MAX} or less")
     val displayOrder: Int = 0,
 ) {
     fun toProduct(imageUrl: String?): Product {

--- a/deal-api-owner/src/main/kotlin/com/chaltteok/owner/product/dto/ProductUpdateRequest.kt
+++ b/deal-api-owner/src/main/kotlin/com/chaltteok/owner/product/dto/ProductUpdateRequest.kt
@@ -1,5 +1,6 @@
 package com.chaltteok.owner.product.dto
 
+import com.chaltteok.core.domain.ProductConstants
 import jakarta.validation.constraints.Max
 import jakarta.validation.constraints.Min
 import jakarta.validation.constraints.NotNull
@@ -21,6 +22,6 @@ class ProductUpdateRequest(
     @field:Min(value = 0, message = "current stock must be 0 or more")
     val currentStock: Int? = null,
     @field:Min(value = 0, message = "display order must be 0 or more")
-    @field:Max(value = 9999, message = "display order must be 9999 or less")
+    @field:Max(value = ProductConstants.DISPLAY_ORDER_MAX, message = "display order must be ${ProductConstants.DISPLAY_ORDER_MAX} or less")
     val displayOrder: Int? = null,
 )

--- a/deal-api-user/src/main/kotlin/com/chaltteok/user/checkout/dto/CheckoutItemRequest.kt
+++ b/deal-api-user/src/main/kotlin/com/chaltteok/user/checkout/dto/CheckoutItemRequest.kt
@@ -4,7 +4,7 @@ import jakarta.validation.constraints.Min
 import jakarta.validation.constraints.NotNull
 
 data class CheckoutItemRequest(
-    @field:NotNull val productId: Long,
+    @field:NotNull val productUuid: String,
     @field:Min(1) val quantity: Int,
     @field:NotNull val price: Long,
 )

--- a/deal-api-user/src/main/kotlin/com/chaltteok/user/checkout/service/CheckoutServiceImpl.kt
+++ b/deal-api-user/src/main/kotlin/com/chaltteok/user/checkout/service/CheckoutServiceImpl.kt
@@ -36,12 +36,12 @@ class CheckoutServiceImpl(
         val order = Order(user = user, totalPrice = request.totalAmount.toInt(), status = OrderStatus.PENDING)
         val savedOrder = orderRepository.save(order)
 
-        val productIds = request.items.map { it.productId }
-        val productMap = productRepository.findAllByIdInWithLock(productIds)
-            .associateBy { it.id!! }
+        val productUuids = request.items.map { it.productUuid }
+        val productMap = productRepository.findAllByProductUuidInWithLock(productUuids)
+            .associateBy { it.productUuid }
 
         val orderItems = request.items.map { item ->
-            val product = productMap[item.productId]
+            val product = productMap[item.productUuid]
                 ?: throw BusinessException(CheckoutErrorCode.PRODUCT_NOT_FOUND)
             if (product.currentStock != null) {
                 if (product.currentStock!! < item.quantity) {

--- a/deal-api-user/src/main/kotlin/com/chaltteok/user/product/dto/ProductResponse.kt
+++ b/deal-api-user/src/main/kotlin/com/chaltteok/user/product/dto/ProductResponse.kt
@@ -3,7 +3,6 @@ package com.chaltteok.user.product.dto
 import com.chaltteok.core.domain.Product
 
 data class ProductResponse(
-    val id: Long,
     val productUuid: String,
     val name: String,
     val price: Long,
@@ -17,7 +16,6 @@ data class ProductResponse(
 ) {
     companion object {
         fun from(product: Product, commentCount: Int = 0, averageRating: Double? = null, salesCount: Long = 0) = ProductResponse(
-            id = product.id!!,
             productUuid = product.productUuid,
             name = product.name,
             price = product.price.toLong(),

--- a/deal-api-user/src/main/kotlin/com/chaltteok/user/product/service/ProductQueryServiceImpl.kt
+++ b/deal-api-user/src/main/kotlin/com/chaltteok/user/product/service/ProductQueryServiceImpl.kt
@@ -28,12 +28,7 @@ class ProductQueryServiceImpl(
     override fun getProductByUuid(productUuid: String): ProductResponse {
         val product = productRepository.findByProductUuid(productUuid)
             ?: throw ResponseStatusException(HttpStatus.NOT_FOUND, "Product not found: $productUuid")
-        val id = product.id!!
-        val commentCount = commentRepository.countRootCommentsByProductIds(listOf(id))
-            .firstOrNull()?.cnt?.toInt() ?: 0
-        val averageRating = commentRepository.avgRatingByProductIds(listOf(id))
-            .firstOrNull()?.avg
-        return ProductResponse.from(product, commentCount, averageRating)
+        return buildResponses(listOf(product)).first()
     }
 
     @Transactional(readOnly = true)

--- a/deal-core/src/main/kotlin/com/chaltteok/core/domain/ProductConstants.kt
+++ b/deal-core/src/main/kotlin/com/chaltteok/core/domain/ProductConstants.kt
@@ -1,0 +1,5 @@
+package com.chaltteok.core.domain
+
+object ProductConstants {
+    const val DISPLAY_ORDER_MAX = 9999L
+}

--- a/deal-core/src/main/kotlin/com/chaltteok/core/repository/product/ProductRepository.kt
+++ b/deal-core/src/main/kotlin/com/chaltteok/core/repository/product/ProductRepository.kt
@@ -18,6 +18,10 @@ interface ProductRepository : JpaRepository<Product, Long>, ProductRepositoryCus
     @Query("SELECT p FROM Product p WHERE p.id IN :ids")
     fun findAllByIdInWithLock(@Param("ids") ids: Collection<Long>): List<Product>
 
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT p FROM Product p WHERE p.productUuid IN :uuids")
+    fun findAllByProductUuidInWithLock(@Param("uuids") uuids: Collection<String>): List<Product>
+
     @Modifying
     @Query("UPDATE Product p SET p.currentStock = p.stockQuantity, p.isSoldOut = false WHERE p.stockQuantity IS NOT NULL AND p.stockQuantity > 0")
     fun resetDailyStockForActiveProducts(): Int


### PR DESCRIPTION
## Summary
- `ProductResponse`에서 내부 PK(`id`) 제거 → `productUuid`만 외부 식별자로 사용 (IDOR 방어)
- `CheckoutItemRequest` `productId → productUuid` 변경, 결제 서비스를 UUID 기반 조회로 전환
- `getProductByUuid`가 `buildResponses`를 재사용하도록 수정 (단건 조회 `salesCount=0` 고정 버그 수정)
- `ProductConstants.DISPLAY_ORDER_MAX` 상수 도입으로 `9999` 매직 넘버 DRY 위반 해소

## 변경 파일
| 파일 | 변경 내용 |
|------|---------|
| `ProductConstants.kt` | 신규: `DISPLAY_ORDER_MAX = 9999` |
| `ProductResponse.kt` | `id` 필드 제거 |
| `ProductQueryServiceImpl.kt` | `getProductByUuid` → `buildResponses` 재사용 |
| `CheckoutItemRequest.kt` | `productId: Long` → `productUuid: String` |
| `CheckoutServiceImpl.kt` | UUID 기반 상품 조회로 전환 |
| `ProductRepository.kt` | `findAllByProductUuidInWithLock` 추가 |
| `ProductRegisterRequest.kt` | `@Max` 값 상수 참조 |
| `ProductUpdateRequest.kt` | `@Max` 값 상수 참조 |

## Test plan
- [ ] 상품 목록/단건 조회 응답에 `id` 필드 없음 확인
- [ ] 단건 조회 `salesCount` 정상 반환 확인
- [ ] 결제 API 정상 동작 확인 (productUuid 기반)

🤖 Generated with [Claude Code](https://claude.com/claude-code)