### PR TITLE
[FIX] 알림 벨 클릭 시 orderNumber null — Notification 엔티티에 orderNumber 필드 추가

### DIFF
--- a/db/migration/add_notifications_order_number.sql
+++ b/db/migration/add_notifications_order_number.sql
@@ -1,0 +1,2 @@
+ALTER TABLE tb_notifications
+    ADD COLUMN IF NOT EXISTS order_number VARCHAR(50) NULL;

--- a/deal-api-owner/src/main/kotlin/com/chaltteok/owner/notification/dto/NotificationResponse.kt
+++ b/deal-api-owner/src/main/kotlin/com/chaltteok/owner/notification/dto/NotificationResponse.kt
@@ -10,6 +10,7 @@ class NotificationResponse(
     val title: String,
     val message: String,
     @get:JsonProperty("isRead") val isRead: Boolean,
+    val orderNumber: String?,
     val createdAt: LocalDateTime,
 ) {
     companion object {
@@ -19,6 +20,7 @@ class NotificationResponse(
             title = notification.title,
             message = notification.message,
             isRead = notification.isRead,
+            orderNumber = notification.orderNumber,
             createdAt = notification.createdAt,
         )
     }

--- a/deal-consumer/src/main/kotlin/com/chaltteok/consumer/notification/consumer/NotificationConsumer.kt
+++ b/deal-consumer/src/main/kotlin/com/chaltteok/consumer/notification/consumer/NotificationConsumer.kt
@@ -30,6 +30,7 @@ class NotificationConsumer(
                 type = NotificationType.ORDER.name,
                 title = "새 주문이 들어왔습니다",
                 message = "${event.productName} (%,d원)".format(event.totalAmount),
+                orderNumber = event.orderNumber,
             )
         )
     }

--- a/deal-core/src/main/kotlin/com/chaltteok/core/domain/Notification.kt
+++ b/deal-core/src/main/kotlin/com/chaltteok/core/domain/Notification.kt
@@ -17,6 +17,9 @@ class Notification(
 
     @Column(name = "is_read", nullable = false)
     var isRead: Boolean = false,
+
+    @Column(name = "order_number", nullable = true, length = 50)
+    val orderNumber: String? = null,
 ) : BaseEntity() {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)


### PR DESCRIPTION
## Summary
- `Notification` 엔티티에 `order_number` 컬럼 추가 (VARCHAR 50, nullable)
- `NotificationConsumer`에서 알림 저장 시 `event.orderNumber` 포함
- `NotificationResponse` DTO에 `orderNumber` 필드 추가 및 매핑
- DB 마이그레이션 SQL 추가

## Changes
| 파일 | 변경 내용 |
|------|----------|
| `deal-core/.../domain/Notification.kt` | `orderNumber: String? = null` 필드 + `@Column` 추가 |
| `deal-consumer/.../NotificationConsumer.kt` | `orderNumber = event.orderNumber` 저장 |
| `deal-api-owner/.../NotificationResponse.kt` | `orderNumber: String?` 필드 + `from()` 매핑 |
| `db/migration/add_notifications_order_number.sql` | ALTER TABLE 마이그레이션 |

## Test plan
- [ ] 주문 완료 후 알림 생성 시 `order_number` 컬럼에 값 저장 확인
- [ ] `/api/v1/owner/notifications` 응답에 `orderNumber` 필드 포함 확인
- [ ] 기존 알림(orderNumber null)도 정상 응답 확인

Resolves #129

🤖 Generated with Claude Code