### PR TITLE
feat: 상품 조회 Redis 캐싱 적용 (성능-p2)

### DIFF
--- a/db/migration/add_orders_status_index.sql
+++ b/db/migration/add_orders_status_index.sql
@@ -1,0 +1,2 @@
+CREATE INDEX IF NOT EXISTS idx_orders_status
+    ON tb_orders (status);

--- a/deal-api-owner/src/main/kotlin/com/chaltteok/owner/config/CacheConfig.kt
+++ b/deal-api-owner/src/main/kotlin/com/chaltteok/owner/config/CacheConfig.kt
@@ -1,0 +1,44 @@
+package com.chaltteok.owner.config
+
+import com.fasterxml.jackson.annotation.JsonTypeInfo
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.jsontype.BasicPolymorphicTypeValidator
+import org.springframework.cache.CacheManager
+import org.springframework.cache.annotation.EnableCaching
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.data.redis.cache.RedisCacheConfiguration
+import org.springframework.data.redis.cache.RedisCacheManager
+import org.springframework.data.redis.connection.RedisConnectionFactory
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer
+import org.springframework.data.redis.serializer.RedisSerializationContext
+import java.time.Duration
+
+@Configuration
+@EnableCaching
+class CacheConfig {
+
+    @Bean
+    fun cacheManager(connectionFactory: RedisConnectionFactory, objectMapper: ObjectMapper): CacheManager {
+        val cacheMapper = objectMapper.copy().activateDefaultTyping(
+            BasicPolymorphicTypeValidator.builder()
+                .allowIfBaseType(Any::class.java)
+                .build(),
+            ObjectMapper.DefaultTyping.NON_FINAL,
+            JsonTypeInfo.As.PROPERTY,
+        )
+        val serializer = GenericJackson2JsonRedisSerializer(cacheMapper)
+        val valuePair = RedisSerializationContext.SerializationPair.fromSerializer(serializer)
+
+        val base = RedisCacheConfiguration.defaultCacheConfig()
+            .serializeValuesWith(valuePair)
+            .disableCachingNullValues()
+
+        return RedisCacheManager.builder(connectionFactory)
+            .cacheDefaults(base.entryTtl(Duration.ofSeconds(120)))
+            .withCacheConfiguration("product", base.entryTtl(Duration.ofSeconds(300)))
+            .withCacheConfiguration("productList", base.entryTtl(Duration.ofSeconds(120)))
+            .withCacheConfiguration("productRecommended", base.entryTtl(Duration.ofSeconds(120)))
+            .build()
+    }
+}

--- a/deal-api-owner/src/main/kotlin/com/chaltteok/owner/product/service/ProductServiceImpl.kt
+++ b/deal-api-owner/src/main/kotlin/com/chaltteok/owner/product/service/ProductServiceImpl.kt
@@ -1,6 +1,7 @@
 package com.chaltteok.owner.product.service
 
 import com.chaltteok.common.exception.BusinessException
+import com.chaltteok.core.cache.CacheNames
 import com.chaltteok.core.repository.product.ProductRepository
 import com.chaltteok.core.repository.productoption.ProductOptionRepository
 import com.chaltteok.owner.product.dto.ProductListResponse
@@ -9,6 +10,8 @@ import com.chaltteok.owner.product.dto.ProductUpdateRequest
 import com.chaltteok.owner.product.enums.ProductErrorCode
 import com.chaltteok.owner.product.util.LocalFileUploader
 import io.github.oshai.kotlinlogging.KotlinLogging
