### PR TITLE
[CHORE] tb_outbox_events DDL 추가 및 P3 코드 개선

### DIFF
--- a/db/migration/add_outbox_events_table.sql
+++ b/db/migration/add_outbox_events_table.sql
@@ -1,0 +1,14 @@
+CREATE TABLE IF NOT EXISTS tb_outbox_events (
+    id           BIGINT       NOT NULL AUTO_INCREMENT PRIMARY KEY,
+    source       VARCHAR(20)  NOT NULL COMMENT 'API_USER | CONSUMER',
+    aggregate_id VARCHAR(100) NOT NULL COMMENT '주문번호 등 도메인 식별자',
+    event_type   VARCHAR(50)  NOT NULL COMMENT 'ORDER_COMPLETED | ORDER_CANCELLED',
+    payload      TEXT         NOT NULL,
+    status       VARCHAR(20)  NOT NULL DEFAULT 'PENDING' COMMENT 'PENDING | PROCESSED | FAILED',
+    retry_count  INT          NOT NULL DEFAULT 0,
+    processed_at DATETIME,
+    created_at   DATETIME     NOT NULL,
+    updated_at   DATETIME     NOT NULL
+);
+
+CREATE INDEX idx_outbox_source_status_created ON tb_outbox_events (source, status, created_at);

