### PR TITLE
[FEAT] 타임세일 수량 선택 구매 및 상품 목록 productUuid 노출

### DIFF
--- a/deal-api-user/src/main/kotlin/com/chaltteok/user/dailystock/dto/OpenDailyStockResponse.kt
+++ b/deal-api-user/src/main/kotlin/com/chaltteok/user/dailystock/dto/OpenDailyStockResponse.kt
@@ -6,6 +6,7 @@ import java.time.LocalDateTime
 
 data class OpenDailyStockResponse(
     val uuid: String,
+    val productUuid: String,
     val productName: String,
     val price: Long,
     val saleDate: LocalDate,
@@ -18,6 +19,7 @@ data class OpenDailyStockResponse(
     companion object {
         fun from(dailyStock: DailyStock) = OpenDailyStockResponse(
             uuid = dailyStock.stockUuid,
+            productUuid = dailyStock.product.productUuid,
             productName = dailyStock.product.name,
             price = dailyStock.product.price.toLong(),
             saleDate = dailyStock.saleDate,

--- a/deal-api-user/src/main/kotlin/com/chaltteok/user/order/dto/OrderRequest.kt
+++ b/deal-api-user/src/main/kotlin/com/chaltteok/user/order/dto/OrderRequest.kt
@@ -1,11 +1,12 @@
 package com.chaltteok.user.order.dto
 
+import jakarta.validation.constraints.Max
 import jakarta.validation.constraints.Min
 import jakarta.validation.constraints.NotBlank
 
 data class OrderRequest(
     @field:NotBlank
     val stockUuid: String,
-    @field:Min(1)
+    @field:Min(1) @field:Max(100)
     val quantity: Int = 1,
 )

--- a/deal-api-user/src/main/kotlin/com/chaltteok/user/order/dto/OrderRequest.kt
+++ b/deal-api-user/src/main/kotlin/com/chaltteok/user/order/dto/OrderRequest.kt
@@ -1,8 +1,11 @@
 package com.chaltteok.user.order.dto
 
+import jakarta.validation.constraints.Min
 import jakarta.validation.constraints.NotBlank
 
 data class OrderRequest(
     @field:NotBlank
     val stockUuid: String,
+    @field:Min(1)
+    val quantity: Int = 1,
 )

--- a/deal-api-user/src/main/kotlin/com/chaltteok/user/order/enums/OrderErrorCode.kt
+++ b/deal-api-user/src/main/kotlin/com/chaltteok/user/order/enums/OrderErrorCode.kt
@@ -12,6 +12,7 @@ enum class OrderErrorCode(
     STOCK_NOT_AVAILABLE(HttpStatus.BAD_REQUEST, "주문 가능한 상태가 아닙니다."),
     INSUFFICIENT_STOCK(HttpStatus.CONFLICT, "재고가 부족합니다."),
     ALREADY_PARTICIPATED(HttpStatus.CONFLICT, "이미 참여한 이벤트입니다."),
+    EXCEEDS_MAX_PURCHASE_COUNT(HttpStatus.BAD_REQUEST, "1인 최대 구매 수량을 초과했습니다."),
     ORDER_NOT_FOUND(HttpStatus.NOT_FOUND, "주문을 찾을 수 없습니다."),
     ORDER_ALREADY_CANCELLED(HttpStatus.BAD_REQUEST, "이미 취소된 주문입니다."),
     ORDER_NOT_CANCELLABLE(HttpStatus.BAD_REQUEST, "취소할 수 없는 주문 상태입니다."),

--- a/deal-api-user/src/main/kotlin/com/chaltteok/user/order/service/OrderServiceImpl.kt
+++ b/deal-api-user/src/main/kotlin/com/chaltteok/user/order/service/OrderServiceImpl.kt
@@ -48,25 +48,30 @@ class OrderServiceImpl(
         if (dailyStock.status != DailyStockStatus.OPEN) {
             throw BusinessException(OrderErrorCode.STOCK_NOT_AVAILABLE)
         }
-        if (dailyStock.remainStock <= 0) {
+        if (dailyStock.remainStock < request.quantity) {
             throw BusinessException(OrderErrorCode.INSUFFICIENT_STOCK)
         }
 
-        val participationCount = eventHistoryRepository.countByUser_IdAndDailyStock_Id(userId, dailyStock.id)
-        if (participationCount >= dailyStock.maxPurchaseCount) {
+        if (request.quantity > dailyStock.maxPurchaseCount) {
             throw BusinessException(OrderErrorCode.ALREADY_PARTICIPATED)
         }
 
-        dailyStock.decrease()
+        val participationCount = eventHistoryRepository.countByUser_IdAndDailyStock_Id(userId, dailyStock.id)
+        if (participationCount + request.quantity > dailyStock.maxPurchaseCount) {
+            throw BusinessException(OrderErrorCode.ALREADY_PARTICIPATED)
+        }
 
+        dailyStock.decrease(request.quantity)
+
+        val totalPrice = dailyStock.salePrice * request.quantity
         val order = orderRepository.save(
-            Order(user = user, totalPrice = dailyStock.salePrice, status = OrderStatus.COMPLETED)
+            Order(user = user, totalPrice = totalPrice, status = OrderStatus.COMPLETED)
         )
         orderItemRepository.save(
-            OrderItem(order = order, product = dailyStock.product, quantity = 1, price = dailyStock.salePrice)
+            OrderItem(order = order, product = dailyStock.product, quantity = request.quantity, price = dailyStock.salePrice)
         )
         paymentRepository.save(
-            Payment(order = order, amount = dailyStock.salePrice, status = PaymentStatus.SUCCESS, paymentMethod = "TIMESALE")
+            Payment(order = order, amount = totalPrice, status = PaymentStatus.SUCCESS, paymentMethod = "TIMESALE")
         )
         eventHistoryRepository.save(EventHistory(user = user, dailyStock = dailyStock, order = order))
 
@@ -83,7 +88,7 @@ class OrderServiceImpl(
         val orderId = order.id ?: error("Order ID가 저장 후에도 null입니다")
         return CheckoutResponse(
             orderId = orderId,
-            totalAmount = dailyStock.salePrice.toLong(),
+            totalAmount = (dailyStock.salePrice * request.quantity).toLong(),
             status = order.status.name,
         )
     }

--- a/deal-api-user/src/main/kotlin/com/chaltteok/user/order/service/OrderServiceImpl.kt
+++ b/deal-api-user/src/main/kotlin/com/chaltteok/user/order/service/OrderServiceImpl.kt
@@ -52,12 +52,11 @@ class OrderServiceImpl(
             throw BusinessException(OrderErrorCode.INSUFFICIENT_STOCK)
         }
 
-        if (request.quantity > dailyStock.maxPurchaseCount) {
-            throw BusinessException(OrderErrorCode.ALREADY_PARTICIPATED)
-        }
-
         val participationCount = eventHistoryRepository.countByUser_IdAndDailyStock_Id(userId, dailyStock.id)
         if (participationCount + request.quantity > dailyStock.maxPurchaseCount) {
+            if (participationCount == 0L) {
+                throw BusinessException(OrderErrorCode.EXCEEDS_MAX_PURCHASE_COUNT)
+            }
             throw BusinessException(OrderErrorCode.ALREADY_PARTICIPATED)
         }
 
@@ -88,7 +87,7 @@ class OrderServiceImpl(
         val orderId = order.id ?: error("Order ID가 저장 후에도 null입니다")
         return CheckoutResponse(
             orderId = orderId,
-            totalAmount = (dailyStock.salePrice * request.quantity).toLong(),
+            totalAmount = totalPrice.toLong(),
             status = order.status.name,
         )
     }

--- a/deal-core/src/main/kotlin/com/chaltteok/core/domain/DailyStock.kt
+++ b/deal-core/src/main/kotlin/com/chaltteok/core/domain/DailyStock.kt
@@ -65,9 +65,9 @@ class DailyStock(
     @Column(name = "stock_uuid", nullable = false, unique = true, length = 36)
     val stockUuid: String = UUID.randomUUID().toString()
 
-    fun decrease() {
-        check(remainStock > 0) { "재고가 없습니다" }
-        remainStock -= 1
+    fun decrease(quantity: Int = 1) {
+        check(remainStock >= quantity) { "재고가 부족합니다" }
+        remainStock -= quantity
         if (remainStock == 0) status = DailyStockStatus.SOLD_OUT
     }
 


### PR DESCRIPTION
## Summary
- 타임세일 상품 구매 시 수량 선택 지원 (1 ~ maxPurchaseCount 범위)
- OpenDailyStockResponse에 productUuid 노출 (FE 타임세일 필터링용)

## Changes

| 파일 | 변경 |
|------|------|
| `DailyStock.kt` | `decrease(quantity: Int = 1)` — 수량 기반 재고 차감 |
| `OrderRequest.kt` | `quantity: Int = 1` 추가 |
| `OrderServiceImpl.kt` | quantity 기반 재고/참여 검증, 총 금액 계산 |
| `OpenDailyStockResponse.kt` | `productUuid: String` 추가 |

## Test plan
- [ ] quantity=2 주문 시 remainStock 2 차감, totalPrice 2배
- [ ] quantity > maxPurchaseCount 시 ALREADY_PARTICIPATED 반환
- [ ] quantity > remainStock 시 INSUFFICIENT_STOCK 반환
- [ ] OpenDailyStockResponse에 productUuid 포함 확인

Resolves #93

🤖 Generated with Claude Code