### PR TITLE
[FIX] 점주 타임세일 삭제 오류 및 유저 구매 플로우 통일

### DIFF
--- a/deal-api-owner/src/main/kotlin/com/chaltteok/owner/dailystock/service/DailyStockServiceImpl.kt
+++ b/deal-api-owner/src/main/kotlin/com/chaltteok/owner/dailystock/service/DailyStockServiceImpl.kt
@@ -3,6 +3,7 @@ package com.chaltteok.owner.dailystock.service
 import com.chaltteok.common.exception.BusinessException
 import com.chaltteok.core.domain.enums.DailyStockStatus
 import com.chaltteok.core.repository.dailystock.DailyStockRepository
+import com.chaltteok.core.repository.eventhistory.EventHistoryRepository
 import com.chaltteok.core.repository.productoption.ProductOptionRepository
 import com.chaltteok.owner.dailystock.dto.DailyStocksRegisterRequest
 import com.chaltteok.owner.dailystock.dto.OwnerDailyStockListResponse
@@ -20,6 +21,7 @@ private val logger = KotlinLogging.logger {}
 class DailyStockServiceImpl(
     private val dailyStockRepository: DailyStockRepository,
     private val productOptionRepository: ProductOptionRepository,
+    private val eventHistoryRepository: EventHistoryRepository,
 ) : DailyStockService {
     override fun registerDailyStock(dailyStocksRegisterRequest: DailyStocksRegisterRequest) {
         val productOption =
@@ -72,6 +74,7 @@ class DailyStockServiceImpl(
     override fun deleteDailyStock(stockUuid: String) {
         val stock = dailyStockRepository.findByStockUuid(stockUuid)
             ?: throw BusinessException(DailyStockErrorCode.INVALID_ID)
+        eventHistoryRepository.deleteAllByDailyStock(stock)
         dailyStockRepository.delete(stock)
         logger.info { "daily stock deleted: $stockUuid" }
     }

--- a/deal-api-user/src/main/kotlin/com/chaltteok/user/dailystock/controller/DailyStockQueryController.kt
+++ b/deal-api-user/src/main/kotlin/com/chaltteok/user/dailystock/controller/DailyStockQueryController.kt
@@ -18,7 +18,7 @@ class DailyStockQueryController(
         ResponseDTO.success(dailyStockQueryService.getOpenDailyStocks())
 
     @GetMapping("/participated")
-    fun getParticipatedStockIds(authentication: Authentication): ResponseDTO<List<Long>> {
+    fun getParticipatedStockIds(authentication: Authentication): ResponseDTO<List<String>> {
         val userId = authentication.principal as Long
         return ResponseDTO.success(dailyStockQueryService.getParticipatedStockIds(userId))
     }

--- a/deal-api-user/src/main/kotlin/com/chaltteok/user/dailystock/dto/OpenDailyStockResponse.kt
+++ b/deal-api-user/src/main/kotlin/com/chaltteok/user/dailystock/dto/OpenDailyStockResponse.kt
@@ -5,7 +5,7 @@ import java.time.LocalDate
 import java.time.LocalDateTime
 
 data class OpenDailyStockResponse(
-    val id: Long,
+    val uuid: String,
     val productName: String,
     val price: Long,
     val saleDate: LocalDate,
@@ -17,7 +17,7 @@ data class OpenDailyStockResponse(
 ) {
     companion object {
         fun from(dailyStock: DailyStock) = OpenDailyStockResponse(
-            id = dailyStock.id!!,
+            uuid = dailyStock.stockUuid,
             productName = dailyStock.product.name,
             price = dailyStock.product.price.toLong(),
             saleDate = dailyStock.saleDate,

--- a/deal-api-user/src/main/kotlin/com/chaltteok/user/dailystock/service/DailyStockQueryService.kt
+++ b/deal-api-user/src/main/kotlin/com/chaltteok/user/dailystock/service/DailyStockQueryService.kt
@@ -4,5 +4,5 @@ import com.chaltteok.user.dailystock.dto.OpenDailyStockResponse
 
 interface DailyStockQueryService {
     fun getOpenDailyStocks(): List<OpenDailyStockResponse>
-    fun getParticipatedStockIds(userId: Long): List<Long>
+    fun getParticipatedStockIds(userId: Long): List<String>
 }

--- a/deal-api-user/src/main/kotlin/com/chaltteok/user/dailystock/service/DailyStockQueryServiceImpl.kt
+++ b/deal-api-user/src/main/kotlin/com/chaltteok/user/dailystock/service/DailyStockQueryServiceImpl.kt
@@ -25,6 +25,5 @@ class DailyStockQueryServiceImpl(
 
     @Transactional(readOnly = true)
     override fun getParticipatedStockIds(userId: Long): List<String> =
-        eventHistoryRepository.findAllByUser_Id(userId)
-            .mapNotNull { it.dailyStock.stockUuid }
+        eventHistoryRepository.findStockUuidsByUserId(userId)
 }

--- a/deal-api-user/src/main/kotlin/com/chaltteok/user/dailystock/service/DailyStockQueryServiceImpl.kt
+++ b/deal-api-user/src/main/kotlin/com/chaltteok/user/dailystock/service/DailyStockQueryServiceImpl.kt
@@ -24,7 +24,7 @@ class DailyStockQueryServiceImpl(
     }
 
     @Transactional(readOnly = true)
-    override fun getParticipatedStockIds(userId: Long): List<Long> =
+    override fun getParticipatedStockIds(userId: Long): List<String> =
         eventHistoryRepository.findAllByUser_Id(userId)
-            .mapNotNull { it.dailyStock.id }
+            .mapNotNull { it.dailyStock.stockUuid }
 }

--- a/deal-api-user/src/main/kotlin/com/chaltteok/user/order/controller/OrderController.kt
+++ b/deal-api-user/src/main/kotlin/com/chaltteok/user/order/controller/OrderController.kt
@@ -1,6 +1,7 @@
 package com.chaltteok.user.order.controller
 
 import com.chaltteok.common.dto.ResponseDTO
+import com.chaltteok.user.checkout.dto.CheckoutResponse
 import com.chaltteok.user.order.dto.OrderRequest
 import com.chaltteok.user.order.service.OrderService
 import jakarta.validation.Valid
@@ -16,10 +17,10 @@ class OrderController(
     fun placeOrder(
         authentication: Authentication,
         @RequestBody @Valid request: OrderRequest,
-    ): ResponseDTO<String> {
+    ): ResponseDTO<CheckoutResponse> {
         val userId = authentication.principal as Long
-        orderService.placeOrder(userId, request)
-        return ResponseDTO.success("주문 요청이 접수되었습니다.")
+        val result = orderService.placeOrder(userId, request)
+        return ResponseDTO.success(result)
     }
 
     @PostMapping("/{orderNumber}/cancel")

--- a/deal-api-user/src/main/kotlin/com/chaltteok/user/order/dto/OrderRequest.kt
+++ b/deal-api-user/src/main/kotlin/com/chaltteok/user/order/dto/OrderRequest.kt
@@ -1,8 +1,8 @@
 package com.chaltteok.user.order.dto
 
-import jakarta.validation.constraints.NotNull
+import jakarta.validation.constraints.NotBlank
 
 data class OrderRequest(
-    @field:NotNull
-    val dailyStockId: Long,
+    @field:NotBlank
+    val stockUuid: String,
 )

--- a/deal-api-user/src/main/kotlin/com/chaltteok/user/order/enums/OrderErrorCode.kt
+++ b/deal-api-user/src/main/kotlin/com/chaltteok/user/order/enums/OrderErrorCode.kt
@@ -10,6 +10,7 @@ enum class OrderErrorCode(
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다."),
     DAILY_STOCK_NOT_FOUND(HttpStatus.NOT_FOUND, "일일 재고를 찾을 수 없습니다."),
     STOCK_NOT_AVAILABLE(HttpStatus.BAD_REQUEST, "주문 가능한 상태가 아닙니다."),
+    INSUFFICIENT_STOCK(HttpStatus.CONFLICT, "재고가 부족합니다."),
     ALREADY_PARTICIPATED(HttpStatus.CONFLICT, "이미 참여한 이벤트입니다."),
     ORDER_NOT_FOUND(HttpStatus.NOT_FOUND, "주문을 찾을 수 없습니다."),
     ORDER_ALREADY_CANCELLED(HttpStatus.BAD_REQUEST, "이미 취소된 주문입니다."),

--- a/deal-api-user/src/main/kotlin/com/chaltteok/user/order/service/OrderService.kt
+++ b/deal-api-user/src/main/kotlin/com/chaltteok/user/order/service/OrderService.kt
@@ -1,8 +1,9 @@
 package com.chaltteok.user.order.service
 
+import com.chaltteok.user.checkout.dto.CheckoutResponse
 import com.chaltteok.user.order.dto.OrderRequest
 
 interface OrderService {
-    fun placeOrder(userId: Long, request: OrderRequest)
+    fun placeOrder(userId: Long, request: OrderRequest): CheckoutResponse
     fun cancelOrder(userId: Long, orderNumber: String)
 }

--- a/deal-api-user/src/main/kotlin/com/chaltteok/user/order/service/OrderServiceImpl.kt
+++ b/deal-api-user/src/main/kotlin/com/chaltteok/user/order/service/OrderServiceImpl.kt
@@ -1,39 +1,56 @@
 package com.chaltteok.user.order.service
 
 import com.chaltteok.common.exception.BusinessException
+import com.chaltteok.core.domain.EventHistory
+import com.chaltteok.core.domain.Notification
+import com.chaltteok.core.domain.Order
+import com.chaltteok.core.domain.OrderItem
+import com.chaltteok.core.domain.Payment
 import com.chaltteok.core.domain.enums.DailyStockStatus
+import com.chaltteok.core.domain.enums.NotificationType
 import com.chaltteok.core.domain.enums.OrderStatus
+import com.chaltteok.core.domain.enums.PaymentStatus
 import com.chaltteok.core.repository.dailystock.DailyStockRepository
 import com.chaltteok.core.repository.eventhistory.EventHistoryRepository
+import com.chaltteok.core.repository.notification.NotificationRepository
 import com.chaltteok.core.repository.order.OrderRepository
+import com.chaltteok.core.repository.orderitem.OrderItemRepository
 import com.chaltteok.core.repository.payment.PaymentRepository
 import com.chaltteok.core.repository.user.UserRepository
-import com.chaltteok.user.infrastructure.kafka.OrderEventProducer
+import com.chaltteok.user.checkout.dto.CheckoutResponse
 import com.chaltteok.user.order.dto.OrderRequest
 import com.chaltteok.user.order.enums.OrderErrorCode
+import io.github.oshai.kotlinlogging.KotlinLogging
+import org.springframework.dao.DataIntegrityViolationException
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+
+private val logger = KotlinLogging.logger {}
 
 @Service
 class OrderServiceImpl(
     private val userRepository: UserRepository,
     private val dailyStockRepository: DailyStockRepository,
-    private val eventHistoryRepository: EventHistoryRepository,
-    private val orderEventProducer: OrderEventProducer,
     private val orderRepository: OrderRepository,
+    private val orderItemRepository: OrderItemRepository,
     private val paymentRepository: PaymentRepository,
+    private val eventHistoryRepository: EventHistoryRepository,
+    private val notificationRepository: NotificationRepository,
 ) : OrderService {
 
-    @Transactional(readOnly = true)
-    override fun placeOrder(userId: Long, request: OrderRequest) {
-        userRepository.findById(userId)
+    @Transactional
+    override fun placeOrder(userId: Long, request: OrderRequest): CheckoutResponse {
+        val user = userRepository.findById(userId)
             .orElseThrow { BusinessException(OrderErrorCode.USER_NOT_FOUND) }
 
-        val dailyStock = dailyStockRepository.findById(request.dailyStockId)
-            .orElseThrow { BusinessException(OrderErrorCode.DAILY_STOCK_NOT_FOUND) }
+        val dailyStock = dailyStockRepository.findByStockUuidWithLock(request.stockUuid)
+            ?: throw BusinessException(OrderErrorCode.DAILY_STOCK_NOT_FOUND)
 
         if (dailyStock.status != DailyStockStatus.OPEN) {
             throw BusinessException(OrderErrorCode.STOCK_NOT_AVAILABLE)
+        }
+        if (dailyStock.remainStock <= 0) {
+            throw BusinessException(OrderErrorCode.INSUFFICIENT_STOCK)
         }
 
         val participationCount = eventHistoryRepository.countByUser_IdAndDailyStock_Id(userId, dailyStock.id)
@@ -41,7 +58,40 @@ class OrderServiceImpl(
             throw BusinessException(OrderErrorCode.ALREADY_PARTICIPATED)
         }
 
-        orderEventProducer.sendOrderEvent(userId, dailyStock.id!!)
+        dailyStock.remainStock -= 1
+        if (dailyStock.remainStock == 0) dailyStock.status = DailyStockStatus.SOLD_OUT
+
+        val order = orderRepository.save(
+            Order(user = user, totalPrice = dailyStock.salePrice, status = OrderStatus.COMPLETED)
+        )
+        orderItemRepository.save(
+            OrderItem(order = order, product = dailyStock.product, quantity = 1, price = dailyStock.salePrice)
+        )
+        paymentRepository.save(
+            Payment(order = order, amount = dailyStock.salePrice, status = PaymentStatus.SUCCESS, paymentMethod = "TIMESALE")
+        )
+
+        try {
+            eventHistoryRepository.saveAndFlush(EventHistory(user = user, dailyStock = dailyStock, order = order))
+        } catch (e: DataIntegrityViolationException) {
+            throw BusinessException(OrderErrorCode.ALREADY_PARTICIPATED)
+        }
+
+        notificationRepository.save(
+            Notification(
+                type = NotificationType.ORDER.name,
+                title = "새 주문이 들어왔습니다",
+                message = "${dailyStock.product.name} (%,d원)".format(dailyStock.salePrice),
+            )
+        )
+
+        logger.info { "타임세일 주문 완료 — userId=$userId, stockUuid=${request.stockUuid}, orderId=${order.id}" }
+
+        return CheckoutResponse(
+            orderId = order.id!!,
+            totalAmount = dailyStock.salePrice.toLong(),
+            status = order.status.name,
+        )
     }
 
     @Transactional

--- a/deal-api-user/src/main/kotlin/com/chaltteok/user/order/service/OrderServiceImpl.kt
+++ b/deal-api-user/src/main/kotlin/com/chaltteok/user/order/service/OrderServiceImpl.kt
@@ -21,7 +21,6 @@ import com.chaltteok.user.checkout.dto.CheckoutResponse
 import com.chaltteok.user.order.dto.OrderRequest
 import com.chaltteok.user.order.enums.OrderErrorCode
 import io.github.oshai.kotlinlogging.KotlinLogging
-import org.springframework.dao.DataIntegrityViolationException
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
@@ -58,8 +57,7 @@ class OrderServiceImpl(
             throw BusinessException(OrderErrorCode.ALREADY_PARTICIPATED)
         }
 
-        dailyStock.remainStock -= 1
-        if (dailyStock.remainStock == 0) dailyStock.status = DailyStockStatus.SOLD_OUT
+        dailyStock.decrease()
 
         val order = orderRepository.save(
             Order(user = user, totalPrice = dailyStock.salePrice, status = OrderStatus.COMPLETED)
@@ -70,12 +68,7 @@ class OrderServiceImpl(
         paymentRepository.save(
             Payment(order = order, amount = dailyStock.salePrice, status = PaymentStatus.SUCCESS, paymentMethod = "TIMESALE")
         )
-
-        try {
-            eventHistoryRepository.saveAndFlush(EventHistory(user = user, dailyStock = dailyStock, order = order))
-        } catch (e: DataIntegrityViolationException) {
-            throw BusinessException(OrderErrorCode.ALREADY_PARTICIPATED)
-        }
+        eventHistoryRepository.save(EventHistory(user = user, dailyStock = dailyStock, order = order))
 
         notificationRepository.save(
             Notification(
@@ -85,10 +78,11 @@ class OrderServiceImpl(
             )
         )
 
-        logger.info { "타임세일 주문 완료 — userId=$userId, stockUuid=${request.stockUuid}, orderId=${order.id}" }
+        logger.info { "타임세일 주문 완료 — stockUuid=${request.stockUuid}, orderNumber=${order.orderNumber}" }
 
+        val orderId = order.id ?: error("Order ID가 저장 후에도 null입니다")
         return CheckoutResponse(
-            orderId = order.id!!,
+            orderId = orderId,
             totalAmount = dailyStock.salePrice.toLong(),
             status = order.status.name,
         )

--- a/deal-core/src/main/kotlin/com/chaltteok/core/domain/DailyStock.kt
+++ b/deal-core/src/main/kotlin/com/chaltteok/core/domain/DailyStock.kt
@@ -65,6 +65,12 @@ class DailyStock(
     @Column(name = "stock_uuid", nullable = false, unique = true, length = 36)
     val stockUuid: String = UUID.randomUUID().toString()
 
+    fun decrease() {
+        check(remainStock > 0) { "재고가 없습니다" }
+        remainStock -= 1
+        if (remainStock == 0) status = DailyStockStatus.SOLD_OUT
+    }
+
     fun update(salePrice: Int, totalQty: Int, startAt: LocalDateTime?, endAt: LocalDateTime?, maxPurchaseCount: Int) {
         val qtyDelta = totalQty - this.totalQty
         this.salePrice = salePrice

--- a/deal-core/src/main/kotlin/com/chaltteok/core/repository/dailystock/DailyStockRepository.kt
+++ b/deal-core/src/main/kotlin/com/chaltteok/core/repository/dailystock/DailyStockRepository.kt
@@ -2,7 +2,9 @@ package com.chaltteok.core.repository.dailystock
 
 import com.chaltteok.core.domain.DailyStock
 import com.chaltteok.core.domain.enums.DailyStockStatus
+import jakarta.persistence.LockModeType
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Lock
 import org.springframework.data.jpa.repository.Modifying
 import org.springframework.data.jpa.repository.Query
 import java.time.LocalDateTime
@@ -12,6 +14,10 @@ interface DailyStockRepository : JpaRepository<DailyStock, Long>, DailStockRepos
     fun findAllWithProduct(): List<DailyStock>
 
     fun findByStockUuid(stockUuid: String): DailyStock?
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT ds FROM DailyStock ds JOIN FETCH ds.product WHERE ds.stockUuid = :uuid")
+    fun findByStockUuidWithLock(uuid: String): DailyStock?
 
     @Query("SELECT ds FROM DailyStock ds JOIN FETCH ds.product WHERE ds.status = :status")
     fun findAllByStatusWithProduct(status: DailyStockStatus): List<DailyStock>

--- a/deal-core/src/main/kotlin/com/chaltteok/core/repository/eventhistory/EventHistoryRepository.kt
+++ b/deal-core/src/main/kotlin/com/chaltteok/core/repository/eventhistory/EventHistoryRepository.kt
@@ -4,11 +4,20 @@ import com.chaltteok.core.domain.DailyStock
 import com.chaltteok.core.domain.EventHistory
 import com.chaltteok.core.domain.User
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Modifying
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
 
 interface EventHistoryRepository : JpaRepository<EventHistory, Long>, EventHistoryRepositoryCustom {
     fun findByUserAndDailyStock(user: User, dailyStock: DailyStock): EventHistory?
     fun findAllByUser_Id(userId: Long): List<EventHistory>
     fun existsByUser_IdAndDailyStock_Id(userId: Long, dailyStockId: Long?): Boolean
     fun countByUser_IdAndDailyStock_Id(userId: Long, dailyStockId: Long?): Long
-    fun deleteAllByDailyStock(dailyStock: DailyStock)
+
+    @Modifying
+    @Query("DELETE FROM EventHistory eh WHERE eh.dailyStock = :dailyStock")
+    fun deleteAllByDailyStock(@Param("dailyStock") dailyStock: DailyStock)
+
+    @Query("SELECT eh.dailyStock.stockUuid FROM EventHistory eh WHERE eh.user.id = :userId")
+    fun findStockUuidsByUserId(@Param("userId") userId: Long): List<String>
 }

--- a/deal-core/src/main/kotlin/com/chaltteok/core/repository/eventhistory/EventHistoryRepository.kt
+++ b/deal-core/src/main/kotlin/com/chaltteok/core/repository/eventhistory/EventHistoryRepository.kt
@@ -10,4 +10,5 @@ interface EventHistoryRepository : JpaRepository<EventHistory, Long>, EventHisto
     fun findAllByUser_Id(userId: Long): List<EventHistory>
     fun existsByUser_IdAndDailyStock_Id(userId: Long, dailyStockId: Long?): Boolean
     fun countByUser_IdAndDailyStock_Id(userId: Long, dailyStockId: Long?): Long
+    fun deleteAllByDailyStock(dailyStock: DailyStock)
 }


### PR DESCRIPTION
## Summary
- 점주가 타임세일을 삭제할 때 FK 제약 위반으로 발생하던 오류 수정
- 유저 타임세일 구매를 Kafka 비동기에서 일반상품 결제와 동일한 동기 플로우로 변경
- `OpenDailyStockResponse` 내부 PK `id` 제거 → `uuid` 노출 (아키텍처 규칙 준수)

## Changes

| 파일 | 변경 |
|------|------|
| `EventHistoryRepository` | `deleteAllByDailyStock()` 추가 |
| `DailyStockRepository` | `findByStockUuidWithLock()` 추가 (비관적 락) |
| `DailyStockServiceImpl` (owner) | 삭제 전 EventHistory 선행 제거 |
| `OpenDailyStockResponse` | `id: Long` 제거, `uuid: String` 추가 |
| `DailyStockQueryService/Impl/Controller` | `getParticipatedStockIds()` 반환 `List<String>` |
| `OrderRequest` | `dailyStockId: Long` → `stockUuid: String` |
| `OrderErrorCode` | `INSUFFICIENT_STOCK` 추가 |
| `OrderServiceImpl` | Kafka 제거, 비관적 락 + 동기 Order/Payment/EventHistory 생성 |
| `OrderController` | 응답 `String` → `CheckoutResponse` |

## Test plan
- [ ] 점주: EventHistory가 있는 타임세일 삭제 정상 처리
- [ ] 유저: 타임세일 구매 시 즉시 orderId/totalAmount 응답 수신
- [ ] 유저: 중복 구매 시 ALREADY_PARTICIPATED 오류
- [ ] 유저: 재고 소진 시 INSUFFICIENT_STOCK 오류

Resolves #91

🤖 Generated with Claude Code