### PR TITLE
[FEAT] 타임세일 기능 구현 - DailyStock 시간 기반 오픈/마감 전환

### DIFF
--- a/db/migration/add_timesale_columns.sql
+++ b/db/migration/add_timesale_columns.sql
@@ -1,0 +1,8 @@
+ALTER TABLE tb_daily_stocks
+    ADD COLUMN start_at DATETIME NULL COMMENT '타임세일 시작 시각',
+    ADD COLUMN end_at DATETIME NULL COMMENT '타임세일 종료 시각',
+    ADD COLUMN max_purchase_count INT NOT NULL DEFAULT 1 COMMENT '1인 최대 구매 횟수';
+
+UPDATE tb_daily_stocks SET start_at = NULL, end_at = NULL WHERE stock_type = 'NORMAL';
+
+CREATE INDEX idx_end_at_status ON tb_daily_stocks (end_at, status);

--- a/deal-api-owner/src/main/kotlin/com/chaltteok/owner/dailystock/dto/DailyStocksRegisterRequest.kt
+++ b/deal-api-owner/src/main/kotlin/com/chaltteok/owner/dailystock/dto/DailyStocksRegisterRequest.kt
@@ -2,9 +2,11 @@ package com.chaltteok.owner.dailystock.dto
 
 import com.chaltteok.core.domain.DailyStock
 import com.chaltteok.core.domain.Product
+import com.chaltteok.core.domain.enums.DailyStockStatus
 import com.chaltteok.owner.dailystock.enums.DailyStockType
 import jakarta.validation.constraints.NotNull
 import java.time.LocalDate