--- a/deal-api-user/src/main/kotlin/com/chaltteok/user/checkout/service/CheckoutServiceImpl.kt
+++ b/deal-api-user/src/main/kotlin/com/chaltteok/user/checkout/service/CheckoutServiceImpl.kt
@@ -81,8 +81,15 @@ class CheckoutServiceImpl(
         savedOrder.status = OrderStatus.COMPLETED
 
         val orderId = savedOrder.id ?: error("Order ID가 저장 후에도 null입니다")
-        val productName = orderItems.joinToString(", ") { it.product.name }
-            .let { if (it.length > 450) it.take(450) + "…" else it }
+        val productName = buildString {
+            for ((index, item) in orderItems.withIndex()) {
+                if (index > 0) append(", ")
+                if (length + item.product.name.length > 450) {
+                    append("…"); break
+                }
+                append(item.product.name)
+            }
+        }
 
         outboxEventWriter.write(
             source = OutboxEvent.SOURCE_API_USER,

--- a/deal-api-user/src/main/kotlin/com/chaltteok/user/order/controller/OrderController.kt
+++ b/deal-api-user/src/main/kotlin/com/chaltteok/user/order/controller/OrderController.kt
@@ -50,9 +50,10 @@ class OrderController(
         @RequestParam(required = false) paymentStatus: String?,
     ): ResponseDTO<OrderHistoryPageResponse> {
         val userId = authentication.principal as Long
-        val pageable = PageRequest.of(page.coerceIn(0, 9_999), size.coerceIn(1, 50))
+        val safeKeyword = keyword?.trim()?.take(100)
+        val pageable = PageRequest.of(page.coerceIn(0, MAX_PAGE), size.coerceIn(1, 50))
         return ResponseDTO.success(
-            orderService.getOrderHistory(userId, keyword, status, fromDate, toDate, paymentStatus, pageable)
+            orderService.getOrderHistory(userId, safeKeyword, status, fromDate, toDate, paymentStatus, pageable)
         )
     }
 
@@ -63,5 +64,9 @@ class OrderController(
     ): ResponseDTO<OrderHistoryResponse> {
         val userId = authentication.principal as Long
         return ResponseDTO.success(orderService.getOrderDetail(userId, orderNumber))
+    }
+
+    companion object {
+        private const val MAX_PAGE = 9_999
     }
 }

--- a/deal-api-user/src/main/kotlin/com/chaltteok/user/order/service/OrderServiceImpl.kt
+++ b/deal-api-user/src/main/kotlin/com/chaltteok/user/order/service/OrderServiceImpl.kt
@@ -82,14 +82,15 @@ class OrderServiceImpl(
 
         order.cancel()
 
-        paymentRepository.findByOrderId(order.id ?: error("Order ID null"))?.cancel()
+        val orderId = order.id ?: error("Order ID null")
+        paymentRepository.findByOrderId(orderId)?.cancel()
 
         outboxEventWriter.write(
             source = OutboxEvent.SOURCE_API_USER,
             aggregateId = order.orderNumber,
             eventType = OutboxEvent.TYPE_ORDER_CANCELLED,
             event = OrderCancelledEvent(
-                orderId = order.id ?: error("Order ID null"),
+                orderId = orderId,
                 orderNumber = order.orderNumber,
                 userName = order.user.nickname,
                 totalAmount = order.totalPrice.toLong(),
@@ -178,14 +179,15 @@ class OrderServiceImpl(
         val order = orderRepository.findByOrderNumberAndUser_Id(orderNumber, userId)
             .orElseThrow { BusinessException(OrderErrorCode.ORDER_NOT_FOUND) }
 
-        val items = orderItemRepository.findByOrderIdWithProduct(order.id ?: error("Order ID null")).map { item ->
+        val orderId = order.id ?: error("Order ID null")
+        val items = orderItemRepository.findByOrderIdWithProduct(orderId).map { item ->
             OrderHistoryItemResponse(
                 productName = item.product.name,
                 quantity = item.quantity,
                 price = item.price.toLong(),
             )
         }
-        val payment = paymentRepository.findByOrderId(order.id ?: error("Order ID null"))?.let { p ->
+        val payment = paymentRepository.findByOrderId(orderId)?.let { p ->
             PaymentInfoResponse(
                 amount = p.amount,
                 pgProvider = p.pgProvider,

--- a/deal-core/src/main/kotlin/com/chaltteok/core/domain/OutboxEvent.kt
+++ b/deal-core/src/main/kotlin/com/chaltteok/core/domain/OutboxEvent.kt
@@ -11,7 +11,7 @@ import java.time.LocalDateTime
 
 @Entity
 @Table(
-    name = "outbox_events",
+    name = "tb_outbox_events",
     indexes = [
         Index(name = "idx_outbox_source_status_created", columnList = "source,status,created_at"),
     ],


### PR DESCRIPTION
## Summary
- `tb_outbox_events` 테이블 DDL 신규 생성 및 엔티티 테이블명 통일
- 코드리뷰 P3 4건 반영

## Changes

| 파일 | 변경 내용 |
|------|----------|
| `db/migration/add_outbox_events_table.sql` (신규) | tb_outbox_events CREATE TABLE + 인덱스 |
| `OutboxEvent.kt` | 테이블명 `outbox_events` → `tb_outbox_events` |
| `OrderController.kt` | `MAX_PAGE = 9_999` 상수화, `keyword` 최대 100자 제한 |
| `OrderServiceImpl.kt` | `order.id ?: error(...)` 중복 → `orderId` 로컬 변수 추출 |
| `CheckoutServiceImpl.kt` | `joinToString + take(450)` → `buildString` 조기 종료 |

## DDL 미리보기
```sql
CREATE TABLE IF NOT EXISTS tb_outbox_events (
    id           BIGINT       NOT NULL AUTO_INCREMENT PRIMARY KEY,
    source       VARCHAR(20)  NOT NULL COMMENT 'API_USER | CONSUMER',
    aggregate_id VARCHAR(100) NOT NULL,
    event_type   VARCHAR(50)  NOT NULL,
    payload      TEXT         NOT NULL,
    status       VARCHAR(20)  NOT NULL DEFAULT 'PENDING',
    retry_count  INT          NOT NULL DEFAULT 0,
    processed_at DATETIME,
    created_at   DATETIME     NOT NULL,
    updated_at   DATETIME     NOT NULL
);
CREATE INDEX idx_outbox_source_status_created ON tb_outbox_events (source, status, created_at);
```

## Test plan
- [ ] `tb_outbox_events` 테이블 생성 후 주문 완료 시 PENDING 레코드 삽입 확인
- [ ] keyword 101자 입력 시 100자로 잘려서 검색되는지 확인
- [ ] 페이지 10000 요청 시 9999로 clamp 되는지 확인

Resolves #119

🤖 Generated with Claude Code