### PR TITLE
[FEAT] 주문 완료 시 점주 알림 생성 및 조회 API

### DIFF
--- a/db/migration/add_notification_table.sql
+++ b/db/migration/add_notification_table.sql
@@ -1,0 +1,11 @@
+CREATE TABLE IF NOT EXISTS tb_notifications (
+    notification_id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    notification_uuid VARCHAR(36) NOT NULL UNIQUE,
+    type VARCHAR(30) NOT NULL,
+    title VARCHAR(100) NOT NULL,
+    message VARCHAR(500) NOT NULL,
+    is_read BOOLEAN NOT NULL DEFAULT FALSE,
+    created_at DATETIME(6) NOT NULL,
+    updated_at DATETIME(6) NOT NULL,
+    INDEX idx_notifications_read_created (is_read, created_at)
+);

--- a/deal-api-owner/src/main/kotlin/com/chaltteok/owner/notification/controller/NotificationController.kt
+++ b/deal-api-owner/src/main/kotlin/com/chaltteok/owner/notification/controller/NotificationController.kt
@@ -1,0 +1,24 @@
+package com.chaltteok.owner.notification.controller
+
+import com.chaltteok.common.dto.ResponseDTO
+import com.chaltteok.owner.notification.dto.NotificationListResponse
+import com.chaltteok.owner.notification.service.NotificationService
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PatchMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/v1/owner/notifications")
+class NotificationController(private val notificationService: NotificationService) {
+
+    @GetMapping
+    fun getNotifications(): ResponseDTO<NotificationListResponse> =
+        ResponseDTO.success(notificationService.getNotifications())
+
+    @PatchMapping("/read")
+    fun markAllRead(): ResponseDTO<Unit> {
+        notificationService.markAllRead()
+        return ResponseDTO.success(Unit)
+    }
+}

--- a/deal-api-owner/src/main/kotlin/com/chaltteok/owner/notification/dto/NotificationListResponse.kt
+++ b/deal-api-owner/src/main/kotlin/com/chaltteok/owner/notification/dto/NotificationListResponse.kt
@@ -1,0 +1,6 @@
+package com.chaltteok.owner.notification.dto
+
+class NotificationListResponse(
+    val notifications: List<NotificationResponse>,
+    val unreadCount: Long,
+)