+import org.springframework.cache.annotation.CacheEvict
+import org.springframework.cache.annotation.Caching
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import org.springframework.web.multipart.MultipartFile
@@ -26,6 +29,10 @@ class ProductServiceImpl(
     override fun getProducts(): List<ProductListResponse> =
         productRepository.findAllWithOption().map { ProductListResponse.from(it) }
 
+    @Caching(evict = [
+        CacheEvict(value = [CacheNames.PRODUCT_LIST], allEntries = true),
+        CacheEvict(value = [CacheNames.PRODUCT_RECOMMENDED], allEntries = true),
+    ])
     @Transactional
     override fun registerProduct(request: ProductRegisterRequest, image: MultipartFile?) {
         val imageUrl = image?.takeIf { !it.isEmpty }?.let { fileUploader.uploadFile(it) }
@@ -35,6 +42,11 @@ class ProductServiceImpl(
         logger.info { "product registered: ${request.name}" }
     }
 
+    @Caching(evict = [
+        CacheEvict(value = [CacheNames.PRODUCT_LIST], allEntries = true),
+        CacheEvict(value = [CacheNames.PRODUCT_RECOMMENDED], allEntries = true),
+        CacheEvict(value = [CacheNames.PRODUCT], key = "#productUuid"),
+    ])
     @Transactional
     override fun updateProduct(productUuid: String, request: ProductUpdateRequest, image: MultipartFile?) {
         val product = productRepository.findByProductUuid(productUuid)
@@ -79,6 +91,11 @@ class ProductServiceImpl(
         else -> request.isSoldOut || request.stockQuantity == 0
     }
 
+    @Caching(evict = [
+        CacheEvict(value = [CacheNames.PRODUCT_LIST], allEntries = true),
+        CacheEvict(value = [CacheNames.PRODUCT_RECOMMENDED], allEntries = true),
+        CacheEvict(value = [CacheNames.PRODUCT], key = "#productUuid"),
+    ])
     @Transactional
     override fun deleteProduct(productUuid: String) {
         val product = productRepository.findByProductUuid(productUuid)
@@ -91,6 +108,11 @@ class ProductServiceImpl(
         logger.info { "product deleted: $productUuid" }
     }
 
+    @Caching(evict = [
+        CacheEvict(value = [CacheNames.PRODUCT_LIST], allEntries = true),
+        CacheEvict(value = [CacheNames.PRODUCT_RECOMMENDED], allEntries = true),
+        CacheEvict(value = [CacheNames.PRODUCT], key = "#productUuid"),
+    ])
     @Transactional
     override fun toggleActive(productUuid: String) {
         val product = productRepository.findByProductUuid(productUuid)
@@ -98,6 +120,10 @@ class ProductServiceImpl(
         product.isActive = !product.isActive
     }
 
+    @Caching(evict = [
+        CacheEvict(value = [CacheNames.PRODUCT_LIST], allEntries = true),
+        CacheEvict(value = [CacheNames.PRODUCT], key = "#productUuid"),
+    ])
     @Transactional
     override fun toggleSoldOut(productUuid: String) {
         val product = productRepository.findByProductUuid(productUuid)
@@ -105,6 +131,11 @@ class ProductServiceImpl(
         product.isSoldOut = !product.isSoldOut
     }
 
+    @Caching(evict = [
+        CacheEvict(value = [CacheNames.PRODUCT_LIST], allEntries = true),
+        CacheEvict(value = [CacheNames.PRODUCT_RECOMMENDED], allEntries = true),
+        CacheEvict(value = [CacheNames.PRODUCT], key = "#productUuid"),
+    ])
     @Transactional
     override fun toggleRecommend(productUuid: String) {
         val product = productRepository.findByProductUuid(productUuid)

--- a/deal-api-user/src/main/kotlin/com/chaltteok/user/config/CacheConfig.kt
+++ b/deal-api-user/src/main/kotlin/com/chaltteok/user/config/CacheConfig.kt
@@ -1,0 +1,44 @@
+package com.chaltteok.user.config
+
+import com.fasterxml.jackson.annotation.JsonTypeInfo
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.jsontype.BasicPolymorphicTypeValidator
+import org.springframework.cache.CacheManager
+import org.springframework.cache.annotation.EnableCaching
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.data.redis.cache.RedisCacheConfiguration
+import org.springframework.data.redis.cache.RedisCacheManager
+import org.springframework.data.redis.connection.RedisConnectionFactory
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer
+import org.springframework.data.redis.serializer.RedisSerializationContext
+import java.time.Duration
+
+@Configuration
+@EnableCaching
+class CacheConfig {
+
+    @Bean
+    fun cacheManager(connectionFactory: RedisConnectionFactory, objectMapper: ObjectMapper): CacheManager {
+        val cacheMapper = objectMapper.copy().activateDefaultTyping(
+            BasicPolymorphicTypeValidator.builder()
+                .allowIfBaseType(Any::class.java)
+                .build(),
+            ObjectMapper.DefaultTyping.NON_FINAL,
+            JsonTypeInfo.As.PROPERTY,
+        )
+        val serializer = GenericJackson2JsonRedisSerializer(cacheMapper)
+        val valuePair = RedisSerializationContext.SerializationPair.fromSerializer(serializer)
+
+        val base = RedisCacheConfiguration.defaultCacheConfig()
+            .serializeValuesWith(valuePair)
+            .disableCachingNullValues()
+
+        return RedisCacheManager.builder(connectionFactory)
+            .cacheDefaults(base.entryTtl(Duration.ofSeconds(120)))
+            .withCacheConfiguration("product", base.entryTtl(Duration.ofSeconds(300)))
+            .withCacheConfiguration("productList", base.entryTtl(Duration.ofSeconds(120)))
+            .withCacheConfiguration("productRecommended", base.entryTtl(Duration.ofSeconds(120)))
+            .build()
+    }
+}

--- a/deal-api-user/src/main/kotlin/com/chaltteok/user/product/service/ProductQueryServiceImpl.kt
+++ b/deal-api-user/src/main/kotlin/com/chaltteok/user/product/service/ProductQueryServiceImpl.kt
@@ -1,11 +1,13 @@
 package com.chaltteok.user.product.service
 
+import com.chaltteok.core.cache.CacheNames
 import com.chaltteok.core.domain.enums.OrderStatus
 import com.chaltteok.core.repository.comment.CommentRepository
 import com.chaltteok.core.repository.orderitem.OrderItemRepository
 import com.chaltteok.core.repository.product.ProductRepository
 import com.chaltteok.core.domain.Product
 import com.chaltteok.user.product.dto.ProductResponse
+import org.springframework.cache.annotation.Cacheable
 import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -18,12 +20,14 @@ class ProductQueryServiceImpl(
     private val orderItemRepository: OrderItemRepository,
 ) : ProductQueryService {
 
+    @Cacheable(CacheNames.PRODUCT_LIST)
     @Transactional(readOnly = true)
     override fun getProducts(): List<ProductResponse> {
         val products = productRepository.findAllActiveByDisplayOrder()
         return buildResponses(products)
     }
 
+    @Cacheable(value = [CacheNames.PRODUCT], key = "#productUuid")
     @Transactional(readOnly = true)
     override fun getProductByUuid(productUuid: String): ProductResponse {
         val product = productRepository.findByProductUuid(productUuid)
@@ -31,6 +35,7 @@ class ProductQueryServiceImpl(
         return buildResponses(listOf(product)).first()
     }
 
+    @Cacheable(CacheNames.PRODUCT_RECOMMENDED)
     @Transactional(readOnly = true)
     override fun getRecommendedProducts(): List<ProductResponse> {
         val products = productRepository.findAllByIsActiveTrueAndIsRecommendedTrue()

--- a/deal-core/src/main/kotlin/com/chaltteok/core/cache/CacheNames.kt
+++ b/deal-core/src/main/kotlin/com/chaltteok/core/cache/CacheNames.kt
@@ -1,0 +1,7 @@
+package com.chaltteok.core.cache
+
+object CacheNames {
+    const val PRODUCT = "product"
+    const val PRODUCT_LIST = "productList"
+    const val PRODUCT_RECOMMENDED = "productRecommended"
+}


### PR DESCRIPTION
## Summary
매 요청마다 DB 3회 집계 쿼리(`countMap` + `ratingMap` + `salesMap`)가 실행되는 성능-p2 이슈를 Redis 캐싱으로 해결합니다.

## 변경 내용

| 파일 | 변경 내용 |
|------|---------|
| `CacheNames.kt` (신규) | 캐시 이름 상수 (`product`, `productList`, `productRecommended`) |
| `user/config/CacheConfig.kt` (신규) | `@EnableCaching` + `RedisCacheManager` — TTL 구성 |
| `owner/config/CacheConfig.kt` (신규) | 동일 TTL 구성 (eviction 공유) |
| `ProductQueryServiceImpl.kt` | `getProducts` · `getProductByUuid` · `getRecommendedProducts` → `@Cacheable` |
| `ProductServiceImpl.kt` | 등록·수정·삭제·토글 → `@CacheEvict` (캐시 무효화) |
| `add_orders_status_index.sql` | `tb_orders(status)` 인덱스 추가 |

## 캐시 전략

```
productList      → TTL 120s  (목록 변경 시 evict)
product::{uuid}  → TTL 300s  (해당 상품 변경 시 evict)
productRecommended → TTL 120s (추천 상태 변경 시 evict)
```

캐시 직렬화: Spring Boot 자동 구성 `ObjectMapper`(Kotlin 지원) + `GenericJackson2JsonRedisSerializer`

## Test plan
- [ ] 상품 목록 첫 요청 DB 조회, 이후 Redis 히트 확인
- [ ] 점주가 상품 수정 후 유저 목록 캐시 무효화 확인
- [ ] TTL 만료 후 DB 재조회 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)