### PR TITLE
[FEAT] 상품 이미지 삭제 기능 추가 및 배너 이미지 경로 분리

### DIFF
--- a/deal-api-owner/src/main/kotlin/com/chaltteok/owner/banner/service/OwnerBannerServiceImpl.kt
+++ b/deal-api-owner/src/main/kotlin/com/chaltteok/owner/banner/service/OwnerBannerServiceImpl.kt
@@ -25,7 +25,7 @@ class OwnerBannerServiceImpl(
 
     @Transactional
     override fun create(request: BannerRequest, image: MultipartFile?) {
-        val imageUrl = image?.takeIf { !it.isEmpty }?.let { localFileUploader.uploadFile(it) }
+        val imageUrl = image?.takeIf { !it.isEmpty }?.let { localFileUploader.uploadFile(it, "banner") }
         val banner = Banner(
             title = request.title,
             subtitle = request.subtitle,
@@ -45,7 +45,7 @@ class OwnerBannerServiceImpl(
         val banner = bannerRepository.findByBannerUuid(bannerUuid)
             ?: throw BusinessException(BannerErrorCode.BANNER_NOT_FOUND)
         val newImageUrl = image?.takeIf { !it.isEmpty }?.let { newImage ->
-            val uploaded = localFileUploader.uploadFile(newImage)
+            val uploaded = localFileUploader.uploadFile(newImage, "banner")
             banner.imageUrl?.let { localFileUploader.deleteFile(it) }
             uploaded
         }

--- a/deal-api-owner/src/main/kotlin/com/chaltteok/owner/product/dto/ProductUpdateRequest.kt
+++ b/deal-api-owner/src/main/kotlin/com/chaltteok/owner/product/dto/ProductUpdateRequest.kt
@@ -24,4 +24,5 @@ class ProductUpdateRequest(
     @field:Min(value = 0, message = "display order must be 0 or more")
     @field:Max(value = ProductConstants.DISPLAY_ORDER_MAX, message = "display order must be ${ProductConstants.DISPLAY_ORDER_MAX} or less")
     val displayOrder: Int? = null,
+    val deleteImage: Boolean = false,
 )

--- a/deal-api-owner/src/main/kotlin/com/chaltteok/owner/product/service/ProductServiceImpl.kt
+++ b/deal-api-owner/src/main/kotlin/com/chaltteok/owner/product/service/ProductServiceImpl.kt
@@ -51,9 +51,20 @@ class ProductServiceImpl(
     override fun updateProduct(productUuid: String, request: ProductUpdateRequest, image: MultipartFile?) {
         val product = productRepository.findByProductUuid(productUuid)
             ?: throw BusinessException(ProductErrorCode.PRODUCT_NOT_FOUND)
-        val newImageUrl = image?.takeIf { !it.isEmpty }?.let { newImage ->
-            product.imageUrl?.let { fileUploader.deleteFile(it) }
-            fileUploader.uploadFile(newImage)
+
+        val newImageUrl = when {
+            // 새 이미지 업로드: 기존 이미지 삭제 후 새 이미지 저장
+            image != null && !image.isEmpty -> {
+                product.imageUrl?.let { fileUploader.deleteFile(it) }
+                fileUploader.uploadFile(image)
+            }
+            // deleteImage=true이고 새 이미지 없음: 기존 이미지만 삭제
+            request.deleteImage && image == null -> {
+                product.imageUrl?.let { fileUploader.deleteFile(it) }
+                null
+            }
+            // 그 외: 이미지 변경 없음
+            else -> product.imageUrl
         }
 
         product.name = request.name
@@ -61,7 +72,7 @@ class ProductServiceImpl(
         product.price = request.price
         product.isActive = request.isActive
         product.isRecommended = request.isRecommended
-        newImageUrl?.let { product.imageUrl = it }
+        product.imageUrl = newImageUrl
         request.displayOrder?.let { product.displayOrder = it }
 
         val effectiveStockQuantity = request.stockQuantity ?: product.stockQuantity

--- a/deal-api-owner/src/main/kotlin/com/chaltteok/owner/product/util/LocalFileUploader.kt
+++ b/deal-api-owner/src/main/kotlin/com/chaltteok/owner/product/util/LocalFileUploader.kt
@@ -17,7 +17,7 @@ class LocalFileUploader(
 ) {
     private val tika = Tika()
 
-    fun uploadFile(file: MultipartFile): String {
+    fun uploadFile(file: MultipartFile, subDir: String = "product"): String {
 
         // 파일 존재 여부 확인
         if (file.isEmpty) {
@@ -41,7 +41,7 @@ class LocalFileUploader(
             throw BusinessException(ProductErrorCode.INVALID_FILE_TYPE)
         }
 
-        val directory = Paths.get(uploadDir).resolve("product").toAbsolutePath().normalize()
+        val directory = Paths.get(uploadDir).resolve(subDir).toAbsolutePath().normalize()
 
         // 디렉토리 없으면 생성
         if (!Files.exists(directory)) {
@@ -57,8 +57,8 @@ class LocalFileUploader(
         val filePath = directory.resolve(savedFileName)
         file.transferTo(filePath.toFile())
 
-        // URL 경로 반환 (/images/product/xxx.jpg 형태로 정적 파일 서빙)
-        return "/images/product/$savedFileName"
+        // URL 경로 반환 (/images/{subDir}/xxx.jpg 형태로 정적 파일 서빙)
+        return "/images/$subDir/$savedFileName"
     }
 
     fun deleteFile(imageUrl: String) {


### PR DESCRIPTION
## Summary
- 상품 수정 시 기존 이미지 삭제 기능 추가 (deleteImage 플래그)
- 배너 이미지 저장 경로를 upload/banner/ 하위로 분리

## Changes
| 파일 | 변경 내용 |
|------|----------|
| `ProductUpdateRequest.kt` | `deleteImage: Boolean = false` 필드 추가 |
| `ProductServiceImpl.kt` | deleteImage=true 시 기존 이미지 삭제 처리 로직 추가 |
| `LocalFileUploader.kt` | `uploadFile(file, subDir="product")` subDir 파라미터 추가 |
| `OwnerBannerServiceImpl.kt` | 배너 업로드 시 `subDir="banner"` 전달 |

## Test plan
- [ ] 상품 수정 시 deleteImage=true로 요청 → 이미지 삭제 + imageUrl=null 확인
- [ ] 상품 수정 시 새 이미지 업로드 → 기존 이미지 삭제 후 새 이미지 저장 확인
- [ ] 배너 이미지 업로드 → upload/banner/ 경로 저장 확인

Resolves #101

🤖 Generated with Claude Code