### PR TITLE
[FIX] 주문 내역이 있는 상품 삭제 시 FK 제약 오류 처리

### DIFF
--- a/deal-api-owner/src/main/kotlin/com/chaltteok/owner/product/enums/ProductErrorCode.kt
+++ b/deal-api-owner/src/main/kotlin/com/chaltteok/owner/product/enums/ProductErrorCode.kt
@@ -12,4 +12,5 @@ enum class ProductErrorCode(
     INVALID_FILE_TYPE("This is an unsupported file type", HttpStatus.BAD_REQUEST),
     FILE_UPLOAD_ERROR("Error uploading file", HttpStatus.INTERNAL_SERVER_ERROR),
     INVALID_STOCK("현재 잔고는 일별 재고 수량을 초과할 수 없습니다.", HttpStatus.BAD_REQUEST),
+    PRODUCT_HAS_ORDERS("주문 내역이 있는 상품은 삭제할 수 없습니다.", HttpStatus.CONFLICT),
 }

--- a/deal-api-owner/src/main/kotlin/com/chaltteok/owner/product/service/ProductServiceImpl.kt
+++ b/deal-api-owner/src/main/kotlin/com/chaltteok/owner/product/service/ProductServiceImpl.kt
@@ -2,6 +2,7 @@ package com.chaltteok.owner.product.service
 
 import com.chaltteok.common.exception.BusinessException
 import com.chaltteok.core.cache.CacheNames
+import com.chaltteok.core.repository.orderitem.OrderItemRepository
 import com.chaltteok.core.repository.product.ProductRepository
 import com.chaltteok.core.repository.productoption.ProductOptionRepository
 import com.chaltteok.owner.product.dto.ProductListResponse
@@ -22,6 +23,7 @@ private val logger = KotlinLogging.logger {}
 class ProductServiceImpl(
     private val productRepository: ProductRepository,
     private val productOptionRepository: ProductOptionRepository,
+    private val orderItemRepository: OrderItemRepository,
     private val fileUploader: LocalFileUploader,
 ) : ProductService {
 
@@ -112,6 +114,9 @@ class ProductServiceImpl(
         val product = productRepository.findByProductUuid(productUuid)
             ?: throw BusinessException(ProductErrorCode.PRODUCT_NOT_FOUND)
         val productId = product.id ?: throw BusinessException(ProductErrorCode.PRODUCT_NOT_FOUND)
+        if (orderItemRepository.existsByProductId(productId)) {
+            throw BusinessException(ProductErrorCode.PRODUCT_HAS_ORDERS)
+        }
         product.imageUrl?.let { fileUploader.deleteFile(it) }
         productOptionRepository.deleteAllByProductId(productId)
         productRepository.delete(product)

--- a/deal-core/src/main/kotlin/com/chaltteok/core/repository/orderitem/OrderItemRepository.kt
+++ b/deal-core/src/main/kotlin/com/chaltteok/core/repository/orderitem/OrderItemRepository.kt
@@ -8,4 +8,6 @@ import org.springframework.data.repository.query.Param
 interface OrderItemRepository : JpaRepository<OrderItem, Long>, OrderItemRepositoryCustom {
     @Query("SELECT oi FROM OrderItem oi JOIN FETCH oi.product WHERE oi.order.id IN :orderIds")
     fun findByOrderIdsWithProduct(@Param("orderIds") orderIds: List<Long>): List<OrderItem>
+
+    fun existsByProductId(productId: Long): Boolean
 }


### PR DESCRIPTION
## Summary
- 주문 내역이 있는 상품 삭제 시 MySQL FK 제약 오류(tb_order_items_ibfk_2) 발생하는 버그 수정
- cascade delete 대신 선행 체크로 주문 이력 보존

## Changes
| 파일 | 변경 내용 |
|------|----------|
| `deal-core/.../OrderItemRepository.kt` | `existsByProductId(productId: Long): Boolean` 추가 |
| `deal-api-owner/.../ProductErrorCode.kt` | `PRODUCT_HAS_ORDERS` (409 Conflict) 추가 |
| `deal-api-owner/.../ProductServiceImpl.kt` | `deleteProduct()` 내 주문 존재 여부 선행 체크 추가 |

## Test plan
- [ ] 주문 내역 없는 상품 삭제 → 정상 삭제 확인
- [ ] 주문 내역 있는 상품 삭제 → 409 CONFLICT + "주문 내역이 있는 상품은 삭제할 수 없습니다." 응답 확인

Resolves #103

🤖 Generated with Claude Code