--- a/deal-api-owner/src/main/kotlin/com/chaltteok/owner/notification/dto/NotificationResponse.kt
+++ b/deal-api-owner/src/main/kotlin/com/chaltteok/owner/notification/dto/NotificationResponse.kt
@@ -5,7 +5,6 @@ import com.fasterxml.jackson.annotation.JsonProperty
 import java.time.LocalDateTime
 
 class NotificationResponse(
-    val id: Long,
     val notificationUuid: String,
     val type: String,
     val title: String,
@@ -15,7 +14,6 @@ class NotificationResponse(
 ) {
     companion object {
         fun from(notification: Notification) = NotificationResponse(
-            id = notification.id!!,
             notificationUuid = notification.notificationUuid,
             type = notification.type,
             title = notification.title,

--- a/deal-api-owner/src/main/kotlin/com/chaltteok/owner/notification/dto/NotificationResponse.kt
+++ b/deal-api-owner/src/main/kotlin/com/chaltteok/owner/notification/dto/NotificationResponse.kt
@@ -1,0 +1,27 @@
+package com.chaltteok.owner.notification.dto
+
+import com.chaltteok.core.domain.Notification
+import com.fasterxml.jackson.annotation.JsonProperty
+import java.time.LocalDateTime
+
+class NotificationResponse(
+    val id: Long,
+    val notificationUuid: String,
+    val type: String,
+    val title: String,
+    val message: String,
+    @get:JsonProperty("isRead") val isRead: Boolean,
+    val createdAt: LocalDateTime,
+) {
+    companion object {
+        fun from(notification: Notification) = NotificationResponse(
+            id = notification.id!!,
+            notificationUuid = notification.notificationUuid,
+            type = notification.type,
+            title = notification.title,
+            message = notification.message,
+            isRead = notification.isRead,
+            createdAt = notification.createdAt,
+        )
+    }
+}

--- a/deal-api-owner/src/main/kotlin/com/chaltteok/owner/notification/service/NotificationService.kt
+++ b/deal-api-owner/src/main/kotlin/com/chaltteok/owner/notification/service/NotificationService.kt
@@ -1,0 +1,8 @@
+package com.chaltteok.owner.notification.service
+
+import com.chaltteok.owner.notification.dto.NotificationListResponse
+
+interface NotificationService {
+    fun getNotifications(): NotificationListResponse
+    fun markAllRead()
+}

--- a/deal-api-owner/src/main/kotlin/com/chaltteok/owner/notification/service/NotificationServiceImpl.kt
+++ b/deal-api-owner/src/main/kotlin/com/chaltteok/owner/notification/service/NotificationServiceImpl.kt
@@ -1,0 +1,29 @@
+package com.chaltteok.owner.notification.service
+
+import com.chaltteok.core.repository.notification.NotificationRepository
+import com.chaltteok.owner.notification.dto.NotificationListResponse
+import com.chaltteok.owner.notification.dto.NotificationResponse
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class NotificationServiceImpl(
+    private val notificationRepository: NotificationRepository,
+) : NotificationService {
+
+    @Transactional(readOnly = true)
+    override fun getNotifications(): NotificationListResponse {
+        val notifications = notificationRepository.findAllByOrderByCreatedAtDesc()
+            .map { NotificationResponse.from(it) }
+        val unreadCount = notificationRepository.countByIsReadFalse()
+        return NotificationListResponse(
+            notifications = notifications,
+            unreadCount = unreadCount,
+        )
+    }
+
+    @Transactional
+    override fun markAllRead() {
+        notificationRepository.markAllAsRead()
+    }
+}

--- a/deal-api-owner/src/main/kotlin/com/chaltteok/owner/notification/service/NotificationServiceImpl.kt
+++ b/deal-api-owner/src/main/kotlin/com/chaltteok/owner/notification/service/NotificationServiceImpl.kt
@@ -13,7 +13,7 @@ class NotificationServiceImpl(
 
     @Transactional(readOnly = true)
     override fun getNotifications(): NotificationListResponse {
-        val notifications = notificationRepository.findAllByOrderByCreatedAtDesc()
+        val notifications = notificationRepository.findTop50ByOrderByCreatedAtDesc()
             .map { NotificationResponse.from(it) }
         val unreadCount = notificationRepository.countByIsReadFalse()
         return NotificationListResponse(

--- a/deal-api-user/src/main/kotlin/com/chaltteok/user/checkout/service/CheckoutServiceImpl.kt
+++ b/deal-api-user/src/main/kotlin/com/chaltteok/user/checkout/service/CheckoutServiceImpl.kt
@@ -3,6 +3,7 @@ package com.chaltteok.user.checkout.service
 import com.chaltteok.common.exception.BusinessException
 import com.chaltteok.core.domain.Notification
 import com.chaltteok.core.domain.Order
+import com.chaltteok.core.domain.enums.NotificationType
 import com.chaltteok.core.domain.OrderItem
 import com.chaltteok.core.domain.enums.OrderStatus
 import com.chaltteok.core.domain.Payment
@@ -63,11 +64,12 @@ class CheckoutServiceImpl(
         savedOrder.status = OrderStatus.COMPLETED
 
         val productNames = orderItems.joinToString(", ") { it.product.name }
+            .let { if (it.length > 450) it.take(450) + "…" else it }
         notificationRepository.save(
             Notification(
-                type = "ORDER",
+                type = NotificationType.ORDER.name,
                 title = "새 주문이 들어왔습니다",
-                message = "%s (%,d원)".format(productNames, request.totalAmount),
+                message = "$productNames (%,d원)".format(request.totalAmount),
             )
         )
 

--- a/deal-api-user/src/main/kotlin/com/chaltteok/user/checkout/service/CheckoutServiceImpl.kt
+++ b/deal-api-user/src/main/kotlin/com/chaltteok/user/checkout/service/CheckoutServiceImpl.kt
@@ -1,11 +1,13 @@
 package com.chaltteok.user.checkout.service
 
 import com.chaltteok.common.exception.BusinessException
+import com.chaltteok.core.domain.Notification
 import com.chaltteok.core.domain.Order
 import com.chaltteok.core.domain.OrderItem
 import com.chaltteok.core.domain.enums.OrderStatus
 import com.chaltteok.core.domain.Payment
 import com.chaltteok.core.domain.enums.PaymentStatus
+import com.chaltteok.core.repository.notification.NotificationRepository
 import com.chaltteok.core.repository.order.OrderRepository
 import com.chaltteok.core.repository.orderitem.OrderItemRepository
 import com.chaltteok.core.repository.payment.PaymentRepository
@@ -24,6 +26,7 @@ class CheckoutServiceImpl(
     private val orderRepository: OrderRepository,
     private val orderItemRepository: OrderItemRepository,
     private val paymentRepository: PaymentRepository,
+    private val notificationRepository: NotificationRepository,
 ) : CheckoutService {
 
     @Transactional
@@ -58,6 +61,15 @@ class CheckoutServiceImpl(
         paymentRepository.save(payment)
 
         savedOrder.status = OrderStatus.COMPLETED
+
+        val productNames = orderItems.joinToString(", ") { it.product.name }
+        notificationRepository.save(
+            Notification(
+                type = "ORDER",
+                title = "새 주문이 들어왔습니다",
+                message = "%s (%,d원)".format(productNames, request.totalAmount),
+            )
+        )
 
         return CheckoutResponse(
             orderId = savedOrder.id!!,

--- a/deal-core/src/main/kotlin/com/chaltteok/core/domain/Notification.kt
+++ b/deal-core/src/main/kotlin/com/chaltteok/core/domain/Notification.kt
@@ -1,0 +1,28 @@
+package com.chaltteok.core.domain
+
+import jakarta.persistence.*
+import java.util.UUID
+
+@Entity
+@Table(name = "tb_notifications", uniqueConstraints = [UniqueConstraint(name = "uk_notification_uuid", columnNames = ["notification_uuid"])])
+class Notification(
+    @Column(name = "type", nullable = false, length = 30)
+    val type: String,
+
+    @Column(name = "title", nullable = false, length = 100)
+    val title: String,
+
+    @Column(name = "message", nullable = false, length = 500)
+    val message: String,
+
+    @Column(name = "is_read", nullable = false)
+    var isRead: Boolean = false,
+) : BaseEntity() {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "notification_id")
+    var id: Long? = null
+
+    @Column(name = "notification_uuid", nullable = false, length = 36)
+    val notificationUuid: String = UUID.randomUUID().toString()
+}

--- a/deal-core/src/main/kotlin/com/chaltteok/core/domain/enums/NotificationType.kt
+++ b/deal-core/src/main/kotlin/com/chaltteok/core/domain/enums/NotificationType.kt
@@ -1,0 +1,5 @@
+package com.chaltteok.core.domain.enums
+
+enum class NotificationType {
+    ORDER
+}

--- a/deal-core/src/main/kotlin/com/chaltteok/core/repository/notification/NotificationRepository.kt
+++ b/deal-core/src/main/kotlin/com/chaltteok/core/repository/notification/NotificationRepository.kt
@@ -1,0 +1,15 @@
+package com.chaltteok.core.repository.notification
+
+import com.chaltteok.core.domain.Notification
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Modifying
+import org.springframework.data.jpa.repository.Query
+
+interface NotificationRepository : JpaRepository<Notification, Long> {
+    fun findAllByOrderByCreatedAtDesc(): List<Notification>
+    fun countByIsReadFalse(): Long
+
+    @Modifying
+    @Query("UPDATE Notification n SET n.isRead = true WHERE n.isRead = false")
+    fun markAllAsRead(): Int
+}

--- a/deal-core/src/main/kotlin/com/chaltteok/core/repository/notification/NotificationRepository.kt
+++ b/deal-core/src/main/kotlin/com/chaltteok/core/repository/notification/NotificationRepository.kt
@@ -6,7 +6,7 @@ import org.springframework.data.jpa.repository.Modifying
 import org.springframework.data.jpa.repository.Query
 
 interface NotificationRepository : JpaRepository<Notification, Long> {
-    fun findAllByOrderByCreatedAtDesc(): List<Notification>
+    fun findTop50ByOrderByCreatedAtDesc(): List<Notification>
     fun countByIsReadFalse(): Long
 
     @Modifying


### PR DESCRIPTION
## Summary
유저가 상품을 주문(결제 완료)하면 점주에게 알림을 자동 생성하고, 점주가 알림 목록 조회 및 일괄 읽음 처리를 할 수 있는 API를 추가합니다.

## Changes
| 파일 | 변경 내용 |
|------|---------|
| `Notification.kt` (신규) | 알림 엔티티 (type/title/message/isRead/UUID) |
| `NotificationRepository.kt` (신규) | 전체 조회, 읽지 않은 수, 일괄 읽음 처리 |
| `CheckoutServiceImpl.kt` (수정) | 결제 완료 후 알림 자동 생성 |
| `NotificationController.kt` (신규) | GET/PATCH /api/v1/owner/notifications |
| `add_notification_table.sql` (신규) | tb_notifications DDL + 인덱스 |

## Test plan
- [ ] 유저 결제 완료 후 tb_notifications에 알림 row 생성 확인
- [ ] GET /api/v1/owner/notifications → 목록 + unreadCount 반환 확인
- [ ] PATCH /api/v1/owner/notifications/read → isRead=true 갱신 확인

Resolves #81

🤖 Generated with Claude Code