### PR TITLE
[FEAT] 점주 daily-stocks 목록 조회/수정/삭제 API 추가

### DIFF
--- a/deal-api-owner/src/main/kotlin/com/chaltteok/owner/dailystock/controller/DailyStocksController.kt
+++ b/deal-api-owner/src/main/kotlin/com/chaltteok/owner/dailystock/controller/DailyStocksController.kt
@@ -2,11 +2,16 @@ package com.chaltteok.owner.dailystock.controller
 
 import com.chaltteok.common.dto.ResponseDTO
 import com.chaltteok.owner.dailystock.dto.DailyStocksRegisterRequest
+import com.chaltteok.owner.dailystock.dto.OwnerDailyStockListResponse
 import com.chaltteok.owner.dailystock.service.DailyStockService
 import jakarta.validation.Valid
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.DeleteMapping
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.PutMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
@@ -16,10 +21,29 @@ import org.springframework.web.bind.annotation.RestController
 class DailyStocksController(
     private val dailyStockService: DailyStockService
 ) {
+    @GetMapping
+    fun getDailyStocks(): ResponseEntity<ResponseDTO<List<OwnerDailyStockListResponse>>> =
+        ResponseEntity.ok(ResponseDTO.success(dailyStockService.findAllDailyStocks()))
+
     @PostMapping
     fun createDailyStock(@Valid @RequestBody dailyStocksRegisterRequest: DailyStocksRegisterRequest)
             : ResponseEntity<ResponseDTO<Any>> {
         dailyStockService.registerDailyStock(dailyStocksRegisterRequest)
-        return ResponseEntity.status(HttpStatus.CREATED).body(ResponseDTO.success());
+        return ResponseEntity.status(HttpStatus.CREATED).body(ResponseDTO.success())
+    }
+
+    @PutMapping("/{stockUuid}")
+    fun updateDailyStock(
+        @PathVariable stockUuid: String,
+        @Valid @RequestBody request: DailyStocksRegisterRequest,
+    ): ResponseEntity<ResponseDTO<Any>> {
+        dailyStockService.updateDailyStock(stockUuid, request)
+        return ResponseEntity.ok(ResponseDTO.success())
+    }
+
+    @DeleteMapping("/{stockUuid}")
+    fun deleteDailyStock(@PathVariable stockUuid: String): ResponseEntity<ResponseDTO<Any>> {
+        dailyStockService.deleteDailyStock(stockUuid)
+        return ResponseEntity.ok(ResponseDTO.success())
     }
 }

