### PR TITLE
[FEAT] 점주 앱 주문 상세 조회 API — GET /api/v1/owner/orders/{orderNumber}

### DIFF
--- a/deal-api-owner/src/main/kotlin/com/chaltteok/owner/order/controller/OwnerOrderController.kt
+++ b/deal-api-owner/src/main/kotlin/com/chaltteok/owner/order/controller/OwnerOrderController.kt
@@ -1,0 +1,18 @@
+package com.chaltteok.owner.order.controller
+
+import com.chaltteok.common.dto.ResponseDTO
+import com.chaltteok.owner.order.dto.OwnerOrderDetailResponse
+import com.chaltteok.owner.order.service.OwnerOrderService
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/v1/owner/orders")
+class OwnerOrderController(private val ownerOrderService: OwnerOrderService) {
+
+    @GetMapping("/{orderNumber}")
+    fun getOrderDetail(@PathVariable orderNumber: String): ResponseDTO<OwnerOrderDetailResponse> =
+        ResponseDTO.success(ownerOrderService.getOrderDetail(orderNumber))
+}

--- a/deal-api-owner/src/main/kotlin/com/chaltteok/owner/order/dto/OwnerOrderDetailResponse.kt
+++ b/deal-api-owner/src/main/kotlin/com/chaltteok/owner/order/dto/OwnerOrderDetailResponse.kt
@@ -1,0 +1,28 @@
+package com.chaltteok.owner.order.dto
+
+import com.chaltteok.core.domain.Order
+import com.chaltteok.core.domain.OrderItem
+import com.chaltteok.core.domain.Payment
+import java.time.LocalDateTime
+
+class OwnerOrderDetailResponse(
+    val orderNumber: String,
+    val totalPrice: Int,
+    val status: String,
+    val orderedAt: LocalDateTime,
+    val items: List<OwnerOrderItemResponse>,
+    val payment: OwnerOrderPaymentResponse?,
+    val canCancel: Boolean,
+) {
+    companion object {
+        fun from(order: Order, items: List<OrderItem>, payment: Payment?) = OwnerOrderDetailResponse(
+            orderNumber = order.orderNumber,
+            totalPrice = order.totalPrice,
+            status = order.status.name,
+            orderedAt = order.orderedAt,
+            items = items.map { OwnerOrderItemResponse.from(it) },
+            payment = payment?.let { OwnerOrderPaymentResponse.from(it) },
+            canCancel = order.isCancellable(),
+        )
+    }
+}

--- a/deal-api-owner/src/main/kotlin/com/chaltteok/owner/order/dto/OwnerOrderItemResponse.kt
+++ b/deal-api-owner/src/main/kotlin/com/chaltteok/owner/order/dto/OwnerOrderItemResponse.kt
@@ -1,0 +1,17 @@
+package com.chaltteok.owner.order.dto
+
+import com.chaltteok.core.domain.OrderItem
+
+class OwnerOrderItemResponse(
+    val productName: String,
+    val quantity: Int,
+    val price: Int,
+) {
+    companion object {
+        fun from(item: OrderItem) = OwnerOrderItemResponse(
+            productName = item.product.name,
+            quantity = item.quantity,
+            price = item.price,
+        )
+    }
+}

--- a/deal-api-owner/src/main/kotlin/com/chaltteok/owner/order/dto/OwnerOrderPaymentResponse.kt
+++ b/deal-api-owner/src/main/kotlin/com/chaltteok/owner/order/dto/OwnerOrderPaymentResponse.kt
@@ -1,0 +1,20 @@
+package com.chaltteok.owner.order.dto
+
+import com.chaltteok.core.domain.Payment
+import java.time.LocalDateTime
+
+class OwnerOrderPaymentResponse(
+    val amount: Int,
+    val paymentMethod: String?,
+    val status: String,
+    val paidAt: LocalDateTime?,
+) {
+    companion object {
+        fun from(payment: Payment) = OwnerOrderPaymentResponse(
+            amount = payment.amount,
+            paymentMethod = payment.paymentMethod,
+            status = payment.status.name,
+            paidAt = payment.paidAt,
+        )
+    }
+}

--- a/deal-api-owner/src/main/kotlin/com/chaltteok/owner/order/service/OwnerOrderService.kt
+++ b/deal-api-owner/src/main/kotlin/com/chaltteok/owner/order/service/OwnerOrderService.kt
@@ -1,0 +1,7 @@
+package com.chaltteok.owner.order.service
+
+import com.chaltteok.owner.order.dto.OwnerOrderDetailResponse
+
+interface OwnerOrderService {
+    fun getOrderDetail(orderNumber: String): OwnerOrderDetailResponse
+}

--- a/deal-api-owner/src/main/kotlin/com/chaltteok/owner/order/service/OwnerOrderServiceImpl.kt
+++ b/deal-api-owner/src/main/kotlin/com/chaltteok/owner/order/service/OwnerOrderServiceImpl.kt
@@ -1,0 +1,27 @@
+package com.chaltteok.owner.order.service
+
+import com.chaltteok.core.repository.order.OrderRepository
+import com.chaltteok.core.repository.orderitem.OrderItemRepository
+import com.chaltteok.core.repository.payment.PaymentRepository
+import com.chaltteok.owner.order.dto.OwnerOrderDetailResponse
+import org.springframework.http.HttpStatus
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import org.springframework.web.server.ResponseStatusException
+
+@Service
+class OwnerOrderServiceImpl(
+    private val orderRepository: OrderRepository,
+    private val orderItemRepository: OrderItemRepository,
+    private val paymentRepository: PaymentRepository,
+) : OwnerOrderService {
+
+    @Transactional(readOnly = true)
+    override fun getOrderDetail(orderNumber: String): OwnerOrderDetailResponse {
+        val order = orderRepository.findByOrderNumber(orderNumber)
+            ?: throw ResponseStatusException(HttpStatus.NOT_FOUND, "주문을 찾을 수 없습니다: $orderNumber")
+        val items = orderItemRepository.findByOrderIdWithProduct(order.id!!)
+        val payment = paymentRepository.findByOrderId(order.id!!)
+        return OwnerOrderDetailResponse.from(order, items, payment)
+    }
+}


### PR DESCRIPTION
## Summary
- 알림 벨 클릭 → `/orders/{orderNumber}` 라우팅 시 호출되는 API가 없어 404(No static resource) 발생
- `GET /api/v1/owner/orders/{orderNumber}` 엔드포인트 신설

## Changes
| 파일 | 변경 내용 |
|------|----------|
| `OwnerOrderController.kt` | `GET /{orderNumber}` 엔드포인트 |
| `OwnerOrderService.kt` | 인터페이스 |
| `OwnerOrderServiceImpl.kt` | `OrderRepository` + `OrderItemRepository` + `PaymentRepository` 조합 조회 |
| `OwnerOrderDetailResponse.kt` | 주문 상세 DTO |
| `OwnerOrderItemResponse.kt` | 주문 상품 항목 DTO |
| `OwnerOrderPaymentResponse.kt` | 결제 정보 DTO |

## Test plan
- [ ] `GET /api/v1/owner/orders/{orderNumber}` 200 응답 확인
- [ ] 존재하지 않는 orderNumber → 404 응답 확인
- [ ] 알림 벨 클릭 → 주문 상세 페이지 정상 렌더링 확인

Resolves #131

🤖 Generated with Claude Code