### PR TITLE
[FEAT] 타임세일 Kafka 비동기 주문 엔드포인트 추가 (부하 테스트용)

### DIFF
--- a/deal-api-user/src/main/kotlin/com/chaltteok/user/order/controller/OrderAsyncController.kt
+++ b/deal-api-user/src/main/kotlin/com/chaltteok/user/order/controller/OrderAsyncController.kt
@@ -1,0 +1,30 @@
+package com.chaltteok.user.order.controller
+
+import com.chaltteok.common.dto.ResponseDTO
+import com.chaltteok.user.order.dto.AsyncOrderResponse
+import com.chaltteok.user.order.dto.OrderRequest
+import com.chaltteok.user.order.service.OrderAsyncService
+import jakarta.validation.Valid
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.security.core.Authentication
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/v1/user/orders/async")
+class OrderAsyncController(
+    private val orderAsyncService: OrderAsyncService,
+) {
+    @PostMapping
+    fun placeOrderAsync(
+        authentication: Authentication,
+        @RequestBody @Valid request: OrderRequest,
+    ): ResponseEntity<ResponseDTO<AsyncOrderResponse>> {
+        val userId = authentication.principal as Long
+        val result = orderAsyncService.placeOrderAsync(userId, request)
+        return ResponseEntity.status(HttpStatus.ACCEPTED).body(ResponseDTO.success(result))
+    }
+}

--- a/deal-api-user/src/main/kotlin/com/chaltteok/user/order/dto/AsyncOrderResponse.kt
+++ b/deal-api-user/src/main/kotlin/com/chaltteok/user/order/dto/AsyncOrderResponse.kt
@@ -3,4 +3,8 @@ package com.chaltteok.user.order.dto
 data class AsyncOrderResponse(
     val status: String,
     val message: String,
-)
+) {
+    companion object {
+        fun pending() = AsyncOrderResponse(status = "PENDING", message = "주문이 접수되었습니다.")
+    }
+}

--- a/deal-api-user/src/main/kotlin/com/chaltteok/user/order/dto/AsyncOrderResponse.kt
+++ b/deal-api-user/src/main/kotlin/com/chaltteok/user/order/dto/AsyncOrderResponse.kt
@@ -1,0 +1,6 @@
+package com.chaltteok.user.order.dto
+
+data class AsyncOrderResponse(
+    val status: String,
+    val message: String,
+)

--- a/deal-api-user/src/main/kotlin/com/chaltteok/user/order/service/OrderAsyncService.kt
+++ b/deal-api-user/src/main/kotlin/com/chaltteok/user/order/service/OrderAsyncService.kt
@@ -1,0 +1,8 @@
+package com.chaltteok.user.order.service
+
+import com.chaltteok.user.order.dto.AsyncOrderResponse
+import com.chaltteok.user.order.dto.OrderRequest
+
+interface OrderAsyncService {
+    fun placeOrderAsync(userId: Long, request: OrderRequest): AsyncOrderResponse
+}

