### PR TITLE
[FEAT] 타임세일 maxPurchaseCount 선택 필드화 및 복수 참여 지원

### DIFF
--- a/db/migration/make_max_purchase_count_nullable.sql
+++ b/db/migration/make_max_purchase_count_nullable.sql
@@ -1,0 +1,5 @@
+-- max_purchase_count: null 허용 (null = 무제한)
+ALTER TABLE tb_daily_stocks MODIFY COLUMN max_purchase_count INT NULL DEFAULT NULL;
+
+-- EventHistory unique constraint 제거: 복수 구매 지원
+ALTER TABLE tb_event_history DROP INDEX uk_one_event_per_user;

--- a/deal-api-owner/src/main/kotlin/com/chaltteok/owner/dailystock/dto/DailyStocksRegisterRequest.kt
+++ b/deal-api-owner/src/main/kotlin/com/chaltteok/owner/dailystock/dto/DailyStocksRegisterRequest.kt
@@ -24,7 +24,7 @@ data class DailyStocksRegisterRequest(
 
     val startAt: LocalDateTime? = null,
     val endAt: LocalDateTime? = null,
-    val maxPurchaseCount: Int = 1,
+    val maxPurchaseCount: Int? = null,
 ) {
     init {
         if ((stockType ?: DailyStockType.NORMAL) == DailyStockType.TIMESALE) {

--- a/deal-api-owner/src/main/kotlin/com/chaltteok/owner/dailystock/dto/OwnerDailyStockListResponse.kt
+++ b/deal-api-owner/src/main/kotlin/com/chaltteok/owner/dailystock/dto/OwnerDailyStockListResponse.kt
@@ -17,7 +17,7 @@ data class OwnerDailyStockListResponse(
     val status: String,
     val startAt: LocalDateTime?,
     val endAt: LocalDateTime?,
-    val maxPurchaseCount: Int,
+    val maxPurchaseCount: Int?,
 ) {
     companion object {
         fun from(stock: DailyStock, optionUuid: String) = OwnerDailyStockListResponse(

--- a/deal-api-user/src/main/kotlin/com/chaltteok/user/dailystock/controller/DailyStockQueryController.kt
+++ b/deal-api-user/src/main/kotlin/com/chaltteok/user/dailystock/controller/DailyStockQueryController.kt
@@ -18,8 +18,8 @@ class DailyStockQueryController(
         ResponseDTO.success(dailyStockQueryService.getOpenDailyStocks())
 
     @GetMapping("/participated")
-    fun getParticipatedStockIds(authentication: Authentication): ResponseDTO<List<String>> {
+    fun getParticipationCounts(authentication: Authentication): ResponseDTO<Map<String, Int>> {
         val userId = authentication.principal as Long
-        return ResponseDTO.success(dailyStockQueryService.getParticipatedStockIds(userId))
+        return ResponseDTO.success(dailyStockQueryService.getParticipationCounts(userId))
     }
 }

--- a/deal-api-user/src/main/kotlin/com/chaltteok/user/dailystock/dto/OpenDailyStockResponse.kt
+++ b/deal-api-user/src/main/kotlin/com/chaltteok/user/dailystock/dto/OpenDailyStockResponse.kt
@@ -16,7 +16,7 @@ data class OpenDailyStockResponse(
     val totalStock: Int,
     val startAt: LocalDateTime?,
     val endAt: LocalDateTime?,
-    val maxPurchaseCount: Int,
+    val maxPurchaseCount: Int?,
 ) {
     companion object {
         fun from(dailyStock: DailyStock) = OpenDailyStockResponse(

--- a/deal-api-user/src/main/kotlin/com/chaltteok/user/dailystock/service/DailyStockQueryService.kt
+++ b/deal-api-user/src/main/kotlin/com/chaltteok/user/dailystock/service/DailyStockQueryService.kt
@@ -4,5 +4,5 @@ import com.chaltteok.user.dailystock.dto.OpenDailyStockResponse
 
 interface DailyStockQueryService {
     fun getOpenDailyStocks(): List<OpenDailyStockResponse>
-    fun getParticipatedStockIds(userId: Long): List<String>
+    fun getParticipationCounts(userId: Long): Map<String, Int>
 }

--- a/deal-api-user/src/main/kotlin/com/chaltteok/user/dailystock/service/DailyStockQueryServiceImpl.kt
+++ b/deal-api-user/src/main/kotlin/com/chaltteok/user/dailystock/service/DailyStockQueryServiceImpl.kt
@@ -24,6 +24,8 @@ class DailyStockQueryServiceImpl(
     }
 
     @Transactional(readOnly = true)
-    override fun getParticipatedStockIds(userId: Long): List<String> =
-        eventHistoryRepository.findStockUuidsByUserId(userId)
+    override fun getParticipationCounts(userId: Long): Map<String, Int> =
+        eventHistoryRepository.findAllWithStockByUserId(userId)
+            .groupBy { it.dailyStock.stockUuid }
+            .mapValues { it.value.size }
 }

--- a/deal-api-user/src/main/kotlin/com/chaltteok/user/order/service/OrderServiceImpl.kt
+++ b/deal-api-user/src/main/kotlin/com/chaltteok/user/order/service/OrderServiceImpl.kt
@@ -52,12 +52,15 @@ class OrderServiceImpl(
             throw BusinessException(OrderErrorCode.INSUFFICIENT_STOCK)
         }
 
-        val participationCount = eventHistoryRepository.countByUser_IdAndDailyStock_Id(userId, dailyStock.id)
-        if (participationCount + request.quantity > dailyStock.maxPurchaseCount) {
-            if (participationCount == 0L) {
-                throw BusinessException(OrderErrorCode.EXCEEDS_MAX_PURCHASE_COUNT)
+        val maxPurchaseCount = dailyStock.maxPurchaseCount
+        if (maxPurchaseCount != null) {
+            val participationCount = eventHistoryRepository.countByUser_IdAndDailyStock_Id(userId, dailyStock.id)
+            if (participationCount + request.quantity > maxPurchaseCount) {
+                if (participationCount == 0L) {
+                    throw BusinessException(OrderErrorCode.EXCEEDS_MAX_PURCHASE_COUNT)
+                }
+                throw BusinessException(OrderErrorCode.ALREADY_PARTICIPATED)
             }
-            throw BusinessException(OrderErrorCode.ALREADY_PARTICIPATED)
         }
 
         dailyStock.decrease(request.quantity)

--- a/deal-core/src/main/kotlin/com/chaltteok/core/domain/DailyStock.kt
+++ b/deal-core/src/main/kotlin/com/chaltteok/core/domain/DailyStock.kt
@@ -50,8 +50,8 @@ class DailyStock(
     @Column(name = "end_at")
     var endAt: LocalDateTime? = null,
 
-    @Column(name = "max_purchase_count", nullable = false)
-    var maxPurchaseCount: Int = 1,
+    @Column(name = "max_purchase_count", nullable = true)
+    var maxPurchaseCount: Int? = null,
 
     @Column(name = "created_at", nullable = false, updatable = false)
     val createdAt: LocalDateTime = LocalDateTime.now()
@@ -71,7 +71,7 @@ class DailyStock(
         if (remainStock == 0) status = DailyStockStatus.SOLD_OUT
     }
 
-    fun update(salePrice: Int, totalQty: Int, startAt: LocalDateTime?, endAt: LocalDateTime?, maxPurchaseCount: Int) {
+    fun update(salePrice: Int, totalQty: Int, startAt: LocalDateTime?, endAt: LocalDateTime?, maxPurchaseCount: Int?) {
         val qtyDelta = totalQty - this.totalQty
         this.salePrice = salePrice
         this.totalQty = totalQty

--- a/deal-core/src/main/kotlin/com/chaltteok/core/domain/EventHistory.kt
+++ b/deal-core/src/main/kotlin/com/chaltteok/core/domain/EventHistory.kt
@@ -1,13 +1,18 @@
 package com.chaltteok.core.domain
 
-import jakarta.persistence.*
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.FetchType
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.ManyToOne
+import jakarta.persistence.Table
 import java.time.LocalDateTime
 
 @Entity
-@Table(
-    name = "tb_event_history",
-    uniqueConstraints = [UniqueConstraint(name = "uk_one_event_per_user", columnNames = ["user_id", "stock_id"])]
-)
+@Table(name = "tb_event_history")
 class EventHistory(
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false)

--- a/deal-core/src/main/kotlin/com/chaltteok/core/repository/eventhistory/EventHistoryRepository.kt
+++ b/deal-core/src/main/kotlin/com/chaltteok/core/repository/eventhistory/EventHistoryRepository.kt
@@ -20,4 +20,7 @@ interface EventHistoryRepository : JpaRepository<EventHistory, Long>, EventHisto
 
     @Query("SELECT eh.dailyStock.stockUuid FROM EventHistory eh WHERE eh.user.id = :userId")
     fun findStockUuidsByUserId(@Param("userId") userId: Long): List<String>
+
+    @Query("SELECT eh FROM EventHistory eh JOIN FETCH eh.dailyStock WHERE eh.user.id = :userId")
+    fun findAllWithStockByUserId(@Param("userId") userId: Long): List<EventHistory>
 }


### PR DESCRIPTION
## Summary
- maxPurchaseCount null=무제한 지원
- 복수 구매(참여 횟수) 추적 API로 변경
- EventHistory unique constraint 제거

## Changes
| 파일 | 변경 |
|------|------|
| DailyStock.kt | maxPurchaseCount: Int? (nullable) |
| EventHistory.kt | UniqueConstraint 제거 |
| EventHistoryRepository.kt | findAllWithStockByUserId 추가 |
| OpenDailyStockResponse.kt | maxPurchaseCount: Int? |
| DailyStocksRegisterRequest.kt | maxPurchaseCount: Int? |
| DailyStockQueryService/Impl | getParticipationCounts() Map<String, Int> |
| DailyStockQueryController | /participated → Map<String, Int> |
| OrderServiceImpl | maxPurchaseCount null 시 횟수 체크 스킵 |
| db/migration/ | max_purchase_count nullable + unique constraint 제거 SQL |

Resolves #97