### PR TITLE
[FIX] 이벤트 주문 quantity Kafka 미전달 — 재고차감·금액·OrderItem 1 고정 버그 수정

### DIFF
--- a/deal-api-user/src/main/kotlin/com/chaltteok/user/infrastructure/kafka/OrderEventProducer.kt
+++ b/deal-api-user/src/main/kotlin/com/chaltteok/user/infrastructure/kafka/OrderEventProducer.kt
@@ -16,9 +16,9 @@ class OrderEventProducer(
     private val kafkaTemplate: KafkaTemplate<String, String>,
     private val objectMapper: ObjectMapper,
 ) {
-    fun sendOrderEvent(userId: Long, dailyStockId: Long, paymentMethod: PaymentMethod) {
+    fun sendOrderEvent(userId: Long, dailyStockId: Long, quantity: Int, paymentMethod: PaymentMethod) {
         val payload = objectMapper.writeValueAsString(
-            OrderPlacedEvent(userId = userId, dailyStockId = dailyStockId, paymentMethod = paymentMethod)
+            OrderPlacedEvent(userId = userId, dailyStockId = dailyStockId, paymentMethod = paymentMethod, quantity = quantity)
         )
         kafkaTemplate.send(TOPIC, userId.toString(), payload)
             .whenComplete { result, ex ->

--- a/deal-api-user/src/main/kotlin/com/chaltteok/user/order/dto/OrderRequest.kt
+++ b/deal-api-user/src/main/kotlin/com/chaltteok/user/order/dto/OrderRequest.kt
@@ -8,7 +8,8 @@ import jakarta.validation.constraints.NotBlank
 data class OrderRequest(
     @field:NotBlank
     val stockUuid: String,
-    @field:Min(1) @field:Max(100)
+    @field:Min(value = 1, message = "수량은 1 이상이어야 합니다")
+    @field:Max(value = 100, message = "1회 최대 구매 수량은 100개입니다")
     val quantity: Int = 1,
     val paymentMethod: PaymentMethod,
 )

--- a/deal-api-user/src/main/kotlin/com/chaltteok/user/order/service/OrderServiceImpl.kt
+++ b/deal-api-user/src/main/kotlin/com/chaltteok/user/order/service/OrderServiceImpl.kt
@@ -62,7 +62,7 @@ class OrderServiceImpl(
         }
 
         val dailyStockId = dailyStock.id ?: error("DailyStock ID가 null입니다")
-        orderEventProducer.sendOrderEvent(userId, dailyStockId, request.paymentMethod)
+        orderEventProducer.sendOrderEvent(userId, dailyStockId, request.quantity, request.paymentMethod)
         logger.info { "타임세일 주문 이벤트 발행 — stockUuid=${request.stockUuid}, userId=$userId" }
 
         return OrderResponse.pending()

--- a/deal-consumer/src/main/kotlin/com/chaltteok/consumer/order/consumer/OrderEventConsumer.kt
+++ b/deal-consumer/src/main/kotlin/com/chaltteok/consumer/order/consumer/OrderEventConsumer.kt
@@ -1,5 +1,6 @@
 package com.chaltteok.consumer.order.consumer
 
+import com.chaltteok.consumer.order.service.OrderProcessCommand
 import com.chaltteok.consumer.order.service.OrderProcessService
 import com.chaltteok.core.event.OrderPlacedEvent
 import com.fasterxml.jackson.databind.ObjectMapper
@@ -19,6 +20,13 @@ class OrderEventConsumer(
     fun consume(message: String) {
         val event = objectMapper.readValue(message, OrderPlacedEvent::class.java)
         log.info { "주문 이벤트 수신 — userId=${event.userId}, dailyStockId=${event.dailyStockId}" }
-        orderProcessService.processOrder(event.userId, event.dailyStockId, event.quantity, event.paymentMethod)
+        orderProcessService.processOrder(
+            OrderProcessCommand(
+                userId = event.userId,
+                dailyStockId = event.dailyStockId,
+                quantity = event.quantity,
+                paymentMethod = event.paymentMethod,
+            )
+        )
     }
 }

--- a/deal-consumer/src/main/kotlin/com/chaltteok/consumer/order/consumer/OrderEventConsumer.kt
+++ b/deal-consumer/src/main/kotlin/com/chaltteok/consumer/order/consumer/OrderEventConsumer.kt
@@ -19,6 +19,6 @@ class OrderEventConsumer(
     fun consume(message: String) {
         val event = objectMapper.readValue(message, OrderPlacedEvent::class.java)
         log.info { "주문 이벤트 수신 — userId=${event.userId}, dailyStockId=${event.dailyStockId}" }
-        orderProcessService.processOrder(event.userId, event.dailyStockId, event.paymentMethod)
+        orderProcessService.processOrder(event.userId, event.dailyStockId, event.quantity, event.paymentMethod)
     }
 }

--- a/deal-consumer/src/main/kotlin/com/chaltteok/consumer/order/exception/OrderProcessingException.kt
+++ b/deal-consumer/src/main/kotlin/com/chaltteok/consumer/order/exception/OrderProcessingException.kt
@@ -1,0 +1,3 @@
+package com.chaltteok.consumer.order.exception
+
+class OrderProcessingException(message: String) : RuntimeException(message)

--- a/deal-consumer/src/main/kotlin/com/chaltteok/consumer/order/service/OrderConfirmService.kt
+++ b/deal-consumer/src/main/kotlin/com/chaltteok/consumer/order/service/OrderConfirmService.kt
@@ -31,14 +31,14 @@ class OrderConfirmService(
     private val outboxEventWriter: OutboxEventWriter,
 ) {
     @Transactional
-    fun confirmOrder(user: User, dailyStock: DailyStock, paymentMethod: PaymentMethod) {
-        val totalPrice = dailyStock.salePrice
+    fun confirmOrder(user: User, dailyStock: DailyStock, quantity: Int, paymentMethod: PaymentMethod) {
+        val totalPrice = dailyStock.salePrice * quantity
 
         val order = orderRepository.save(
             Order(user = user, totalPrice = totalPrice, status = OrderStatus.COMPLETED)
         )
         orderItemRepository.save(
-            OrderItem(order = order, product = dailyStock.product, quantity = 1, price = dailyStock.salePrice)
+            OrderItem(order = order, product = dailyStock.product, quantity = quantity, price = dailyStock.salePrice)
         )
         paymentRepository.save(
             Payment(order = order, amount = totalPrice, status = PaymentStatus.SUCCESS, paymentMethod = paymentMethod.name, paidAt = LocalDateTime.now())

--- a/deal-consumer/src/main/kotlin/com/chaltteok/consumer/order/service/OrderConfirmService.kt
+++ b/deal-consumer/src/main/kotlin/com/chaltteok/consumer/order/service/OrderConfirmService.kt
@@ -32,16 +32,16 @@ class OrderConfirmService(
 ) {
     @Transactional
     fun confirmOrder(user: User, dailyStock: DailyStock, quantity: Int, paymentMethod: PaymentMethod) {
-        val totalPrice = dailyStock.salePrice * quantity
+        val totalPrice = dailyStock.salePrice.toLong() * quantity
 
         val order = orderRepository.save(
-            Order(user = user, totalPrice = totalPrice, status = OrderStatus.COMPLETED)
+            Order(user = user, totalPrice = totalPrice.toInt(), status = OrderStatus.COMPLETED)
         )
         orderItemRepository.save(
             OrderItem(order = order, product = dailyStock.product, quantity = quantity, price = dailyStock.salePrice)
         )
         paymentRepository.save(
-            Payment(order = order, amount = totalPrice, status = PaymentStatus.SUCCESS, paymentMethod = paymentMethod.name, paidAt = LocalDateTime.now())
+            Payment(order = order, amount = totalPrice.toInt(), status = PaymentStatus.SUCCESS, paymentMethod = paymentMethod.name, paidAt = LocalDateTime.now())
         )
 
         // order 미설정인 EventHistory(DuplicateChecker가 생성)에 order 역참조 backfill

--- a/deal-consumer/src/main/kotlin/com/chaltteok/consumer/order/service/OrderProcessCommand.kt
+++ b/deal-consumer/src/main/kotlin/com/chaltteok/consumer/order/service/OrderProcessCommand.kt
@@ -1,0 +1,10 @@
+package com.chaltteok.consumer.order.service
+
+import com.chaltteok.core.domain.enums.PaymentMethod
+
+data class OrderProcessCommand(
+    val userId: Long,
+    val dailyStockId: Long,
+    val quantity: Int,
+    val paymentMethod: PaymentMethod,
+)

--- a/deal-consumer/src/main/kotlin/com/chaltteok/consumer/order/service/OrderProcessService.kt
+++ b/deal-consumer/src/main/kotlin/com/chaltteok/consumer/order/service/OrderProcessService.kt
@@ -3,5 +3,5 @@ package com.chaltteok.consumer.order.service
 import com.chaltteok.core.domain.enums.PaymentMethod
 
 interface OrderProcessService {
-    fun processOrder(userId: Long, dailyStockId: Long, paymentMethod: PaymentMethod)
+    fun processOrder(userId: Long, dailyStockId: Long, quantity: Int, paymentMethod: PaymentMethod)
 }

--- a/deal-consumer/src/main/kotlin/com/chaltteok/consumer/order/service/OrderProcessService.kt
+++ b/deal-consumer/src/main/kotlin/com/chaltteok/consumer/order/service/OrderProcessService.kt
@@ -1,7 +1,5 @@
 package com.chaltteok.consumer.order.service
 
-import com.chaltteok.core.domain.enums.PaymentMethod
-
 interface OrderProcessService {
-    fun processOrder(userId: Long, dailyStockId: Long, quantity: Int, paymentMethod: PaymentMethod)
+    fun processOrder(command: OrderProcessCommand)
 }

--- a/deal-consumer/src/main/kotlin/com/chaltteok/consumer/order/service/OrderProcessServiceImpl.kt
+++ b/deal-consumer/src/main/kotlin/com/chaltteok/consumer/order/service/OrderProcessServiceImpl.kt
@@ -1,8 +1,8 @@
 package com.chaltteok.consumer.order.service
 
+import com.chaltteok.consumer.order.exception.OrderProcessingException
 import com.chaltteok.consumer.order.service.helper.EventHistoryDuplicateChecker
 import com.chaltteok.consumer.order.service.helper.StockDecrementHelper
-import com.chaltteok.core.domain.enums.PaymentMethod
 import com.chaltteok.core.infrastructure.lock.DistributedLockService
 import com.chaltteok.core.repository.dailystock.DailyStockRepository
 import com.chaltteok.core.repository.user.UserRepository
@@ -27,48 +27,50 @@ class OrderProcessServiceImpl(
     private val distributedLockService: DistributedLockService,
 ) : OrderProcessService {
 
-    override fun processOrder(userId: Long, dailyStockId: Long, quantity: Int, paymentMethod: PaymentMethod) {
-        val user = userRepository.findById(userId)
-            .orElseThrow { RuntimeException("User not found: $userId") }
-        val dailyStock = dailyStockRepository.findById(dailyStockId)
-            .orElseThrow { RuntimeException("DailyStock not found: $dailyStockId") }
+    override fun processOrder(command: OrderProcessCommand) {
+        require(command.quantity >= 1) { "유효하지 않은 quantity: ${command.quantity}" }
+
+        val user = userRepository.findById(command.userId)
+            .orElseThrow { OrderProcessingException("User not found: ${command.userId}") }
+        val dailyStock = dailyStockRepository.findById(command.dailyStockId)
+            .orElseThrow { OrderProcessingException("DailyStock not found: ${command.dailyStockId}") }
 
         if (duplicateChecker.isDuplicate(user, dailyStock)) {
-            log.warn { "중복 구매 요청 무시 — userId=$userId, dailyStockId=$dailyStockId" }
+            log.warn { "중복 구매 요청 무시 — userId=${command.userId}, dailyStockId=${command.dailyStockId}" }
             return
         }
 
-        val lockKey = "lock:daily-stock:$dailyStockId"
+        val lockKey = "lock:daily-stock:${command.dailyStockId}"
         // waitSec=0: Kafka 컨슈머 스레드 블로킹 방지 — 락 획득 실패 시 즉시 스킵, Kafka 재처리에 위임
         distributedLockService.withLock(
             key = lockKey,
             waitSec = 0L,
             leaseSec = LOCK_LEASE_SEC,
             onFail = {
-                log.warn { "분산 락 획득 실패로 주문 처리 스킵 — userId=$userId, dailyStockId=$dailyStockId" }
+                log.warn { "분산 락 획득 실패로 주문 처리 스킵 — userId=${command.userId}, dailyStockId=${command.dailyStockId}" }
             },
         ) {
             var retries = 0
             var stockDecremented = false
             while (!stockDecremented && retries < MAX_RETRY) {
                 try {
-                    stockDecremented = stockDecrementHelper.tryDecrement(dailyStockId, quantity)
+                    stockDecremented = stockDecrementHelper.tryDecrement(command.dailyStockId, command.quantity)
                     if (!stockDecremented) {
-                        log.warn { "재고 소진 — dailyStockId=$dailyStockId" }
+                        log.warn { "재고 소진 — dailyStockId=${command.dailyStockId}" }
                         return@withLock
                     }
                 } catch (e: ObjectOptimisticLockingFailureException) {
                     retries++
-                    log.warn { "낙관적 락 충돌, 재시도 $retries/$MAX_RETRY — dailyStockId=$dailyStockId" }
+                    log.warn { "낙관적 락 충돌, 재시도 $retries/$MAX_RETRY — dailyStockId=${command.dailyStockId}" }
                     if (retries >= MAX_RETRY) {
-                        log.error { "낙관적 락 재시도 초과, 주문 처리 포기 — dailyStockId=$dailyStockId" }
+                        log.error { "낙관적 락 재시도 초과, 주문 처리 포기 — dailyStockId=${command.dailyStockId}" }
                         return@withLock
                     }
                     Thread.sleep(RETRY_DELAY_MS)
                 }
             }
             // 별도 빈을 통해 호출 → Spring 프록시 경유 → @Transactional 적용
-            orderConfirmService.confirmOrder(user, dailyStock, quantity, paymentMethod)
+            orderConfirmService.confirmOrder(user, dailyStock, command.quantity, command.paymentMethod)
         }
     }
 }

--- a/deal-consumer/src/main/kotlin/com/chaltteok/consumer/order/service/OrderProcessServiceImpl.kt
+++ b/deal-consumer/src/main/kotlin/com/chaltteok/consumer/order/service/OrderProcessServiceImpl.kt
@@ -27,7 +27,7 @@ class OrderProcessServiceImpl(
     private val distributedLockService: DistributedLockService,
 ) : OrderProcessService {
 
-    override fun processOrder(userId: Long, dailyStockId: Long, paymentMethod: PaymentMethod) {
+    override fun processOrder(userId: Long, dailyStockId: Long, quantity: Int, paymentMethod: PaymentMethod) {
         val user = userRepository.findById(userId)
             .orElseThrow { RuntimeException("User not found: $userId") }
         val dailyStock = dailyStockRepository.findById(dailyStockId)
@@ -52,7 +52,7 @@ class OrderProcessServiceImpl(
             var stockDecremented = false
             while (!stockDecremented && retries < MAX_RETRY) {
                 try {
-                    stockDecremented = stockDecrementHelper.tryDecrement(dailyStockId)
+                    stockDecremented = stockDecrementHelper.tryDecrement(dailyStockId, quantity)
                     if (!stockDecremented) {
                         log.warn { "재고 소진 — dailyStockId=$dailyStockId" }
                         return@withLock
@@ -68,7 +68,7 @@ class OrderProcessServiceImpl(
                 }
             }
             // 별도 빈을 통해 호출 → Spring 프록시 경유 → @Transactional 적용
-            orderConfirmService.confirmOrder(user, dailyStock, paymentMethod)
+            orderConfirmService.confirmOrder(user, dailyStock, quantity, paymentMethod)
         }
     }
 }

--- a/deal-consumer/src/main/kotlin/com/chaltteok/consumer/order/service/helper/StockDecrementHelper.kt
+++ b/deal-consumer/src/main/kotlin/com/chaltteok/consumer/order/service/helper/StockDecrementHelper.kt
@@ -1,5 +1,6 @@
 package com.chaltteok.consumer.order.service.helper
 
+import com.chaltteok.consumer.order.exception.OrderProcessingException
 import com.chaltteok.core.domain.enums.DailyStockStatus
 import com.chaltteok.core.repository.dailystock.DailyStockRepository
 import org.springframework.stereotype.Component
@@ -13,8 +14,11 @@ class StockDecrementHelper(
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     fun tryDecrement(dailyStockId: Long, quantity: Int): Boolean {
         val stock = dailyStockRepository.findById(dailyStockId)
-            .orElseThrow { RuntimeException("DailyStock not found: $dailyStockId") }
-        if (stock.remainStock < quantity) return false
+            .orElseThrow { OrderProcessingException("DailyStock not found: $dailyStockId") }
+        if (stock.remainStock < quantity) {
+            if (stock.remainStock == 0) stock.status = DailyStockStatus.SOLD_OUT
+            return false
+        }
         stock.remainStock -= quantity
         if (stock.remainStock == 0) stock.status = DailyStockStatus.SOLD_OUT
         return true

--- a/deal-consumer/src/main/kotlin/com/chaltteok/consumer/order/service/helper/StockDecrementHelper.kt
+++ b/deal-consumer/src/main/kotlin/com/chaltteok/consumer/order/service/helper/StockDecrementHelper.kt
@@ -11,11 +11,11 @@ class StockDecrementHelper(
     private val dailyStockRepository: DailyStockRepository,
 ) {
     @Transactional(propagation = Propagation.REQUIRES_NEW)
-    fun tryDecrement(dailyStockId: Long): Boolean {
+    fun tryDecrement(dailyStockId: Long, quantity: Int): Boolean {
         val stock = dailyStockRepository.findById(dailyStockId)
             .orElseThrow { RuntimeException("DailyStock not found: $dailyStockId") }
-        if (stock.remainStock <= 0) return false
-        stock.remainStock -= 1
+        if (stock.remainStock < quantity) return false
+        stock.remainStock -= quantity
         if (stock.remainStock == 0) stock.status = DailyStockStatus.SOLD_OUT
         return true
     }

--- a/deal-core/src/main/kotlin/com/chaltteok/core/event/OrderPlacedEvent.kt
+++ b/deal-core/src/main/kotlin/com/chaltteok/core/event/OrderPlacedEvent.kt
@@ -1,10 +1,12 @@
 package com.chaltteok.core.event
 
 import com.chaltteok.core.domain.enums.PaymentMethod
+import com.fasterxml.jackson.annotation.JsonProperty
 
 data class OrderPlacedEvent(
     val userId: Long,
     val dailyStockId: Long,
     val paymentMethod: PaymentMethod,
+    @JsonProperty(defaultValue = "1")
     val quantity: Int = 1,
 )

--- a/deal-core/src/main/kotlin/com/chaltteok/core/event/OrderPlacedEvent.kt
+++ b/deal-core/src/main/kotlin/com/chaltteok/core/event/OrderPlacedEvent.kt
@@ -6,4 +6,5 @@ data class OrderPlacedEvent(
     val userId: Long,
     val dailyStockId: Long,
     val paymentMethod: PaymentMethod,
+    val quantity: Int = 1,
 )


### PR DESCRIPTION
## Summary
- 타임세일 이벤트 상품 주문 시 \`quantity\`가 Kafka 이벤트에 포함되지 않아 재고 차감·결제금액·OrderItem이 항상 1개 기준으로 저장되는 버그 수정
- \`OrderPlacedEvent\` → \`OrderConfirmService\`까지 전체 파이프라인에 \`quantity\` 전파

## Changes

| 파일 | 변경 내용 |
|------|-----------|
| `OrderPlacedEvent.kt` | `quantity: Int = 1` 필드 추가 (기본값으로 역호환) |
| `OrderEventProducer.kt` | `sendOrderEvent()`에 `quantity` 파라미터 추가 |
| `OrderServiceImpl.kt` | `request.quantity`를 Kafka 이벤트에 전달 |
| `OrderEventConsumer.kt` | `event.quantity`를 `processOrder()`에 전달 |
| `OrderProcessService.kt` | 인터페이스 시그니처에 `quantity` 추가 |
| `OrderProcessServiceImpl.kt` | `quantity` 수신 및 하위 서비스에 전파 |
| `StockDecrementHelper.kt` | `remainStock -= quantity` (기존: 항상 -1) |
| `OrderConfirmService.kt` | `totalPrice = salePrice * quantity`, `OrderItem.quantity = quantity` |

## Test plan
- [ ] 수량 2 이상으로 이벤트 주문 시 재고가 해당 수량만큼 차감되는지 확인
- [ ] OrderItem.quantity가 요청 수량과 일치하는지 확인
- [ ] Payment.amount가 salePrice × quantity인지 확인
- [ ] quantity=1 기본 케이스 정상 동작 확인

Resolves #127

🤖 Generated with Claude Code