--- a/deal-api-user/src/main/kotlin/com/chaltteok/user/order/service/OrderAsyncServiceImpl.kt
+++ b/deal-api-user/src/main/kotlin/com/chaltteok/user/order/service/OrderAsyncServiceImpl.kt
@@ -37,6 +37,8 @@ class OrderAsyncServiceImpl(
         if (maxPurchaseCount != null) {
             val participated = eventHistoryRepository.countByUser_IdAndDailyStock_Id(userId, dailyStock.id)
             if (participated + request.quantity > maxPurchaseCount) {
+                // participated == 0: 구매 이력은 없지만 요청 수량 자체가 1인 한도 초과
+                // participated  > 0: 이미 참여한 이력이 있어 추가 구매 불가
                 if (participated == 0L) throw BusinessException(OrderErrorCode.EXCEEDS_MAX_PURCHASE_COUNT)
                 throw BusinessException(OrderErrorCode.ALREADY_PARTICIPATED)
             }
@@ -44,9 +46,8 @@ class OrderAsyncServiceImpl(
 
         val dailyStockId = dailyStock.id ?: error("DailyStock ID가 null입니다")
         orderEventProducer.sendOrderEvent(userId, dailyStockId)
-
         logger.info { "타임세일 주문 이벤트 발행 — stockUuid=${request.stockUuid}, userId=$userId" }
 
-        return AsyncOrderResponse(status = "PENDING", message = "주문이 접수되었습니다.")
+        return AsyncOrderResponse.pending()
     }
 }

--- a/deal-api-user/src/main/kotlin/com/chaltteok/user/order/service/OrderAsyncServiceImpl.kt
+++ b/deal-api-user/src/main/kotlin/com/chaltteok/user/order/service/OrderAsyncServiceImpl.kt
@@ -1,0 +1,52 @@
+package com.chaltteok.user.order.service
+
+import com.chaltteok.common.exception.BusinessException
+import com.chaltteok.core.domain.enums.DailyStockStatus
+import com.chaltteok.core.repository.dailystock.DailyStockRepository
+import com.chaltteok.core.repository.eventhistory.EventHistoryRepository
+import com.chaltteok.user.infrastructure.kafka.OrderEventProducer
+import com.chaltteok.user.order.dto.AsyncOrderResponse
+import com.chaltteok.user.order.dto.OrderRequest
+import com.chaltteok.user.order.enums.OrderErrorCode
+import io.github.oshai.kotlinlogging.KotlinLogging
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+private val logger = KotlinLogging.logger {}
+
+@Service
+class OrderAsyncServiceImpl(
+    private val dailyStockRepository: DailyStockRepository,
+    private val eventHistoryRepository: EventHistoryRepository,
+    private val orderEventProducer: OrderEventProducer,
+) : OrderAsyncService {
+
+    @Transactional(readOnly = true)
+    override fun placeOrderAsync(userId: Long, request: OrderRequest): AsyncOrderResponse {
+        val dailyStock = dailyStockRepository.findByStockUuid(request.stockUuid)
+            ?: throw BusinessException(OrderErrorCode.DAILY_STOCK_NOT_FOUND)
+
+        if (dailyStock.status != DailyStockStatus.OPEN) {
+            throw BusinessException(OrderErrorCode.STOCK_NOT_AVAILABLE)
+        }
+        if (dailyStock.remainStock < request.quantity) {
+            throw BusinessException(OrderErrorCode.INSUFFICIENT_STOCK)
+        }
+
+        val maxPurchaseCount = dailyStock.maxPurchaseCount
+        if (maxPurchaseCount != null) {
+            val participated = eventHistoryRepository.countByUser_IdAndDailyStock_Id(userId, dailyStock.id)
+            if (participated + request.quantity > maxPurchaseCount) {
+                if (participated == 0L) throw BusinessException(OrderErrorCode.EXCEEDS_MAX_PURCHASE_COUNT)
+                throw BusinessException(OrderErrorCode.ALREADY_PARTICIPATED)
+            }
+        }
+
+        val dailyStockId = dailyStock.id ?: error("DailyStock ID가 null입니다")
+        orderEventProducer.sendOrderEvent(userId, dailyStockId)
+
+        logger.info { "타임세일 주문 이벤트 발행 — stockUuid=${request.stockUuid}, userId=$userId" }
+
+        return AsyncOrderResponse(status = "PENDING", message = "주문이 접수되었습니다.")
+    }
+}

--- a/deal-consumer/src/main/kotlin/com/chaltteok/consumer/order/service/OrderProcessServiceImpl.kt
+++ b/deal-consumer/src/main/kotlin/com/chaltteok/consumer/order/service/OrderProcessServiceImpl.kt
@@ -2,13 +2,19 @@ package com.chaltteok.consumer.order.service
 
 import com.chaltteok.consumer.order.service.helper.EventHistoryDuplicateChecker
 import com.chaltteok.consumer.order.service.helper.StockDecrementHelper
+import com.chaltteok.core.domain.Notification
 import com.chaltteok.core.domain.Order
 import com.chaltteok.core.domain.OrderItem
+import com.chaltteok.core.domain.Payment
+import com.chaltteok.core.domain.enums.NotificationType
 import com.chaltteok.core.domain.enums.OrderStatus
+import com.chaltteok.core.domain.enums.PaymentStatus
 import com.chaltteok.core.repository.dailystock.DailyStockRepository
 import com.chaltteok.core.repository.eventhistory.EventHistoryRepository
+import com.chaltteok.core.repository.notification.NotificationRepository
 import com.chaltteok.core.repository.order.OrderRepository
 import com.chaltteok.core.repository.orderitem.OrderItemRepository
+import com.chaltteok.core.repository.payment.PaymentRepository
 import com.chaltteok.core.repository.user.UserRepository
 import io.github.oshai.kotlinlogging.KotlinLogging
 import org.springframework.orm.ObjectOptimisticLockingFailureException
@@ -26,7 +32,9 @@ class OrderProcessServiceImpl(
     private val dailyStockRepository: DailyStockRepository,
     private val orderRepository: OrderRepository,
     private val orderItemRepository: OrderItemRepository,
+    private val paymentRepository: PaymentRepository,
     private val eventHistoryRepository: EventHistoryRepository,
+    private val notificationRepository: NotificationRepository,
     private val duplicateChecker: EventHistoryDuplicateChecker,
     private val stockDecrementHelper: StockDecrementHelper,
 ) : OrderProcessService {
@@ -37,13 +45,11 @@ class OrderProcessServiceImpl(
         val dailyStock = dailyStockRepository.findById(dailyStockId)
             .orElseThrow { RuntimeException("DailyStock not found: $dailyStockId") }
 
-        // 1단계: 1인 1회 구매 검증 (REQUIRES_NEW 트랜잭션 — UniqueKey 위반 격리)
         if (duplicateChecker.isDuplicate(user, dailyStock)) {
             log.warn { "중복 구매 요청 무시 — userId=$userId, dailyStockId=$dailyStockId" }
             return
         }
 
-        // 2단계: 재고 차감 (낙관적 락 재시도, 각 시도마다 별도 REQUIRES_NEW 트랜잭션)
         var retries = 0
         var stockDecremented = false
         while (!stockDecremented && retries < MAX_RETRY) {
@@ -64,7 +70,6 @@ class OrderProcessServiceImpl(
             }
         }
 
-        // 3단계: 주문 확정 (Order + OrderItem 저장, EventHistory에 order 역참조 backfill)
         confirmOrder(userId, dailyStockId)
     }
 
@@ -72,18 +77,29 @@ class OrderProcessServiceImpl(
     fun confirmOrder(userId: Long, dailyStockId: Long) {
         val user = userRepository.findById(userId).orElseThrow()
         val dailyStock = dailyStockRepository.findById(dailyStockId).orElseThrow()
+        val totalPrice = dailyStock.salePrice
 
         val order = orderRepository.save(
-            Order(user = user, totalPrice = dailyStock.product.price, status = OrderStatus.COMPLETED)
+            Order(user = user, totalPrice = totalPrice, status = OrderStatus.COMPLETED)
         )
         orderItemRepository.save(
-            OrderItem(order = order, product = dailyStock.product, quantity = 1, price = dailyStock.product.price)
+            OrderItem(order = order, product = dailyStock.product, quantity = 1, price = dailyStock.salePrice)
+        )
+        paymentRepository.save(
+            Payment(order = order, amount = totalPrice, status = PaymentStatus.SUCCESS, paymentMethod = "TIMESALE")
         )
 
-        // EventHistory에 확정된 Order 역참조 backfill
         eventHistoryRepository.findByUserAndDailyStock(user, dailyStock)?.let {
             it.order = order
         }
+
+        notificationRepository.save(
+            Notification(
+                type = NotificationType.ORDER.name,
+                title = "새 주문이 들어왔습니다",
+                message = "${dailyStock.product.name} (%,d원)".format(dailyStock.salePrice),
+            )
+        )
 
         log.info { "주문 확정 완료 — orderId=${order.id}, userId=$userId, dailyStockId=$dailyStockId" }
     }

--- a/deal-consumer/src/main/kotlin/com/chaltteok/consumer/order/service/OrderProcessServiceImpl.kt
+++ b/deal-consumer/src/main/kotlin/com/chaltteok/consumer/order/service/OrderProcessServiceImpl.kt
@@ -2,10 +2,12 @@ package com.chaltteok.consumer.order.service
 
 import com.chaltteok.consumer.order.service.helper.EventHistoryDuplicateChecker
 import com.chaltteok.consumer.order.service.helper.StockDecrementHelper
+import com.chaltteok.core.domain.DailyStock
 import com.chaltteok.core.domain.Notification
 import com.chaltteok.core.domain.Order
 import com.chaltteok.core.domain.OrderItem
 import com.chaltteok.core.domain.Payment
+import com.chaltteok.core.domain.User
 import com.chaltteok.core.domain.enums.NotificationType
 import com.chaltteok.core.domain.enums.OrderStatus
 import com.chaltteok.core.domain.enums.PaymentStatus
@@ -25,6 +27,7 @@ private val log = KotlinLogging.logger {}
 
 private const val MAX_RETRY = 3
 private const val RETRY_DELAY_MS = 50L
+private const val PAYMENT_METHOD_TIMESALE = "TIMESALE"
 
 @Service
 class OrderProcessServiceImpl(
@@ -70,13 +73,11 @@ class OrderProcessServiceImpl(
             }
         }
 
-        confirmOrder(userId, dailyStockId)
+        confirmOrder(user, dailyStock)
     }
 
     @Transactional
-    fun confirmOrder(userId: Long, dailyStockId: Long) {
-        val user = userRepository.findById(userId).orElseThrow()
-        val dailyStock = dailyStockRepository.findById(dailyStockId).orElseThrow()
+    internal fun confirmOrder(user: User, dailyStock: DailyStock) {
         val totalPrice = dailyStock.salePrice
 
         val order = orderRepository.save(
@@ -86,7 +87,7 @@ class OrderProcessServiceImpl(
             OrderItem(order = order, product = dailyStock.product, quantity = 1, price = dailyStock.salePrice)
         )
         paymentRepository.save(
-            Payment(order = order, amount = totalPrice, status = PaymentStatus.SUCCESS, paymentMethod = "TIMESALE")
+            Payment(order = order, amount = totalPrice, status = PaymentStatus.SUCCESS, paymentMethod = PAYMENT_METHOD_TIMESALE)
         )
 
         eventHistoryRepository.findByUserAndDailyStock(user, dailyStock)?.let {
@@ -101,6 +102,6 @@ class OrderProcessServiceImpl(
             )
         )
 
-        log.info { "주문 확정 완료 — orderId=${order.id}, userId=$userId, dailyStockId=$dailyStockId" }
+        log.info { "주문 확정 완료 — orderId=${order.id}, userId=${user.id}, dailyStockId=${dailyStock.id}" }
     }
 }


### PR DESCRIPTION
## Summary
타임세일 주문 처리 방식 2가지를 동시에 운용하여 부하 테스트로 성능 비교

- 동기식 `POST /api/v1/user/orders` — 비관적 락 (기존 유지)
- 비동기식 `POST /api/v1/user/orders/async` — Kafka 이벤트 발행 (신규)

## Changes
| 파일 | 변경 내용 |
|------|----------|
| `OrderAsyncController.kt` | 신규: POST /orders/async, HTTP 202 반환 |
| `OrderAsyncService.kt` | 신규: interface |
| `OrderAsyncServiceImpl.kt` | 신규: 락 없는 사전 검증 + Kafka 발행 |
| `AsyncOrderResponse.kt` | 신규: {status, message} DTO |
| `OrderProcessServiceImpl.kt` | 수정: Payment + Notification 저장 추가, salePrice 버그 수정 |

## 부하 테스트 시나리오
| 항목 | 동기 `/orders` | 비동기 `/orders/async` |
|------|------|------|
| 동시성 | SELECT FOR UPDATE (비관적 락) | 낙관적 락 재시도 (consumer) |
| 응답 | 즉시 주문 결과 | 202 PENDING |
| 측정 지표 | TPS, P99 latency, DB 커넥션 점유 | TPS, P99 latency, 재고 정합성 |

## Test plan
- [ ] POST /orders/async → 202 + {status: "PENDING"} 응답 확인
- [ ] Kafka 메시지 발행 → deal-consumer 수신 → Order/Payment/Notification 저장 확인
- [ ] 동시 N건 요청 시 재고 정합성 (초과 주문 없음) 확인
- [ ] 재고 소진 후 추가 요청 시 409 반환 확인

Resolves #105

🤖 Generated with Claude Code