### PR TITLE
[FEAT] 댓글·문의 이미지 첨부 기능 추가

### DIFF
--- a/db/migration/add_attachment_table.sql
+++ b/db/migration/add_attachment_table.sql
@@ -1,0 +1,13 @@
+CREATE TABLE IF NOT EXISTS tb_attachment (
+    attachment_id   BIGINT       NOT NULL AUTO_INCREMENT,
+    attachment_uuid VARCHAR(36)  NOT NULL,
+    attachment_type VARCHAR(20),
+    reference_uuid  VARCHAR(36),
+    file_url        VARCHAR(500) NOT NULL,
+    original_filename VARCHAR(255) NOT NULL,
+    created_at      DATETIME     NOT NULL,
+    updated_at      DATETIME     NOT NULL,
+    CONSTRAINT pk_attachment PRIMARY KEY (attachment_id),
+    CONSTRAINT uk_attachment_uuid UNIQUE (attachment_uuid),
+    INDEX idx_attachment_reference (reference_uuid, attachment_type)
+);

--- a/deal-api-owner/src/main/kotlin/com/chaltteok/owner/comment/dto/AttachmentInfo.kt
+++ b/deal-api-owner/src/main/kotlin/com/chaltteok/owner/comment/dto/AttachmentInfo.kt
@@ -1,0 +1,7 @@
+package com.chaltteok.owner.comment.dto
+
+class AttachmentInfo(
+    val attachmentUuid: String,
+    val fileUrl: String,
+    val originalFilename: String,
+)

--- a/deal-api-owner/src/main/kotlin/com/chaltteok/owner/comment/dto/OwnerCommentResponse.kt
+++ b/deal-api-owner/src/main/kotlin/com/chaltteok/owner/comment/dto/OwnerCommentResponse.kt
@@ -1,5 +1,6 @@
 package com.chaltteok.owner.comment.dto
 
+import com.chaltteok.core.domain.Attachment
 import com.chaltteok.core.domain.Comment
 import com.fasterxml.jackson.annotation.JsonProperty
 import java.time.LocalDateTime