--- a/deal-api-owner/src/main/kotlin/com/chaltteok/owner/dailystock/dto/OwnerDailyStockListResponse.kt
+++ b/deal-api-owner/src/main/kotlin/com/chaltteok/owner/dailystock/dto/OwnerDailyStockListResponse.kt
@@ -5,7 +5,6 @@ import java.time.LocalDate
 import java.time.LocalDateTime
 
 data class OwnerDailyStockListResponse(
-    val id: Long,
     val uuid: String,
     val productUuid: String,
     val productName: String,
@@ -22,7 +21,6 @@ data class OwnerDailyStockListResponse(
 ) {
     companion object {
         fun from(stock: DailyStock, optionUuid: String) = OwnerDailyStockListResponse(
-            id = stock.id!!,
             uuid = stock.stockUuid,
             productUuid = stock.product.productUuid,
             productName = stock.product.name,

--- a/deal-api-owner/src/main/kotlin/com/chaltteok/owner/dailystock/dto/OwnerDailyStockListResponse.kt
+++ b/deal-api-owner/src/main/kotlin/com/chaltteok/owner/dailystock/dto/OwnerDailyStockListResponse.kt
@@ -1,0 +1,41 @@
+package com.chaltteok.owner.dailystock.dto
+
+import com.chaltteok.core.domain.DailyStock
+import java.time.LocalDate
+import java.time.LocalDateTime
+
+data class OwnerDailyStockListResponse(
+    val id: Long,
+    val uuid: String,
+    val productUuid: String,
+    val productName: String,
+    val optionUuid: String,
+    val saleDate: LocalDate,
+    val stockType: String,
+    val salePrice: Int,
+    val totalQty: Int,
+    val remainStock: Int,
+    val status: String,
+    val startAt: LocalDateTime?,
+    val endAt: LocalDateTime?,
+    val maxPurchaseCount: Int,
+) {
+    companion object {
+        fun from(stock: DailyStock, optionUuid: String) = OwnerDailyStockListResponse(
+            id = stock.id!!,
+            uuid = stock.stockUuid,
+            productUuid = stock.product.productUuid,
+            productName = stock.product.name,
+            optionUuid = optionUuid,
+            saleDate = stock.saleDate,
+            stockType = stock.stockType,
+            salePrice = stock.salePrice,
+            totalQty = stock.totalQty,
+            remainStock = stock.remainStock,
+            status = stock.status.name,
+            startAt = stock.startAt,
+            endAt = stock.endAt,
+            maxPurchaseCount = stock.maxPurchaseCount,
+        )
+    }
+}

--- a/deal-api-owner/src/main/kotlin/com/chaltteok/owner/dailystock/enums/DailyStockErrorCode.kt
+++ b/deal-api-owner/src/main/kotlin/com/chaltteok/owner/dailystock/enums/DailyStockErrorCode.kt
@@ -7,7 +7,8 @@ enum class DailyStockErrorCode (
     override val message: String,
     override val status: HttpStatus
 ):ErrorCode{
-    INVALID_ID("Invalid id",HttpStatus.BAD_REQUEST),
-    EVENT_PRICE_REQUIRED("I don't have a price",HttpStatus.BAD_REQUEST),
-    DUPLICATE_STOCK("It's already registered in stock",HttpStatus.BAD_REQUEST),
+    INVALID_ID("Invalid stock id", HttpStatus.BAD_REQUEST),
+    INVALID_OPTION_ID("Invalid option id", HttpStatus.BAD_REQUEST),
+    EVENT_PRICE_REQUIRED("I don't have a price", HttpStatus.BAD_REQUEST),
+    DUPLICATE_STOCK("It's already registered in stock", HttpStatus.BAD_REQUEST),
 }

--- a/deal-api-owner/src/main/kotlin/com/chaltteok/owner/dailystock/service/DailyStockService.kt
+++ b/deal-api-owner/src/main/kotlin/com/chaltteok/owner/dailystock/service/DailyStockService.kt
@@ -1,7 +1,11 @@
 package com.chaltteok.owner.dailystock.service
 
 import com.chaltteok.owner.dailystock.dto.DailyStocksRegisterRequest
+import com.chaltteok.owner.dailystock.dto.OwnerDailyStockListResponse
 
 interface DailyStockService {
     fun registerDailyStock(dailyStocksRegisterRequest: DailyStocksRegisterRequest)
+    fun findAllDailyStocks(): List<OwnerDailyStockListResponse>
+    fun deleteDailyStock(stockUuid: String)
+    fun updateDailyStock(stockUuid: String, request: DailyStocksRegisterRequest)
 }

--- a/deal-api-owner/src/main/kotlin/com/chaltteok/owner/dailystock/service/DailyStockServiceImpl.kt
+++ b/deal-api-owner/src/main/kotlin/com/chaltteok/owner/dailystock/service/DailyStockServiceImpl.kt
@@ -5,11 +5,13 @@ import com.chaltteok.core.domain.enums.DailyStockStatus
 import com.chaltteok.core.repository.dailystock.DailyStockRepository
 import com.chaltteok.core.repository.productoption.ProductOptionRepository
 import com.chaltteok.owner.dailystock.dto.DailyStocksRegisterRequest
+import com.chaltteok.owner.dailystock.dto.OwnerDailyStockListResponse
 import com.chaltteok.owner.dailystock.enums.DailyStockErrorCode
 import com.chaltteok.owner.dailystock.enums.DailyStockType
 import io.github.oshai.kotlinlogging.KotlinLogging
 import org.springframework.dao.DataIntegrityViolationException
 import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
 import java.time.LocalDateTime
 
 private val logger = KotlinLogging.logger {}
@@ -50,6 +52,42 @@ class DailyStockServiceImpl(
             logger.info { "daily stock registered successfully" }
         } catch (e: DataIntegrityViolationException) {
             logger.warn { "Duplicate stock registration attempt" }
+            throw BusinessException(DailyStockErrorCode.DUPLICATE_STOCK)
+        }
+    }
+
+    @Transactional(readOnly = true)
+    override fun findAllDailyStocks(): List<OwnerDailyStockListResponse> {
+        return dailyStockRepository.findAllWithProduct().map { stock ->
+            val optionUuid = productOptionRepository.findFirstByProduct(stock.product)
+                .map { it.optionUuid }.orElse("")
+            OwnerDailyStockListResponse.from(stock, optionUuid)
+        }
+    }
+
+    @Transactional
+    override fun deleteDailyStock(stockUuid: String) {
+        val stock = dailyStockRepository.findByStockUuid(stockUuid)
+            ?: throw BusinessException(DailyStockErrorCode.INVALID_ID)
+        dailyStockRepository.delete(stock)
+        logger.info { "daily stock deleted: $stockUuid" }
+    }
+
+    @Transactional
+    override fun updateDailyStock(stockUuid: String, request: DailyStocksRegisterRequest) {
+        val existing = dailyStockRepository.findByStockUuid(stockUuid)
+            ?: throw BusinessException(DailyStockErrorCode.INVALID_ID)
+        val productOption = productOptionRepository.findProductOptionByOptionUuid(request.optionId)
+            .orElseThrow { BusinessException(DailyStockErrorCode.INVALID_ID) }
+        val finalPrice = request.salePrice ?: productOption.price
+        val newStock = request.toDailyStockEntity(productOption.product, finalPrice, existing.status)
+        dailyStockRepository.delete(existing)
+        dailyStockRepository.flush()
+        try {
+            dailyStockRepository.save(newStock)
+            logger.info { "daily stock updated: $stockUuid" }
+        } catch (e: DataIntegrityViolationException) {
+            logger.warn { "Duplicate stock on update" }
             throw BusinessException(DailyStockErrorCode.DUPLICATE_STOCK)
         }
     }

--- a/deal-api-owner/src/main/kotlin/com/chaltteok/owner/dailystock/service/DailyStockServiceImpl.kt
+++ b/deal-api-owner/src/main/kotlin/com/chaltteok/owner/dailystock/service/DailyStockServiceImpl.kt
@@ -58,9 +58,12 @@ class DailyStockServiceImpl(
 
     @Transactional(readOnly = true)
     override fun findAllDailyStocks(): List<OwnerDailyStockListResponse> {
-        return dailyStockRepository.findAllWithProduct().map { stock ->
-            val optionUuid = productOptionRepository.findFirstByProduct(stock.product)
-                .map { it.optionUuid }.orElse("")
+        val stocks = dailyStockRepository.findAllWithProduct()
+        val optionMap = productOptionRepository
+            .findAllByProductIn(stocks.map { it.product }.distinctBy { it.id })
+            .associateBy { it.product.id }
+        return stocks.map { stock ->
+            val optionUuid = optionMap[stock.product.id]?.optionUuid ?: ""
             OwnerDailyStockListResponse.from(stock, optionUuid)
         }
     }
@@ -78,17 +81,9 @@ class DailyStockServiceImpl(
         val existing = dailyStockRepository.findByStockUuid(stockUuid)
             ?: throw BusinessException(DailyStockErrorCode.INVALID_ID)
         val productOption = productOptionRepository.findProductOptionByOptionUuid(request.optionId)
-            .orElseThrow { BusinessException(DailyStockErrorCode.INVALID_ID) }
+            .orElseThrow { BusinessException(DailyStockErrorCode.INVALID_OPTION_ID) }
         val finalPrice = request.salePrice ?: productOption.price
-        val newStock = request.toDailyStockEntity(productOption.product, finalPrice, existing.status)
-        dailyStockRepository.delete(existing)
-        dailyStockRepository.flush()
-        try {
-            dailyStockRepository.save(newStock)
-            logger.info { "daily stock updated: $stockUuid" }
-        } catch (e: DataIntegrityViolationException) {
-            logger.warn { "Duplicate stock on update" }
-            throw BusinessException(DailyStockErrorCode.DUPLICATE_STOCK)
-        }
+        existing.update(finalPrice, request.totalQty, request.startAt, request.endAt, request.maxPurchaseCount)
+        logger.info { "daily stock updated: $stockUuid" }
     }
 }

--- a/deal-core/src/main/kotlin/com/chaltteok/core/domain/DailyStock.kt
+++ b/deal-core/src/main/kotlin/com/chaltteok/core/domain/DailyStock.kt
@@ -29,10 +29,10 @@ class DailyStock(
     val stockType: String = "NORMAL",
 
     @Column(name = "sale_price", nullable = false)
-    val salePrice: Int,
+    var salePrice: Int,
 
     @Column(name = "total_qty", nullable = false)
-    val totalQty: Int,
+    var totalQty: Int,
 
     @Column(name = "remain_stock", nullable = false)
     var remainStock: Int,
@@ -45,13 +45,13 @@ class DailyStock(
     var status: DailyStockStatus = DailyStockStatus.OPEN,
 
     @Column(name = "start_at")
-    val startAt: LocalDateTime? = null,
+    var startAt: LocalDateTime? = null,
 
     @Column(name = "end_at")
-    val endAt: LocalDateTime? = null,
+    var endAt: LocalDateTime? = null,
 
     @Column(name = "max_purchase_count", nullable = false)
-    val maxPurchaseCount: Int = 1,
+    var maxPurchaseCount: Int = 1,
 
     @Column(name = "created_at", nullable = false, updatable = false)
     val createdAt: LocalDateTime = LocalDateTime.now()
@@ -64,4 +64,14 @@ class DailyStock(
 
     @Column(name = "stock_uuid", nullable = false, unique = true, length = 36)
     val stockUuid: String = UUID.randomUUID().toString()
+
+    fun update(salePrice: Int, totalQty: Int, startAt: LocalDateTime?, endAt: LocalDateTime?, maxPurchaseCount: Int) {
+        val qtyDelta = totalQty - this.totalQty
+        this.salePrice = salePrice
+        this.totalQty = totalQty
+        this.remainStock = maxOf(0, this.remainStock + qtyDelta)
+        this.startAt = startAt
+        this.endAt = endAt
+        this.maxPurchaseCount = maxPurchaseCount
+    }
 }

--- a/deal-core/src/main/kotlin/com/chaltteok/core/repository/dailystock/DailyStockRepository.kt
+++ b/deal-core/src/main/kotlin/com/chaltteok/core/repository/dailystock/DailyStockRepository.kt
@@ -8,6 +8,11 @@ import org.springframework.data.jpa.repository.Query
 import java.time.LocalDateTime
 
 interface DailyStockRepository : JpaRepository<DailyStock, Long>, DailStockRepositoryCustom {
+    @Query("SELECT ds FROM DailyStock ds JOIN FETCH ds.product")
+    fun findAllWithProduct(): List<DailyStock>
+
+    fun findByStockUuid(stockUuid: String): DailyStock?
+
     @Query("SELECT ds FROM DailyStock ds JOIN FETCH ds.product WHERE ds.status = :status")
     fun findAllByStatusWithProduct(status: DailyStockStatus): List<DailyStock>
 

--- a/deal-core/src/main/kotlin/com/chaltteok/core/repository/productoption/ProductOptionRepository.kt
+++ b/deal-core/src/main/kotlin/com/chaltteok/core/repository/productoption/ProductOptionRepository.kt
@@ -1,5 +1,6 @@
 package com.chaltteok.core.repository.productoption
 
+import com.chaltteok.core.domain.Product
 import com.chaltteok.core.domain.ProductOption
 import org.springframework.data.jpa.repository.JpaRepository
 import java.util.*
@@ -7,4 +8,5 @@ import java.util.*
 
 interface ProductOptionRepository : JpaRepository<ProductOption, Long>, ProductOptionRepositoryCustom {
     fun findProductOptionByOptionUuid(uuid: String): Optional<ProductOption>
+    fun findFirstByProduct(product: Product): Optional<ProductOption>
 }

--- a/deal-core/src/main/kotlin/com/chaltteok/core/repository/productoption/ProductOptionRepository.kt
+++ b/deal-core/src/main/kotlin/com/chaltteok/core/repository/productoption/ProductOptionRepository.kt
@@ -9,4 +9,5 @@ import java.util.*
 interface ProductOptionRepository : JpaRepository<ProductOption, Long>, ProductOptionRepositoryCustom {
     fun findProductOptionByOptionUuid(uuid: String): Optional<ProductOption>
     fun findFirstByProduct(product: Product): Optional<ProductOption>
+    fun findAllByProductIn(products: List<Product>): List<ProductOption>
 }


### PR DESCRIPTION
## Summary
- GET /api/v1/owner/daily-stocks 엔드포인트 신설로 405 에러 수정
- DELETE, PUT 엔드포인트도 함께 추가 (FE stock/product 페이지에서 필요)

## Changes
| 파일 | 변경 내용 |
|------|----------|
| DailyStocksController | GET / PUT / DELETE 엔드포인트 추가 |
| DailyStockService | findAllDailyStocks / deleteDailyStock / updateDailyStock 선언 |
| DailyStockServiceImpl | 위 3개 메서드 구현 |
| OwnerDailyStockListResponse | 점주용 목록 응답 DTO 신설 |
| DailyStockRepository | findAllWithProduct(), findByStockUuid() 추가 |
| ProductOptionRepository | findFirstByProduct() 추가 |

## Test plan
- [ ] GET /api/v1/owner/daily-stocks 200 응답 확인
- [ ] DELETE /api/v1/owner/daily-stocks/{uuid} 삭제 확인
- [ ] PUT /api/v1/owner/daily-stocks/{uuid} 수정 후 목록 재조회 확인
- [ ] 존재하지 않는 uuid로 DELETE/PUT 시 에러 반환 확인

Resolves #89

🤖 Generated with Claude Code