+import java.time.LocalDateTime
 
 data class DailyStocksRegisterRequest(
     @field:NotNull(message = "option id must not be null")
@@ -19,8 +21,19 @@ data class DailyStocksRegisterRequest(
 
     @field:NotNull(message = "sale amount must not be null")
     val totalQty: Int,
+
+    val startAt: LocalDateTime? = null,
+    val endAt: LocalDateTime? = null,
+    val maxPurchaseCount: Int = 1,
 ) {
-    fun toDailyStockEntity(product: Product, salePrice: Int): DailyStock {
+    init {
+        if ((stockType ?: DailyStockType.NORMAL) == DailyStockType.TIMESALE) {
+            require(startAt != null) { "startAt is required for TIMESALE stock" }
+            require(endAt != null) { "endAt is required for TIMESALE stock" }
+        }
+    }
+
+    fun toDailyStockEntity(product: Product, salePrice: Int, status: DailyStockStatus = DailyStockStatus.OPEN): DailyStock {
         val finalStockType = (this.stockType ?: DailyStockType.NORMAL).name
 
         return DailyStock(
@@ -30,6 +43,10 @@ data class DailyStocksRegisterRequest(
             salePrice = salePrice,
             totalQty = totalQty,
             remainStock = totalQty,
+            status = status,
+            startAt = startAt,
+            endAt = endAt,
+            maxPurchaseCount = maxPurchaseCount,
         )
     }
 }

--- a/deal-api-owner/src/main/kotlin/com/chaltteok/owner/dailystock/enums/DailyStockType.kt
+++ b/deal-api-owner/src/main/kotlin/com/chaltteok/owner/dailystock/enums/DailyStockType.kt
@@ -2,5 +2,6 @@ package com.chaltteok.owner.dailystock.enums
 
 enum class DailyStockType {
     NORMAL,
-    EVENT
+    EVENT,
+    TIMESALE
 }

--- a/deal-api-owner/src/main/kotlin/com/chaltteok/owner/dailystock/service/DailyStockServiceImpl.kt
+++ b/deal-api-owner/src/main/kotlin/com/chaltteok/owner/dailystock/service/DailyStockServiceImpl.kt
@@ -1,6 +1,7 @@
 package com.chaltteok.owner.dailystock.service
 
 import com.chaltteok.common.exception.BusinessException
+import com.chaltteok.core.domain.enums.DailyStockStatus
 import com.chaltteok.core.repository.dailystock.DailyStockRepository
 import com.chaltteok.core.repository.productoption.ProductOptionRepository
 import com.chaltteok.owner.dailystock.dto.DailyStocksRegisterRequest
@@ -9,6 +10,7 @@ import com.chaltteok.owner.dailystock.enums.DailyStockType
 import io.github.oshai.kotlinlogging.KotlinLogging
 import org.springframework.dao.DataIntegrityViolationException
 import org.springframework.stereotype.Service
+import java.time.LocalDateTime
 
 private val logger = KotlinLogging.logger {}
 
@@ -30,7 +32,18 @@ class DailyStockServiceImpl(
             throw BusinessException(DailyStockErrorCode.EVENT_PRICE_REQUIRED)
         }
 
-        val stock = dailyStocksRegisterRequest.toDailyStockEntity(productOption.product, finalPrice)
+        val initialStatus = if (stockType == DailyStockType.TIMESALE) {
+            val now = LocalDateTime.now()
+            if (dailyStocksRegisterRequest.startAt != null && dailyStocksRegisterRequest.startAt.isAfter(now)) {
+                DailyStockStatus.SCHEDULED
+            } else {
+                DailyStockStatus.OPEN
+            }
+        } else {
+            DailyStockStatus.OPEN
+        }
+
+        val stock = dailyStocksRegisterRequest.toDailyStockEntity(productOption.product, finalPrice, initialStatus)
 
         try {
             dailyStockRepository.save(stock)

--- a/deal-api-owner/src/main/kotlin/com/chaltteok/owner/product/scheduler/ProductStockScheduler.kt
+++ b/deal-api-owner/src/main/kotlin/com/chaltteok/owner/product/scheduler/ProductStockScheduler.kt
@@ -25,6 +25,15 @@ class ProductStockScheduler(
 
     @Scheduled(cron = "0 * * * * *")
     @Transactional
+    fun openScheduledTimeSales() {
+        val opened = dailyStockRepository.openScheduledStocks(LocalDateTime.now())
+        if (opened > 0) {
+            logger.info { "Opened $opened scheduled time sale stocks" }
+        }
+    }
+
+    @Scheduled(cron = "0 * * * * *")
+    @Transactional
     fun closeExpiredTimeSales() {
         val closed = dailyStockRepository.closeExpiredStocks(LocalDateTime.now())
         if (closed > 0) {

--- a/deal-api-owner/src/main/kotlin/com/chaltteok/owner/product/scheduler/ProductStockScheduler.kt
+++ b/deal-api-owner/src/main/kotlin/com/chaltteok/owner/product/scheduler/ProductStockScheduler.kt
@@ -1,16 +1,19 @@
 package com.chaltteok.owner.product.scheduler
 
+import com.chaltteok.core.repository.dailystock.DailyStockRepository
 import com.chaltteok.core.repository.product.ProductRepository
 import io.github.oshai.kotlinlogging.KotlinLogging
 import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.stereotype.Component
 import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDateTime
 
 private val logger = KotlinLogging.logger {}
 
 @Component
 class ProductStockScheduler(
     private val productRepository: ProductRepository,
+    private val dailyStockRepository: DailyStockRepository,
 ) {
     @Scheduled(cron = "0 0 0 * * *", zone = "Asia/Seoul")
     @Transactional
@@ -18,5 +21,14 @@ class ProductStockScheduler(
         val reset = productRepository.resetDailyStockForActiveProducts()
         productRepository.markZeroStockAsSoldOut()
         logger.info { "Daily stock reset completed: $reset products restored" }
+    }
+
+    @Scheduled(cron = "0 * * * * *")
+    @Transactional
+    fun closeExpiredTimeSales() {
+        val closed = dailyStockRepository.closeExpiredStocks(LocalDateTime.now())
+        if (closed > 0) {
+            logger.info { "Closed $closed expired time sale stocks" }
+        }
     }
 }

--- a/deal-api-user/src/main/kotlin/com/chaltteok/user/dailystock/dto/OpenDailyStockResponse.kt
+++ b/deal-api-user/src/main/kotlin/com/chaltteok/user/dailystock/dto/OpenDailyStockResponse.kt
@@ -2,6 +2,7 @@ package com.chaltteok.user.dailystock.dto
 
 import com.chaltteok.core.domain.DailyStock
 import java.time.LocalDate
+import java.time.LocalDateTime
 
 data class OpenDailyStockResponse(
     val id: Long,
@@ -10,6 +11,9 @@ data class OpenDailyStockResponse(
     val saleDate: LocalDate,
     val remainStock: Int,
     val totalStock: Int,
+    val startAt: LocalDateTime?,
+    val endAt: LocalDateTime?,
+    val maxPurchaseCount: Int,
 ) {
     companion object {
         fun from(dailyStock: DailyStock) = OpenDailyStockResponse(
@@ -19,6 +23,9 @@ data class OpenDailyStockResponse(
             saleDate = dailyStock.saleDate,
             remainStock = dailyStock.remainStock,
             totalStock = dailyStock.totalQty,
+            startAt = dailyStock.startAt,
+            endAt = dailyStock.endAt,
+            maxPurchaseCount = dailyStock.maxPurchaseCount,
         )
     }
 }

--- a/deal-api-user/src/main/kotlin/com/chaltteok/user/dailystock/service/DailyStockQueryServiceImpl.kt
+++ b/deal-api-user/src/main/kotlin/com/chaltteok/user/dailystock/service/DailyStockQueryServiceImpl.kt
@@ -6,6 +6,7 @@ import com.chaltteok.core.repository.eventhistory.EventHistoryRepository
 import com.chaltteok.user.dailystock.dto.OpenDailyStockResponse
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDateTime
 
 @Service
 class DailyStockQueryServiceImpl(
@@ -14,9 +15,13 @@ class DailyStockQueryServiceImpl(
 ) : DailyStockQueryService {
 
     @Transactional(readOnly = true)
-    override fun getOpenDailyStocks(): List<OpenDailyStockResponse> =
-        dailyStockRepository.findAllByStatusWithProduct(DailyStockStatus.OPEN)
-            .map { OpenDailyStockResponse.from(it) }
+    override fun getOpenDailyStocks(): List<OpenDailyStockResponse> {
+        val now = LocalDateTime.now()
+        val legacy = dailyStockRepository.findAllByStatusWithProduct(DailyStockStatus.OPEN)
+            .filter { it.startAt == null }
+        val timeSale = dailyStockRepository.findActiveTimeSaleStocks(DailyStockStatus.OPEN, now)
+        return (legacy + timeSale).map { OpenDailyStockResponse.from(it) }
+    }
 
     @Transactional(readOnly = true)
     override fun getParticipatedStockIds(userId: Long): List<Long> =

--- a/deal-api-user/src/main/kotlin/com/chaltteok/user/order/service/OrderServiceImpl.kt
+++ b/deal-api-user/src/main/kotlin/com/chaltteok/user/order/service/OrderServiceImpl.kt
@@ -36,7 +36,8 @@ class OrderServiceImpl(
             throw BusinessException(OrderErrorCode.STOCK_NOT_AVAILABLE)
         }
 
-        if (eventHistoryRepository.existsByUser_IdAndDailyStock_Id(userId, dailyStock.id)) {
+        val participationCount = eventHistoryRepository.countByUser_IdAndDailyStock_Id(userId, dailyStock.id)
+        if (participationCount >= dailyStock.maxPurchaseCount) {
             throw BusinessException(OrderErrorCode.ALREADY_PARTICIPATED)
         }
 

--- a/deal-core/src/main/kotlin/com/chaltteok/core/domain/DailyStock.kt
+++ b/deal-core/src/main/kotlin/com/chaltteok/core/domain/DailyStock.kt
@@ -44,6 +44,15 @@ class DailyStock(
     @Column(length = 20)
     var status: DailyStockStatus = DailyStockStatus.OPEN,
 
+    @Column(name = "start_at")
+    val startAt: LocalDateTime? = null,
+
+    @Column(name = "end_at")
+    val endAt: LocalDateTime? = null,
+
+    @Column(name = "max_purchase_count", nullable = false)
+    val maxPurchaseCount: Int = 1,
+
     @Column(name = "created_at", nullable = false, updatable = false)
     val createdAt: LocalDateTime = LocalDateTime.now()
 

--- a/deal-core/src/main/kotlin/com/chaltteok/core/domain/enums/DailyStockStatus.kt
+++ b/deal-core/src/main/kotlin/com/chaltteok/core/domain/enums/DailyStockStatus.kt
@@ -1,5 +1,5 @@
 package com.chaltteok.core.domain.enums
 
 enum class DailyStockStatus {
-    OPEN, SOLD_OUT, CLOSED
+    SCHEDULED, OPEN, SOLD_OUT, CLOSED
 }

--- a/deal-core/src/main/kotlin/com/chaltteok/core/repository/dailystock/DailyStockRepository.kt
+++ b/deal-core/src/main/kotlin/com/chaltteok/core/repository/dailystock/DailyStockRepository.kt
@@ -17,4 +17,8 @@ interface DailyStockRepository : JpaRepository<DailyStock, Long>, DailStockRepos
     @Query("UPDATE DailyStock ds SET ds.status = com.chaltteok.core.domain.enums.DailyStockStatus.CLOSED WHERE ds.endAt < :now AND ds.status = com.chaltteok.core.domain.enums.DailyStockStatus.OPEN")
     @Modifying
     fun closeExpiredStocks(now: LocalDateTime): Int
+
+    @Query("UPDATE DailyStock ds SET ds.status = com.chaltteok.core.domain.enums.DailyStockStatus.OPEN WHERE ds.startAt <= :now AND ds.status = com.chaltteok.core.domain.enums.DailyStockStatus.SCHEDULED")
+    @Modifying
+    fun openScheduledStocks(now: LocalDateTime): Int
 }

--- a/deal-core/src/main/kotlin/com/chaltteok/core/repository/dailystock/DailyStockRepository.kt
+++ b/deal-core/src/main/kotlin/com/chaltteok/core/repository/dailystock/DailyStockRepository.kt
@@ -3,9 +3,18 @@ package com.chaltteok.core.repository.dailystock
 import com.chaltteok.core.domain.DailyStock
 import com.chaltteok.core.domain.enums.DailyStockStatus
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Modifying
 import org.springframework.data.jpa.repository.Query
+import java.time.LocalDateTime
 
 interface DailyStockRepository : JpaRepository<DailyStock, Long>, DailStockRepositoryCustom {
     @Query("SELECT ds FROM DailyStock ds JOIN FETCH ds.product WHERE ds.status = :status")
     fun findAllByStatusWithProduct(status: DailyStockStatus): List<DailyStock>
+
+    @Query("SELECT ds FROM DailyStock ds JOIN FETCH ds.product WHERE ds.status = :status AND ds.startAt <= :now AND ds.endAt >= :now")
+    fun findActiveTimeSaleStocks(status: DailyStockStatus, now: LocalDateTime): List<DailyStock>
+
+    @Query("UPDATE DailyStock ds SET ds.status = com.chaltteok.core.domain.enums.DailyStockStatus.CLOSED WHERE ds.endAt < :now AND ds.status = com.chaltteok.core.domain.enums.DailyStockStatus.OPEN")
+    @Modifying
+    fun closeExpiredStocks(now: LocalDateTime): Int
 }

--- a/deal-core/src/main/kotlin/com/chaltteok/core/repository/eventhistory/EventHistoryRepository.kt
+++ b/deal-core/src/main/kotlin/com/chaltteok/core/repository/eventhistory/EventHistoryRepository.kt
@@ -9,4 +9,5 @@ interface EventHistoryRepository : JpaRepository<EventHistory, Long>, EventHisto
     fun findByUserAndDailyStock(user: User, dailyStock: DailyStock): EventHistory?
     fun findAllByUser_Id(userId: Long): List<EventHistory>
     fun existsByUser_IdAndDailyStock_Id(userId: Long, dailyStockId: Long?): Boolean
+    fun countByUser_IdAndDailyStock_Id(userId: Long, dailyStockId: Long?): Long
 }


### PR DESCRIPTION
## Summary
- `DailyStock` 엔티티에 `startAt`/`endAt` 컬럼 추가로 시간 기반 타임세일 구조 전환
- 기존 레거시 일별 오픈 방식과 완전 호환 유지 (startAt == null 여부로 구분)
- 매분 스케줄러로 만료된 타임세일 자동 CLOSED 처리

## Changes
| 파일 | 변경 내용 |
|------|---------|
| `DailyStock.kt` | `startAt`, `endAt`, `maxPurchaseCount` 필드 추가 |
| `DailyStockStatus.kt` | `SCHEDULED` 상태 추가 |
| `DailyStockType.kt` | `TIMESALE` 타입 추가 |
| `DailyStocksRegisterRequest.kt` | `startAt`, `endAt`, `maxPurchaseCount` 입력 + TIMESALE 필수 검증 |
| `DailyStockServiceImpl.kt` | startAt 기준 SCHEDULED/OPEN 초기 상태 결정 |
| `DailyStockRepository.kt` | `findActiveTimeSaleStocks`, `closeExpiredStocks` 쿼리 추가 |
| `DailyStockQueryServiceImpl.kt` | 레거시+타임세일 합산 반환 |
| `OpenDailyStockResponse.kt` | `startAt`, `endAt`, `maxPurchaseCount` 포함 |
| `ProductStockScheduler.kt` | 매분 만료 타임세일 자동 CLOSED 처리 |
| `add_timesale_columns.sql` | DB 마이그레이션: 컬럼 3개 + 인덱스 추가 |

## Test plan
- [ ] TIMESALE 타입으로 startAt/endAt 있는 daily-stock 등록 → SCHEDULED/OPEN 초기 상태 확인
- [ ] 현재 시각이 [startAt, endAt] 범위인 타임세일만 유저 API에서 반환되는지 확인
- [ ] endAt 경과 후 매분 스케줄러에 의해 CLOSED 전환 확인
- [ ] NORMAL 타입 기존 재고 정상 반환 확인 (레거시 호환)
- [ ] DB 마이그레이션 적용 후 기존 데이터 무결성 확인

Resolves #87

🤖 Generated with Claude Code