@@ -17,9 +18,14 @@ class OwnerCommentResponse(
     val parentId: Long?,
     val replies: List<OwnerCommentResponse>,
     val createdAt: LocalDateTime,
+    val attachments: List<AttachmentInfo> = emptyList(),
 ) {
     companion object {
-        fun from(comment: Comment, userUuid: String = "") = OwnerCommentResponse(
+        fun from(
+            comment: Comment,
+            userUuid: String = "",
+            attachmentMap: Map<String, List<Attachment>> = emptyMap(),
+        ) = OwnerCommentResponse(
             commentId = comment.id!!,
             commentUuid = comment.commentUuid,
             productUuid = comment.product.productUuid,
@@ -32,12 +38,16 @@ class OwnerCommentResponse(
             parentId = comment.parentId,
             replies = emptyList(),
             createdAt = comment.createdAt,
+            attachments = attachmentMap[comment.commentUuid].orEmpty().map {
+                AttachmentInfo(it.attachmentUuid, it.fileUrl, it.originalFilename)
+            },
         )
 
         fun fromWithReplies(
             comment: Comment,
             replies: List<Comment>,
             uuidMap: Map<Long, String>,
+            attachmentMap: Map<String, List<Attachment>> = emptyMap(),
         ) = OwnerCommentResponse(
             commentId = comment.id!!,
             commentUuid = comment.commentUuid,
@@ -49,8 +59,13 @@ class OwnerCommentResponse(
             isSecret = comment.isSecret,
             isOwnerReply = comment.isOwnerReply,
             parentId = comment.parentId,
-            replies = replies.map { from(it, if (it.isOwnerReply) "" else uuidMap[it.userId] ?: "") },
+            replies = replies.map {
+                from(it, if (it.isOwnerReply) "" else uuidMap[it.userId] ?: "", attachmentMap)
+            },
             createdAt = comment.createdAt,
+            attachments = attachmentMap[comment.commentUuid].orEmpty().map {
+                AttachmentInfo(it.attachmentUuid, it.fileUrl, it.originalFilename)
+            },
         )
     }
 }

--- a/deal-api-owner/src/main/kotlin/com/chaltteok/owner/comment/service/OwnerCommentServiceImpl.kt
+++ b/deal-api-owner/src/main/kotlin/com/chaltteok/owner/comment/service/OwnerCommentServiceImpl.kt
@@ -2,6 +2,8 @@ package com.chaltteok.owner.comment.service
 
 import com.chaltteok.common.exception.BusinessException
 import com.chaltteok.core.domain.Comment
+import com.chaltteok.core.domain.enums.AttachmentType
+import com.chaltteok.core.repository.attachment.AttachmentRepository
 import com.chaltteok.core.repository.comment.CommentRepository
 import com.chaltteok.core.repository.user.UserRepository
 import com.chaltteok.owner.comment.dto.OwnerCommentPageResponse
@@ -17,6 +19,7 @@ import org.springframework.transaction.annotation.Transactional
 class OwnerCommentServiceImpl(
     private val commentRepository: CommentRepository,
     private val userRepository: UserRepository,
+    private val attachmentRepository: AttachmentRepository,
 ) : OwnerCommentService {
 
     @Transactional(readOnly = true)
@@ -34,9 +37,15 @@ class OwnerCommentServiceImpl(
             .distinct()
         val uuidMap = userRepository.findAllById(userIds).associate { it.id!! to it.userUuid }
 
+        val allUuids = (roots + replies).map { it.commentUuid }
+        val attachmentMap = if (allUuids.isNotEmpty()) {
+            attachmentRepository.findAllByReferenceUuidInAndAttachmentType(allUuids, AttachmentType.COMMENT.name)
+                .groupBy { it.referenceUuid!! }
+        } else emptyMap()
+
         val replyMap = replies.groupBy { it.parentId }
         val content = roots.map { root ->
-            OwnerCommentResponse.fromWithReplies(root, replyMap[root.id] ?: emptyList(), uuidMap)
+            OwnerCommentResponse.fromWithReplies(root, replyMap[root.id] ?: emptyList(), uuidMap, attachmentMap)
         }
         return OwnerCommentPageResponse(content, rootPage.totalElements, rootPage.totalPages, page, size)
     }

--- a/deal-api-owner/src/main/kotlin/com/chaltteok/owner/inquiry/dto/OwnerInquiryResponse.kt
+++ b/deal-api-owner/src/main/kotlin/com/chaltteok/owner/inquiry/dto/OwnerInquiryResponse.kt
@@ -1,6 +1,8 @@
 package com.chaltteok.owner.inquiry.dto
 
+import com.chaltteok.core.domain.Attachment
 import com.chaltteok.core.domain.Inquiry
+import com.chaltteok.owner.comment.dto.AttachmentInfo
 import java.time.LocalDateTime
 
 class OwnerInquiryResponse(
@@ -12,9 +14,10 @@ class OwnerInquiryResponse(
     val answer: String?,
     val answeredAt: LocalDateTime?,
     val createdAt: LocalDateTime,
+    val attachments: List<AttachmentInfo> = emptyList(),
 ) {
     companion object {
-        fun from(inquiry: Inquiry, userUuid: String) = OwnerInquiryResponse(
+        fun from(inquiry: Inquiry, userUuid: String, attachments: List<Attachment> = emptyList()) = OwnerInquiryResponse(
             inquiryUuid = inquiry.inquiryUuid,
             userUuid = userUuid,
             title = inquiry.title,
@@ -23,6 +26,7 @@ class OwnerInquiryResponse(
             answer = inquiry.answer,
             answeredAt = inquiry.answeredAt,
             createdAt = inquiry.createdAt,
+            attachments = attachments.map { AttachmentInfo(it.attachmentUuid, it.fileUrl, it.originalFilename) },
         )
     }
 }

--- a/deal-api-owner/src/main/kotlin/com/chaltteok/owner/inquiry/service/OwnerInquiryServiceImpl.kt
+++ b/deal-api-owner/src/main/kotlin/com/chaltteok/owner/inquiry/service/OwnerInquiryServiceImpl.kt
@@ -1,6 +1,8 @@
 package com.chaltteok.owner.inquiry.service
 
 import com.chaltteok.common.exception.BusinessException
+import com.chaltteok.core.domain.enums.AttachmentType
+import com.chaltteok.core.repository.attachment.AttachmentRepository
 import com.chaltteok.core.repository.inquiry.InquiryRepository
 import com.chaltteok.core.repository.user.UserRepository
 import com.chaltteok.owner.inquiry.dto.AnswerRequest
@@ -17,6 +19,7 @@ import java.time.LocalDateTime
 class OwnerInquiryServiceImpl(
     private val inquiryRepository: InquiryRepository,
     private val userRepository: UserRepository,
+    private val attachmentRepository: AttachmentRepository,
 ) : OwnerInquiryService {
 
     @Transactional(readOnly = true)
@@ -27,8 +30,16 @@ class OwnerInquiryServiceImpl(
         val userIds = inquiryPage.content.map { it.userId }.distinct()
         val uuidMap = userRepository.findAllById(userIds).associate { it.id!! to it.userUuid }
 
+        val inquiryUuids = inquiryPage.content.map { it.inquiryUuid }
+        val attachmentMap = if (inquiryUuids.isNotEmpty()) {
+            attachmentRepository.findAllByReferenceUuidInAndAttachmentType(inquiryUuids, AttachmentType.INQUIRY.name)
+                .groupBy { it.referenceUuid!! }
+        } else emptyMap()
+
         return OwnerInquiryPageResponse(
-            content = inquiryPage.content.map { OwnerInquiryResponse.from(it, uuidMap[it.userId] ?: "") },
+            content = inquiryPage.content.map {
+                OwnerInquiryResponse.from(it, uuidMap[it.userId] ?: "", attachmentMap[it.inquiryUuid].orEmpty())
+            },
             totalElements = inquiryPage.totalElements,
             totalPages = inquiryPage.totalPages,
             currentPage = page,

--- a/deal-api-user/build.gradle.kts
+++ b/deal-api-user/build.gradle.kts
@@ -1,4 +1,5 @@
 dependencies {
     implementation(project(":deal-common-api"))
     implementation("org.springframework.boot:spring-boot-starter-validation")
+    implementation("org.apache.tika:tika-core:2.9.1")
 }

--- a/deal-api-user/src/main/kotlin/com/chaltteok/user/comment/dto/AttachmentInfo.kt
+++ b/deal-api-user/src/main/kotlin/com/chaltteok/user/comment/dto/AttachmentInfo.kt
@@ -1,0 +1,7 @@
+package com.chaltteok.user.comment.dto
+
+class AttachmentInfo(
+    val attachmentUuid: String,
+    val fileUrl: String,
+    val originalFilename: String,
+)

--- a/deal-api-user/src/main/kotlin/com/chaltteok/user/comment/dto/CommentRequest.kt
+++ b/deal-api-user/src/main/kotlin/com/chaltteok/user/comment/dto/CommentRequest.kt
@@ -3,9 +3,11 @@ package com.chaltteok.user.comment.dto
 import jakarta.validation.constraints.Max
 import jakarta.validation.constraints.Min
 import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.Size
 
 class CommentRequest(
     @field:NotBlank val content: String,
     @field:Min(1) @field:Max(5) val rating: Int? = null,
     val isSecret: Boolean = false,
+    @field:Size(max = 3) val attachmentUuids: List<String> = emptyList(),
 )

--- a/deal-api-user/src/main/kotlin/com/chaltteok/user/comment/dto/CommentResponse.kt
+++ b/deal-api-user/src/main/kotlin/com/chaltteok/user/comment/dto/CommentResponse.kt
@@ -1,5 +1,6 @@
 package com.chaltteok.user.comment.dto
 
+import com.chaltteok.core.domain.Attachment
 import com.chaltteok.core.domain.Comment
 import com.fasterxml.jackson.annotation.JsonProperty
 import java.time.LocalDateTime
@@ -14,6 +15,7 @@ class CommentResponse(
     val replies: List<CommentResponse>,
     val createdAt: LocalDateTime,
     @get:JsonProperty("isMine") val isMine: Boolean,
+    val attachments: List<AttachmentInfo> = emptyList(),
 ) {
     companion object {
         fun from(
@@ -21,6 +23,7 @@ class CommentResponse(
             replies: List<Comment> = emptyList(),
             requestingUserId: Long?,
             nicknameMap: Map<Long, String> = emptyMap(),
+            attachmentMap: Map<String, List<Attachment>> = emptyMap(),
         ): CommentResponse = CommentResponse(
             commentUuid = comment.commentUuid,
             nickname = if (comment.isOwnerReply) null else nicknameMap[comment.userId],
@@ -28,9 +31,12 @@ class CommentResponse(
             rating = comment.rating,
             isSecret = comment.isSecret,
             isOwnerReply = comment.isOwnerReply,
-            replies = replies.map { from(it, emptyList(), requestingUserId, nicknameMap) },
+            replies = replies.map { from(it, emptyList(), requestingUserId, nicknameMap, attachmentMap) },
             createdAt = comment.createdAt,
             isMine = requestingUserId == comment.userId,
+            attachments = attachmentMap[comment.commentUuid].orEmpty().map {
+                AttachmentInfo(it.attachmentUuid, it.fileUrl, it.originalFilename)
+            },
         )
     }
 }

--- a/deal-api-user/src/main/kotlin/com/chaltteok/user/comment/service/UserCommentServiceImpl.kt
+++ b/deal-api-user/src/main/kotlin/com/chaltteok/user/comment/service/UserCommentServiceImpl.kt
@@ -12,6 +12,7 @@ import com.chaltteok.user.comment.dto.CommentRequest
 import com.chaltteok.user.comment.dto.CommentResponse
 import com.chaltteok.user.comment.dto.ReplyRequest
 import com.chaltteok.user.comment.enums.CommentErrorCode
+import com.chaltteok.user.file.enums.FileErrorCode
 import org.springframework.data.domain.PageRequest
 import org.springframework.data.domain.Sort
 import org.springframework.stereotype.Service
@@ -61,11 +62,14 @@ class UserCommentServiceImpl(
             )
         )
         if (request.attachmentUuids.isNotEmpty()) {
-            attachmentRepository.updateReferenceByUuids(
+            val updated = attachmentRepository.updateReferenceByUuids(
                 request.attachmentUuids,
                 comment.commentUuid,
                 AttachmentType.COMMENT.name
             )
+            if (updated != request.attachmentUuids.size) {
+                throw BusinessException(FileErrorCode.ATTACHMENT_OWNERSHIP_VIOLATION)
+            }
         }
         val nickname = userRepository.findById(userId).map { it.nickname }.orElse(null)
         return CommentResponse.from(comment, emptyList(), userId, if (nickname != null) mapOf(userId to nickname) else emptyMap())
@@ -96,11 +100,14 @@ class UserCommentServiceImpl(
         comment.rating = request.rating
         comment.isSecret = request.isSecret
         if (request.attachmentUuids.isNotEmpty()) {
-            attachmentRepository.updateReferenceByUuids(
+            val updated = attachmentRepository.updateReferenceByUuids(
                 request.attachmentUuids,
                 comment.commentUuid,
                 AttachmentType.COMMENT.name
             )
+            if (updated != request.attachmentUuids.size) {
+                throw BusinessException(FileErrorCode.ATTACHMENT_OWNERSHIP_VIOLATION)
+            }
         }
         val nickname = userRepository.findById(userId).map { it.nickname }.orElse(null)
         return CommentResponse.from(comment, emptyList(), userId, if (nickname != null) mapOf(userId to nickname) else emptyMap())

--- a/deal-api-user/src/main/kotlin/com/chaltteok/user/comment/service/UserCommentServiceImpl.kt
+++ b/deal-api-user/src/main/kotlin/com/chaltteok/user/comment/service/UserCommentServiceImpl.kt
@@ -2,6 +2,8 @@ package com.chaltteok.user.comment.service
 
 import com.chaltteok.common.exception.BusinessException
 import com.chaltteok.core.domain.Comment
+import com.chaltteok.core.domain.enums.AttachmentType
+import com.chaltteok.core.repository.attachment.AttachmentRepository
 import com.chaltteok.core.repository.comment.CommentRepository
 import com.chaltteok.core.repository.product.ProductRepository
 import com.chaltteok.core.repository.user.UserRepository
@@ -20,6 +22,7 @@ class UserCommentServiceImpl(
     private val commentRepository: CommentRepository,
     private val productRepository: ProductRepository,
     private val userRepository: UserRepository,
+    private val attachmentRepository: AttachmentRepository,
 ) : UserCommentService {
 
     @Transactional(readOnly = true)
@@ -32,9 +35,14 @@ class UserCommentServiceImpl(
         val allComments = roots + replies
         val userIds = allComments.filter { !it.isOwnerReply }.map { it.userId }.distinct()
         val nicknameMap = userRepository.findAllById(userIds).associate { it.id!! to it.nickname }
+        val allUuids = allComments.map { it.commentUuid }
+        val attachmentMap = if (allUuids.isNotEmpty()) {
+            attachmentRepository.findAllByReferenceUuidInAndAttachmentType(allUuids, AttachmentType.COMMENT.name)
+                .groupBy { it.referenceUuid!! }
+        } else emptyMap()
         val replyMap = replies.groupBy { it.parentId }
         val content = roots.map { root ->
-            CommentResponse.from(root, replyMap[root.id] ?: emptyList(), requestingUserId, nicknameMap)
+            CommentResponse.from(root, replyMap[root.id] ?: emptyList(), requestingUserId, nicknameMap, attachmentMap)
         }
         return CommentPageResponse(content, rootPage.totalElements, rootPage.totalPages, page, size)
     }
@@ -52,6 +60,13 @@ class UserCommentServiceImpl(
                 isSecret = request.isSecret,
             )
         )
+        if (request.attachmentUuids.isNotEmpty()) {
+            attachmentRepository.updateReferenceByUuids(
+                request.attachmentUuids,
+                comment.commentUuid,
+                AttachmentType.COMMENT.name
+            )
+        }
         val nickname = userRepository.findById(userId).map { it.nickname }.orElse(null)
         return CommentResponse.from(comment, emptyList(), userId, if (nickname != null) mapOf(userId to nickname) else emptyMap())
     }
@@ -80,6 +95,13 @@ class UserCommentServiceImpl(
         comment.content = request.content
         comment.rating = request.rating
         comment.isSecret = request.isSecret
+        if (request.attachmentUuids.isNotEmpty()) {
+            attachmentRepository.updateReferenceByUuids(
+                request.attachmentUuids,
+                comment.commentUuid,
+                AttachmentType.COMMENT.name
+            )
+        }
         val nickname = userRepository.findById(userId).map { it.nickname }.orElse(null)
         return CommentResponse.from(comment, emptyList(), userId, if (nickname != null) mapOf(userId to nickname) else emptyMap())
     }

--- a/deal-api-user/src/main/kotlin/com/chaltteok/user/config/WebConfig.kt
+++ b/deal-api-user/src/main/kotlin/com/chaltteok/user/config/WebConfig.kt
@@ -1,11 +1,15 @@
 package com.chaltteok.user.config
 
+import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.annotation.Configuration
 import org.springframework.web.servlet.config.annotation.CorsRegistry
+import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer
 
 @Configuration
-class WebConfig : WebMvcConfigurer {
+class WebConfig(
+    @Value("\${file.upload-dir}") private val uploadDir: String,
+) : WebMvcConfigurer {
     override fun addCorsMappings(registry: CorsRegistry) {
         registry.addMapping("/api/**")
             .allowedOrigins("http://localhost:3000")
@@ -13,5 +17,15 @@ class WebConfig : WebMvcConfigurer {
             .allowedHeaders("*")
             .allowCredentials(false)
             .maxAge(3600)
+        registry.addMapping("/images/**")
+            .allowedOriginPatterns("*")
+            .allowedMethods("GET", "OPTIONS")
+            .allowedHeaders("*")
+            .allowCredentials(false)
+    }
+
+    override fun addResourceHandlers(registry: ResourceHandlerRegistry) {
+        registry.addResourceHandler("/images/**")
+            .addResourceLocations("file:$uploadDir/")
     }
 }

--- a/deal-api-user/src/main/kotlin/com/chaltteok/user/file/controller/FileUploadController.kt
+++ b/deal-api-user/src/main/kotlin/com/chaltteok/user/file/controller/FileUploadController.kt
@@ -1,0 +1,33 @@
+package com.chaltteok.user.file.controller
+
+import com.chaltteok.common.dto.ResponseDTO
+import com.chaltteok.core.domain.Attachment
+import com.chaltteok.core.repository.attachment.AttachmentRepository
+import com.chaltteok.user.file.dto.FileUploadResponse
+import com.chaltteok.user.file.util.LocalFileUploader
+import org.springframework.http.HttpStatus
+import org.springframework.web.bind.annotation.*
+import org.springframework.web.multipart.MultipartFile
+
+@RestController
+@RequestMapping("/api/v1/user/files")
+class FileUploadController(
+    private val localFileUploader: LocalFileUploader,
+    private val attachmentRepository: AttachmentRepository,
+) {
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    fun upload(@RequestParam("file") file: MultipartFile): ResponseDTO<FileUploadResponse> {
+        val (fileUrl, originalFilename) = localFileUploader.upload(file)
+        val attachment = attachmentRepository.save(
+            Attachment(fileUrl = fileUrl, originalFilename = originalFilename)
+        )
+        return ResponseDTO.success(
+            FileUploadResponse(
+                attachmentUuid = attachment.attachmentUuid,
+                fileUrl = fileUrl,
+                originalFilename = originalFilename,
+            )
+        )
+    }
+}

--- a/deal-api-user/src/main/kotlin/com/chaltteok/user/file/controller/FileUploadController.kt
+++ b/deal-api-user/src/main/kotlin/com/chaltteok/user/file/controller/FileUploadController.kt
@@ -1,33 +1,25 @@
 package com.chaltteok.user.file.controller
 
 import com.chaltteok.common.dto.ResponseDTO
-import com.chaltteok.core.domain.Attachment
-import com.chaltteok.core.repository.attachment.AttachmentRepository
 import com.chaltteok.user.file.dto.FileUploadResponse
-import com.chaltteok.user.file.util.LocalFileUploader
+import com.chaltteok.user.file.service.FileUploadService
 import org.springframework.http.HttpStatus
+import org.springframework.security.core.Authentication
 import org.springframework.web.bind.annotation.*
 import org.springframework.web.multipart.MultipartFile
 
 @RestController
 @RequestMapping("/api/v1/user/files")
 class FileUploadController(
-    private val localFileUploader: LocalFileUploader,
-    private val attachmentRepository: AttachmentRepository,
+    private val fileUploadService: FileUploadService,
 ) {
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
-    fun upload(@RequestParam("file") file: MultipartFile): ResponseDTO<FileUploadResponse> {
-        val (fileUrl, originalFilename) = localFileUploader.upload(file)
-        val attachment = attachmentRepository.save(
-            Attachment(fileUrl = fileUrl, originalFilename = originalFilename)
-        )
-        return ResponseDTO.success(
-            FileUploadResponse(
-                attachmentUuid = attachment.attachmentUuid,
-                fileUrl = fileUrl,
-                originalFilename = originalFilename,
-            )
-        )
+    fun upload(
+        authentication: Authentication,
+        @RequestParam("file") file: MultipartFile,
+    ): ResponseDTO<FileUploadResponse> {
+        authentication.principal as Long  // 인증 강제 (미인증 시 401)
+        return ResponseDTO.success(fileUploadService.upload(file))
     }
 }

--- a/deal-api-user/src/main/kotlin/com/chaltteok/user/file/dto/FileUploadResponse.kt
+++ b/deal-api-user/src/main/kotlin/com/chaltteok/user/file/dto/FileUploadResponse.kt
@@ -1,0 +1,7 @@
+package com.chaltteok.user.file.dto
+
+class FileUploadResponse(
+    val attachmentUuid: String,
+    val fileUrl: String,
+    val originalFilename: String,
+)

--- a/deal-api-user/src/main/kotlin/com/chaltteok/user/file/enums/FileErrorCode.kt
+++ b/deal-api-user/src/main/kotlin/com/chaltteok/user/file/enums/FileErrorCode.kt
@@ -10,4 +10,5 @@ enum class FileErrorCode(
     FILE_EMPTY("파일이 비어있습니다.", HttpStatus.BAD_REQUEST),
     INVALID_FILE_TYPE("JPEG, PNG 파일만 첨부 가능합니다.", HttpStatus.BAD_REQUEST),
     FILE_UPLOAD_FAILED("파일 업로드에 실패했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
+    ATTACHMENT_OWNERSHIP_VIOLATION("첨부파일 소유권 오류: 이미 연결되었거나 존재하지 않는 파일이 포함되어 있습니다.", HttpStatus.FORBIDDEN),
 }

--- a/deal-api-user/src/main/kotlin/com/chaltteok/user/file/enums/FileErrorCode.kt
+++ b/deal-api-user/src/main/kotlin/com/chaltteok/user/file/enums/FileErrorCode.kt
@@ -1,0 +1,13 @@
+package com.chaltteok.user.file.enums
+
+import com.chaltteok.common.enums.ErrorCode
+import org.springframework.http.HttpStatus
+
+enum class FileErrorCode(
+    override val message: String,
+    override val status: HttpStatus,
+) : ErrorCode {
+    FILE_EMPTY("파일이 비어있습니다.", HttpStatus.BAD_REQUEST),
+    INVALID_FILE_TYPE("JPEG, PNG 파일만 첨부 가능합니다.", HttpStatus.BAD_REQUEST),
+    FILE_UPLOAD_FAILED("파일 업로드에 실패했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
+}

--- a/deal-api-user/src/main/kotlin/com/chaltteok/user/file/service/FileUploadService.kt
+++ b/deal-api-user/src/main/kotlin/com/chaltteok/user/file/service/FileUploadService.kt
@@ -1,0 +1,8 @@
+package com.chaltteok.user.file.service
+
+import com.chaltteok.user.file.dto.FileUploadResponse
+import org.springframework.web.multipart.MultipartFile
+
+interface FileUploadService {
+    fun upload(file: MultipartFile): FileUploadResponse
+}

--- a/deal-api-user/src/main/kotlin/com/chaltteok/user/file/service/FileUploadServiceImpl.kt
+++ b/deal-api-user/src/main/kotlin/com/chaltteok/user/file/service/FileUploadServiceImpl.kt
@@ -1,0 +1,29 @@
+package com.chaltteok.user.file.service
+
+import com.chaltteok.core.domain.Attachment
+import com.chaltteok.core.repository.attachment.AttachmentRepository
+import com.chaltteok.user.file.dto.FileUploadResponse
+import com.chaltteok.user.file.util.LocalFileUploader
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import org.springframework.web.multipart.MultipartFile
+
+@Service
+class FileUploadServiceImpl(
+    private val localFileUploader: LocalFileUploader,
+    private val attachmentRepository: AttachmentRepository,
+) : FileUploadService {
+
+    @Transactional
+    override fun upload(file: MultipartFile): FileUploadResponse {
+        val (fileUrl, originalFilename) = localFileUploader.upload(file)
+        val attachment = attachmentRepository.save(
+            Attachment(fileUrl = fileUrl, originalFilename = originalFilename)
+        )
+        return FileUploadResponse(
+            attachmentUuid = attachment.attachmentUuid,
+            fileUrl = fileUrl,
+            originalFilename = originalFilename,
+        )
+    }
+}

--- a/deal-api-user/src/main/kotlin/com/chaltteok/user/file/util/LocalFileUploader.kt
+++ b/deal-api-user/src/main/kotlin/com/chaltteok/user/file/util/LocalFileUploader.kt
@@ -1,0 +1,34 @@
+package com.chaltteok.user.file.util
+
+import com.chaltteok.common.exception.BusinessException
+import com.chaltteok.user.file.enums.FileErrorCode
+import org.apache.tika.Tika
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.stereotype.Component
+import org.springframework.web.multipart.MultipartFile
+import java.nio.file.Files
+import java.nio.file.Paths
+import java.util.UUID
+
+@Component
+class LocalFileUploader(
+    @Value("\${file.upload-dir}") private val uploadDir: String,
+) {
+    private val tika = Tika()
+    private val allowedMimeTypes = listOf("image/jpeg", "image/png")
+
+    fun upload(file: MultipartFile): Pair<String, String> {  // (fileUrl, originalFilename)
+        if (file.isEmpty) throw BusinessException(FileErrorCode.FILE_EMPTY)
+        val mimeType = file.inputStream.use { tika.detect(it) }
+        if (mimeType !in allowedMimeTypes) throw BusinessException(FileErrorCode.INVALID_FILE_TYPE)
+
+        val directory = Paths.get(uploadDir).toAbsolutePath().normalize()
+        if (!Files.exists(directory)) Files.createDirectories(directory)
+
+        val originalFilename = file.originalFilename ?: "unknown.jpg"
+        val extension = originalFilename.substringAfterLast(".", "jpg")
+        val savedName = "${UUID.randomUUID()}.$extension"
+        file.transferTo(directory.resolve(savedName).toFile())
+        return Pair("/images/$savedName", originalFilename)
+    }
+}

--- a/deal-api-user/src/main/kotlin/com/chaltteok/user/file/util/LocalFileUploader.kt
+++ b/deal-api-user/src/main/kotlin/com/chaltteok/user/file/util/LocalFileUploader.kt
@@ -15,20 +15,26 @@ class LocalFileUploader(
     @Value("\${file.upload-dir}") private val uploadDir: String,
 ) {
     private val tika = Tika()
-    private val allowedMimeTypes = listOf("image/jpeg", "image/png")
+    private val allowedMimeTypes = setOf("image/jpeg", "image/png")
+    private val mimeToExt = mapOf("image/jpeg" to "jpg", "image/png" to "png")
 
-    fun upload(file: MultipartFile): Pair<String, String> {  // (fileUrl, originalFilename)
+    fun upload(file: MultipartFile): Pair<String, String> {
         if (file.isEmpty) throw BusinessException(FileErrorCode.FILE_EMPTY)
+
         val mimeType = file.inputStream.use { tika.detect(it) }
         if (mimeType !in allowedMimeTypes) throw BusinessException(FileErrorCode.INVALID_FILE_TYPE)
 
         val directory = Paths.get(uploadDir).toAbsolutePath().normalize()
         if (!Files.exists(directory)) Files.createDirectories(directory)
 
-        val originalFilename = file.originalFilename ?: "unknown.jpg"
-        val extension = originalFilename.substringAfterLast(".", "jpg")
+        val originalFilename = file.originalFilename?.ifBlank { null } ?: "upload"
+        val extension = mimeToExt[mimeType]!!  // MIME 기반 확장자, 원본 미사용
         val savedName = "${UUID.randomUUID()}.$extension"
-        file.transferTo(directory.resolve(savedName).toFile())
+
+        val filePath = directory.resolve(savedName).normalize()
+        check(filePath.startsWith(directory)) { "경로 이탈 감지" }
+
+        file.transferTo(filePath.toFile())
         return Pair("/images/$savedName", originalFilename)
     }
 }

--- a/deal-api-user/src/main/kotlin/com/chaltteok/user/inquiry/dto/InquiryRequest.kt
+++ b/deal-api-user/src/main/kotlin/com/chaltteok/user/inquiry/dto/InquiryRequest.kt
@@ -1,8 +1,10 @@
 package com.chaltteok.user.inquiry.dto
 
 import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.Size
 
 class InquiryRequest(
     @field:NotBlank val title: String,
     @field:NotBlank val content: String,
+    @field:Size(max = 3) val attachmentUuids: List<String> = emptyList(),
 )

--- a/deal-api-user/src/main/kotlin/com/chaltteok/user/inquiry/dto/InquiryResponse.kt
+++ b/deal-api-user/src/main/kotlin/com/chaltteok/user/inquiry/dto/InquiryResponse.kt
@@ -1,6 +1,8 @@
 package com.chaltteok.user.inquiry.dto
 
+import com.chaltteok.core.domain.Attachment
 import com.chaltteok.core.domain.Inquiry
+import com.chaltteok.user.comment.dto.AttachmentInfo
 import java.time.LocalDateTime
 
 class InquiryResponse(
@@ -11,9 +13,10 @@ class InquiryResponse(
     val answer: String?,
     val answeredAt: LocalDateTime?,
     val createdAt: LocalDateTime,
+    val attachments: List<AttachmentInfo> = emptyList(),
 ) {
     companion object {
-        fun from(inquiry: Inquiry) = InquiryResponse(
+        fun from(inquiry: Inquiry, attachments: List<Attachment> = emptyList()) = InquiryResponse(
             inquiryUuid = inquiry.inquiryUuid,
             title = inquiry.title,
             content = inquiry.content,
@@ -21,6 +24,7 @@ class InquiryResponse(
             answer = inquiry.answer,
             answeredAt = inquiry.answeredAt,
             createdAt = inquiry.createdAt,
+            attachments = attachments.map { AttachmentInfo(it.attachmentUuid, it.fileUrl, it.originalFilename) },
         )
     }
 }

--- a/deal-api-user/src/main/kotlin/com/chaltteok/user/inquiry/service/UserInquiryServiceImpl.kt
+++ b/deal-api-user/src/main/kotlin/com/chaltteok/user/inquiry/service/UserInquiryServiceImpl.kt
@@ -1,6 +1,8 @@
 package com.chaltteok.user.inquiry.service
 
 import com.chaltteok.core.domain.Inquiry
+import com.chaltteok.core.domain.enums.AttachmentType
+import com.chaltteok.core.repository.attachment.AttachmentRepository
 import com.chaltteok.core.repository.inquiry.InquiryRepository
 import com.chaltteok.user.inquiry.dto.InquiryRequest
 import com.chaltteok.user.inquiry.dto.InquiryResponse
@@ -10,11 +12,19 @@ import org.springframework.transaction.annotation.Transactional
 @Service
 class UserInquiryServiceImpl(
     private val inquiryRepository: InquiryRepository,
+    private val attachmentRepository: AttachmentRepository,
 ) : UserInquiryService {
 
     @Transactional(readOnly = true)
-    override fun getMyInquiries(userId: Long): List<InquiryResponse> =
-        inquiryRepository.findByUserIdOrderByCreatedAtDesc(userId).map { InquiryResponse.from(it) }
+    override fun getMyInquiries(userId: Long): List<InquiryResponse> {
+        val inquiries = inquiryRepository.findByUserIdOrderByCreatedAtDesc(userId)
+        val inquiryUuids = inquiries.map { it.inquiryUuid }
+        val attachmentMap = if (inquiryUuids.isNotEmpty()) {
+            attachmentRepository.findAllByReferenceUuidInAndAttachmentType(inquiryUuids, AttachmentType.INQUIRY.name)
+                .groupBy { it.referenceUuid!! }
+        } else emptyMap()
+        return inquiries.map { InquiryResponse.from(it, attachmentMap[it.inquiryUuid].orEmpty()) }
+    }
 
     @Transactional
     override fun create(userId: Long, request: InquiryRequest): InquiryResponse {
@@ -25,6 +35,13 @@ class UserInquiryServiceImpl(
                 content = request.content,
             )
         )
+        if (request.attachmentUuids.isNotEmpty()) {
+            attachmentRepository.updateReferenceByUuids(
+                request.attachmentUuids,
+                inquiry.inquiryUuid,
+                AttachmentType.INQUIRY.name
+            )
+        }
         return InquiryResponse.from(inquiry)
     }
 }

--- a/deal-api-user/src/main/kotlin/com/chaltteok/user/inquiry/service/UserInquiryServiceImpl.kt
+++ b/deal-api-user/src/main/kotlin/com/chaltteok/user/inquiry/service/UserInquiryServiceImpl.kt
@@ -1,9 +1,11 @@
 package com.chaltteok.user.inquiry.service
 
+import com.chaltteok.common.exception.BusinessException
 import com.chaltteok.core.domain.Inquiry
 import com.chaltteok.core.domain.enums.AttachmentType
 import com.chaltteok.core.repository.attachment.AttachmentRepository
 import com.chaltteok.core.repository.inquiry.InquiryRepository
+import com.chaltteok.user.file.enums.FileErrorCode
 import com.chaltteok.user.inquiry.dto.InquiryRequest
 import com.chaltteok.user.inquiry.dto.InquiryResponse
 import org.springframework.stereotype.Service
@@ -36,11 +38,14 @@ class UserInquiryServiceImpl(
             )
         )
         if (request.attachmentUuids.isNotEmpty()) {
-            attachmentRepository.updateReferenceByUuids(
+            val updated = attachmentRepository.updateReferenceByUuids(
                 request.attachmentUuids,
                 inquiry.inquiryUuid,
                 AttachmentType.INQUIRY.name
             )
+            if (updated != request.attachmentUuids.size) {
+                throw BusinessException(FileErrorCode.ATTACHMENT_OWNERSHIP_VIOLATION)
+            }
         }
         return InquiryResponse.from(inquiry)
     }

--- a/deal-api-user/src/main/resources/application.yml
+++ b/deal-api-user/src/main/resources/application.yml
@@ -3,6 +3,10 @@ spring:
     name: deal-api-user
   config:
     import: classpath:application-core.yml
+  servlet:
+    multipart:
+      max-file-size: 5MB
+      max-request-size: 20MB
 
 server:
   port: 8080

--- a/deal-core/src/main/kotlin/com/chaltteok/core/domain/Attachment.kt
+++ b/deal-core/src/main/kotlin/com/chaltteok/core/domain/Attachment.kt
@@ -1,0 +1,23 @@
+package com.chaltteok.core.domain
+
+import jakarta.persistence.*
+import java.util.UUID
+
+@Entity
+@Table(
+    name = "tb_attachment",
+    uniqueConstraints = [UniqueConstraint(name = "uk_attachment_uuid", columnNames = ["attachment_uuid"])],
+    indexes = [Index(name = "idx_attachment_reference", columnList = "reference_uuid,attachment_type")]
+)
+class Attachment(
+    @Column(name = "file_url", nullable = false, length = 500) val fileUrl: String,
+    @Column(name = "original_filename", nullable = false, length = 255) val originalFilename: String,
+    @Column(name = "attachment_type", length = 20) var attachmentType: String? = null,
+    @Column(name = "reference_uuid", length = 36) var referenceUuid: String? = null,
+) : BaseEntity() {
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "attachment_id") var id: Long? = null
+
+    @Column(name = "attachment_uuid", nullable = false, length = 36)
+    val attachmentUuid: String = UUID.randomUUID().toString()
+}

--- a/deal-core/src/main/kotlin/com/chaltteok/core/domain/enums/AttachmentType.kt
+++ b/deal-core/src/main/kotlin/com/chaltteok/core/domain/enums/AttachmentType.kt
@@ -1,0 +1,3 @@
+package com.chaltteok.core.domain.enums
+
+enum class AttachmentType { COMMENT, INQUIRY }

--- a/deal-core/src/main/kotlin/com/chaltteok/core/repository/attachment/AttachmentRepository.kt
+++ b/deal-core/src/main/kotlin/com/chaltteok/core/repository/attachment/AttachmentRepository.kt
@@ -1,0 +1,21 @@
+package com.chaltteok.core.repository.attachment
+
+import com.chaltteok.core.domain.Attachment
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Modifying
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
+
+interface AttachmentRepository : JpaRepository<Attachment, Long> {
+    fun findAllByReferenceUuidAndAttachmentType(referenceUuid: String, attachmentType: String): List<Attachment>
+
+    fun findAllByReferenceUuidInAndAttachmentType(referenceUuids: List<String>, attachmentType: String): List<Attachment>
+
+    @Modifying
+    @Query("UPDATE Attachment a SET a.referenceUuid = :referenceUuid, a.attachmentType = :attachmentType WHERE a.attachmentUuid IN :uuids")
+    fun updateReferenceByUuids(
+        @Param("uuids") uuids: List<String>,
+        @Param("referenceUuid") referenceUuid: String,
+        @Param("attachmentType") attachmentType: String,
+    ): Int
+}

--- a/deal-core/src/main/kotlin/com/chaltteok/core/repository/attachment/AttachmentRepository.kt
+++ b/deal-core/src/main/kotlin/com/chaltteok/core/repository/attachment/AttachmentRepository.kt
@@ -12,7 +12,7 @@ interface AttachmentRepository : JpaRepository<Attachment, Long> {
     fun findAllByReferenceUuidInAndAttachmentType(referenceUuids: List<String>, attachmentType: String): List<Attachment>
 
     @Modifying
-    @Query("UPDATE Attachment a SET a.referenceUuid = :referenceUuid, a.attachmentType = :attachmentType WHERE a.attachmentUuid IN :uuids")
+    @Query("UPDATE Attachment a SET a.referenceUuid = :referenceUuid, a.attachmentType = :attachmentType WHERE a.attachmentUuid IN :uuids AND a.referenceUuid IS NULL")
     fun updateReferenceByUuids(
         @Param("uuids") uuids: List<String>,
         @Param("referenceUuid") referenceUuid: String,


### PR DESCRIPTION
## Summary
- 댓글과 1:1 문의 작성 시 이미지(JPEG/PNG) 최대 3장 첨부 가능
- 별도 파일 업로드 엔드포인트(`POST /api/v1/user/files`)에서 Attachment UUID 발급 후 댓글/문의 생성 시 UUID 목록 전달
- Attachment 엔티티(tb_attachment)로 첨부파일을 분리 관리 (reference_uuid + attachment_type)

## Changes
| 모듈 | 파일 | 내용 |
|------|------|------|
| deal-core | Attachment.kt, AttachmentType.kt, AttachmentRepository.kt | 첨부파일 엔티티/레포지토리 신규 |
| deal-api-user | FileUploadController, LocalFileUploader, FileErrorCode | 파일 업로드 API + Tika MIME 검증 |
| deal-api-user | CommentRequest/Response, InquiryRequest/Response | attachmentUuids 입력 + attachments 출력 |
| deal-api-owner | OwnerCommentResponse, OwnerInquiryResponse | attachments 조회 반영 |
| db/migration | add_attachment_table.sql | tb_attachment DDL |

## Test plan
- [ ] `POST /api/v1/user/files` — JPEG/PNG 업로드 성공, attachmentUuid 반환
- [ ] `POST /api/v1/user/files` — PNG 이외 파일 → 400 INVALID_FILE_TYPE
- [ ] 댓글 생성 시 attachmentUuids 포함 → 조회 시 attachments 포함 응답
- [ ] 문의 생성 시 attachmentUuids 포함 → 조회 시 attachments 포함 응답

Resolves #83

🤖 Generated with Claude Code