### PR TITLE
[FEAT] 대시보드 getOverview API 커스텀 기간 파라미터 추가

### DIFF
--- a/deal-api-owner/src/main/kotlin/com/chaltteok/owner/dashboard/controller/DashboardController.kt
+++ b/deal-api-owner/src/main/kotlin/com/chaltteok/owner/dashboard/controller/DashboardController.kt
@@ -3,7 +3,9 @@ package com.chaltteok.owner.dashboard.controller
 import com.chaltteok.common.dto.ResponseDTO
 import com.chaltteok.owner.dashboard.enums.DashboardPeriod
 import com.chaltteok.owner.dashboard.service.DashboardService
+import jakarta.validation.constraints.PastOrPresent
 import org.springframework.format.annotation.DateTimeFormat
+import org.springframework.validation.annotation.Validated
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
@@ -12,13 +14,14 @@ import java.time.LocalDate
 
 @RestController
 @RequestMapping("/api/v1/owner/dashboard")
+@Validated
 class DashboardController(private val dashboardService: DashboardService) {
 
     @GetMapping("/overview")
     fun getOverview(
         @RequestParam(defaultValue = "DAILY") period: DashboardPeriod,
-        @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) from: LocalDate?,
-        @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) to: LocalDate?,
+        @PastOrPresent @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) from: LocalDate?,
+        @PastOrPresent @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) to: LocalDate?,
     ) = ResponseDTO.success(dashboardService.getOverview(period, from, to))
 
     @GetMapping("/sales-trend")

--- a/deal-api-owner/src/main/kotlin/com/chaltteok/owner/dashboard/controller/DashboardController.kt
+++ b/deal-api-owner/src/main/kotlin/com/chaltteok/owner/dashboard/controller/DashboardController.kt
@@ -17,7 +17,9 @@ class DashboardController(private val dashboardService: DashboardService) {
     @GetMapping("/overview")
     fun getOverview(
         @RequestParam(defaultValue = "DAILY") period: DashboardPeriod,
-    ) = ResponseDTO.success(dashboardService.getOverview(period))
+        @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) from: LocalDate?,
+        @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) to: LocalDate?,
+    ) = ResponseDTO.success(dashboardService.getOverview(period, from, to))
 
     @GetMapping("/sales-trend")
     fun getSalesTrend(

--- a/deal-api-owner/src/main/kotlin/com/chaltteok/owner/dashboard/service/DashboardService.kt
+++ b/deal-api-owner/src/main/kotlin/com/chaltteok/owner/dashboard/service/DashboardService.kt
@@ -8,7 +8,7 @@ import com.chaltteok.owner.dashboard.enums.DashboardPeriod
 import java.time.LocalDate
 
 interface DashboardService {
-    fun getOverview(period: DashboardPeriod): DashboardOverviewResponse
+    fun getOverview(period: DashboardPeriod, from: LocalDate? = null, to: LocalDate? = null): DashboardOverviewResponse
     fun getSalesTrend(from: LocalDate, to: LocalDate): SalesTrendResponse
     fun getTopProducts(from: LocalDate, to: LocalDate, limit: Int): TopProductsResponse
     fun getHourlySales(date: LocalDate): HourlySalesResponse

--- a/deal-api-owner/src/main/kotlin/com/chaltteok/owner/dashboard/service/DashboardServiceImpl.kt
+++ b/deal-api-owner/src/main/kotlin/com/chaltteok/owner/dashboard/service/DashboardServiceImpl.kt
@@ -24,18 +24,22 @@ class DashboardServiceImpl(
     private val userRepository: UserRepository,
 ) : DashboardService {
 
-    override fun getOverview(period: DashboardPeriod): DashboardOverviewResponse {
-        val (from, to) = resolvePeriodRange(period)
+    override fun getOverview(period: DashboardPeriod, from: LocalDate?, to: LocalDate?): DashboardOverviewResponse {
+        val (fromDt, toDt) = if (from != null && to != null) {
+            Pair(from.atStartOfDay(), to.atTime(LocalTime.MAX))
+        } else {
+            resolvePeriodRange(period)
+        }
 
-        val salesAgg = orderRepository.findSalesPeriodAgg(from, to)
-        val newCustomers = userRepository.countNewUsers(from, to)
-        val repeatCustomers = userRepository.countRepeatOrderUsers(from, to)
+        val salesAgg = orderRepository.findSalesPeriodAgg(fromDt, toDt)
+        val newCustomers = userRepository.countNewUsers(fromDt, toDt)
+        val repeatCustomers = userRepository.countRepeatOrderUsers(fromDt, toDt)
         val avgOrderValue = if (salesAgg.orderCount > 0) salesAgg.totalRevenue / salesAgg.orderCount else 0L
 
         return DashboardOverviewResponse(
             period = period.name,
-            from = from,
-            to = to,
+            from = fromDt,
+            to = toDt,
             totalRevenue = salesAgg.totalRevenue,
             orderCount = salesAgg.orderCount,
             avgOrderValue = avgOrderValue,

--- a/deal-api-owner/src/main/kotlin/com/chaltteok/owner/dashboard/service/DashboardServiceImpl.kt
+++ b/deal-api-owner/src/main/kotlin/com/chaltteok/owner/dashboard/service/DashboardServiceImpl.kt
@@ -25,6 +25,12 @@ class DashboardServiceImpl(
 ) : DashboardService {
 
     override fun getOverview(period: DashboardPeriod, from: LocalDate?, to: LocalDate?): DashboardOverviewResponse {
+        if (from != null && to != null) {
+            require(!from.isAfter(to)) { "시작일은 종료일보다 이전이어야 합니다." }
+            require(!to.isAfter(LocalDate.now())) { "종료일은 오늘 이전이어야 합니다." }
+            require(!from.isBefore(to.minusDays(365))) { "조회 기간은 최대 365일입니다." }
+        }
+
         val (fromDt, toDt) = if (from != null && to != null) {
             Pair(from.atStartOfDay(), to.atTime(LocalTime.MAX))
         } else {


### PR DESCRIPTION
## Summary
- getOverview API에 optional from/to 파라미터 추가
- 기존 DAILY/WEEKLY/MONTHLY 프리셋 동작 완전 호환 유지

## Changes
| 파일 | 내용 |
|------|------|
| DashboardController.kt | from/to RequestParam(required=false) 추가 |
| DashboardService.kt | getOverview 시그니처에 from/to nullable 파라미터 추가 |
| DashboardServiceImpl.kt | from/to 제공 시 커스텀 범위, 미제공 시 period 기반 분기 |

## Test plan
- [ ] period=DAILY (from/to 없음) → 기존 동작 동일
- [ ] from=2026-05-01&to=2026-05-31 → 해당 기간 집계 반환

Resolves #85

🤖 Generated with Claude Code