### PR TITLE
fix: 코드 리뷰 p3/Low 이슈 수정

### DIFF
--- a/db/migration/add_product_display_order_id_index.sql
+++ b/db/migration/add_product_display_order_id_index.sql
@@ -1,0 +1,2 @@
+CREATE INDEX IF NOT EXISTS idx_products_display_order_id
+    ON tb_products (display_order, id);

--- a/deal-api-owner/src/main/kotlin/com/chaltteok/owner/product/service/ProductServiceImpl.kt
+++ b/deal-api-owner/src/main/kotlin/com/chaltteok/owner/product/service/ProductServiceImpl.kt
@@ -49,9 +49,8 @@ class ProductServiceImpl(
         product.price = request.price
         product.isActive = request.isActive
         product.isRecommended = request.isRecommended
-        if (newImageUrl != null) product.imageUrl = newImageUrl
-
-        if (request.displayOrder != null) product.displayOrder = request.displayOrder
+        newImageUrl?.let { product.imageUrl = it }
+        request.displayOrder?.let { product.displayOrder = it }
 
         val effectiveStockQuantity = request.stockQuantity ?: product.stockQuantity
         if (request.currentStock != null && effectiveStockQuantity != null

--- a/deal-api-user/src/main/kotlin/com/chaltteok/user/product/service/ProductQueryServiceImpl.kt
+++ b/deal-api-user/src/main/kotlin/com/chaltteok/user/product/service/ProductQueryServiceImpl.kt
@@ -20,7 +20,7 @@ class ProductQueryServiceImpl(
 
     @Transactional(readOnly = true)
     override fun getProducts(): List<ProductResponse> {
-        val products = productRepository.findAllByIsActiveTrueOrderByDisplayOrderAscNameAsc()
+        val products = productRepository.findAllActiveByDisplayOrder()
         return buildResponses(products)
     }
 
@@ -52,8 +52,9 @@ class ProductQueryServiceImpl(
             .associate { it.productId to it.avg }
         val salesMap = orderItemRepository.sumQuantityByProductIds(ids, OrderStatus.COMPLETED)
             .associate { it.productId to it.totalQty }
-        return products.map {
-            ProductResponse.from(it, countMap[it.id!!] ?: 0, ratingMap[it.id!!], salesMap[it.id!!] ?: 0L)
+        return products.mapNotNull { product ->
+            val id = product.id ?: return@mapNotNull null
+            ProductResponse.from(product, countMap[id] ?: 0, ratingMap[id], salesMap[id] ?: 0L)
         }
     }
 }

--- a/deal-core/src/main/kotlin/com/chaltteok/core/repository/orderitem/OrderItemRepository.kt
+++ b/deal-core/src/main/kotlin/com/chaltteok/core/repository/orderitem/OrderItemRepository.kt
@@ -1,29 +1,11 @@
 package com.chaltteok.core.repository.orderitem
 
 import com.chaltteok.core.domain.OrderItem
-import com.chaltteok.core.domain.enums.OrderStatus
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
 import org.springframework.data.repository.query.Param
 
-interface SalesCountProjection {
-    val productId: Long
-    val totalQty: Long
-}
-
 interface OrderItemRepository : JpaRepository<OrderItem, Long>, OrderItemRepositoryCustom {
     @Query("SELECT oi FROM OrderItem oi JOIN FETCH oi.product WHERE oi.order.id IN :orderIds")
-    fun findByOrderIdsWithProduct(orderIds: List<Long>): List<OrderItem>
-
-    @Query("""
-        SELECT oi.product.id AS productId, SUM(oi.quantity) AS totalQty
-        FROM OrderItem oi
-        WHERE oi.product.id IN :productIds
-        AND oi.order.status = :status
-        GROUP BY oi.product.id
-    """)
-    fun sumQuantityByProductIds(
-        @Param("productIds") productIds: List<Long>,
-        @Param("status") status: OrderStatus,
-    ): List<SalesCountProjection>
+    fun findByOrderIdsWithProduct(@Param("orderIds") orderIds: List<Long>): List<OrderItem>
 }

--- a/deal-core/src/main/kotlin/com/chaltteok/core/repository/orderitem/OrderItemRepositoryCustom.kt
+++ b/deal-core/src/main/kotlin/com/chaltteok/core/repository/orderitem/OrderItemRepositoryCustom.kt
@@ -1,8 +1,10 @@
 package com.chaltteok.core.repository.orderitem
 
+import com.chaltteok.core.domain.enums.OrderStatus
 import com.chaltteok.core.repository.orderitem.dto.TopProductAgg
 import java.time.LocalDateTime
 
 interface OrderItemRepositoryCustom {
     fun findTopProducts(from: LocalDateTime, to: LocalDateTime, limit: Int): List<TopProductAgg>
+    fun sumQuantityByProductIds(productIds: List<Long>, status: OrderStatus): List<SalesCountProjection>
 }

--- a/deal-core/src/main/kotlin/com/chaltteok/core/repository/orderitem/OrderItemRepositoryImpl.kt
+++ b/deal-core/src/main/kotlin/com/chaltteok/core/repository/orderitem/OrderItemRepositoryImpl.kt
@@ -16,6 +16,28 @@ class OrderItemRepositoryImpl(private val jpaQueryFactory: JPAQueryFactory) : Or
     private val qOrder = QOrder.order
     private val qProduct = QProduct.product
 
+    override fun sumQuantityByProductIds(productIds: List<Long>, status: OrderStatus): List<SalesCountProjection> {
+        if (productIds.isEmpty()) return emptyList()
+        return jpaQueryFactory
+            .select(qProduct.id, qOrderItem.quantity.longValue().sum())
+            .from(qOrderItem)
+            .join(qOrderItem.order, qOrder)
+            .join(qOrderItem.product, qProduct)
+            .where(
+                qProduct.id.`in`(productIds),
+                qOrder.status.eq(status),
+            )
+            .groupBy(qProduct.id)
+            .fetch()
+            .mapNotNull { tuple ->
+                val pid = tuple.get(qProduct.id) ?: return@mapNotNull null
+                object : SalesCountProjection {
+                    override val productId: Long = pid
+                    override val totalQty: Long = tuple.get(qOrderItem.quantity.longValue().sum()) ?: 0L
+                }
+            }
+    }
+
     override fun findTopProducts(from: LocalDateTime, to: LocalDateTime, limit: Int): List<TopProductAgg> {
         val uuidExpr = qProduct.productUuid
         val nameExpr = qProduct.name

--- a/deal-core/src/main/kotlin/com/chaltteok/core/repository/orderitem/SalesCountProjection.kt
+++ b/deal-core/src/main/kotlin/com/chaltteok/core/repository/orderitem/SalesCountProjection.kt
@@ -1,0 +1,6 @@
+package com.chaltteok.core.repository.orderitem
+
+interface SalesCountProjection {
+    val productId: Long
+    val totalQty: Long
+}

--- a/deal-core/src/main/kotlin/com/chaltteok/core/repository/product/ProductRepository.kt
+++ b/deal-core/src/main/kotlin/com/chaltteok/core/repository/product/ProductRepository.kt
@@ -10,7 +10,10 @@ import org.springframework.data.repository.query.Param
 
 interface ProductRepository : JpaRepository<Product, Long>, ProductRepositoryCustom {
     fun findAllByIsActiveTrue(): List<Product>
-    fun findAllByIsActiveTrueOrderByDisplayOrderAscNameAsc(): List<Product>
+
+    @Query("SELECT p FROM Product p WHERE p.isActive = true ORDER BY p.displayOrder ASC, p.name ASC")
+    fun findAllActiveByDisplayOrder(): List<Product>
+
     fun findAllByIsActiveTrueAndIsRecommendedTrue(): List<Product>
     fun findByProductUuid(productUuid: String): Product?
 


### PR DESCRIPTION
## Summary
- `SalesCountProjection` 별도 파일로 분리 (아키텍처-p3)
- `sumQuantityByProductIds`를 `OrderItemRepositoryCustom`으로 이전 — QueryDSL 명시적 JOIN + 빈 리스트 early return (보안-p3, 성능-p3)
- `ProductRepository` 메서드명 `@Query`로 추상화 (아키텍처-p3 OCP)
- `buildResponses`에서 `id!!` 반복 제거 → `mapNotNull` 패턴 적용 (유지보수-Low)
- nullable 할당 `if → ?.let` 스타일 통일 (유지보수-Low)
- `tb_products (display_order, id)` 인덱스 추가 마이그레이션 (성능-p3)

## 변경 파일
| 파일 | 변경 내용 |
|------|---------|
| `SalesCountProjection.kt` | 신규 분리 |
| `OrderItemRepository.kt` | 인라인 Projection 제거, @Query 제거 |
| `OrderItemRepositoryCustom.kt` | `sumQuantityByProductIds` 시그니처 추가 |
| `OrderItemRepositoryImpl.kt` | QueryDSL 구현 (명시적 JOIN, 빈 리스트 가드) |
| `ProductRepository.kt` | `findAllActiveByDisplayOrder()` + `@Query` |
| `ProductQueryServiceImpl.kt` | 메서드명 갱신, `id!!` → `mapNotNull` |
| `ProductServiceImpl.kt` | `?.let` 스타일 통일 |
| `add_product_display_order_id_index.sql` | 신규 인덱스 마이그레이션 |

## Test plan
- [ ] 상품 목록 정렬 정상 동작
- [ ] 판매량 집계 정상 동작
- [ ] 빈 상품 목록에서 집계 쿼리 미실행 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)