### PR TITLE
[FEAT] 점주 앱 주문 목록 조회 API — GET /api/v1/owner/orders

### DIFF
--- a/db/migration/add_orders_status_ordered_at_index.sql
+++ b/db/migration/add_orders_status_ordered_at_index.sql
@@ -1,0 +1,2 @@
+-- ordered_at 기반 정렬 쿼리 최적화 인덱스
+CREATE INDEX idx_orders_ordered_at ON tb_orders (ordered_at DESC);

--- a/deal-api-owner/src/main/kotlin/com/chaltteok/owner/order/controller/OwnerOrderController.kt
+++ b/deal-api-owner/src/main/kotlin/com/chaltteok/owner/order/controller/OwnerOrderController.kt
@@ -2,15 +2,25 @@ package com.chaltteok.owner.order.controller
 
 import com.chaltteok.common.dto.ResponseDTO
 import com.chaltteok.owner.order.dto.OwnerOrderDetailResponse
+import com.chaltteok.owner.order.dto.OwnerOrderListResponse
 import com.chaltteok.owner.order.service.OwnerOrderService
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 
 @RestController
 @RequestMapping("/api/v1/owner/orders")
 class OwnerOrderController(private val ownerOrderService: OwnerOrderService) {
+
+    @GetMapping
+    fun getOrders(
+        @RequestParam(required = false) status: String?,
+        @RequestParam(defaultValue = "0") page: Int,
+        @RequestParam(defaultValue = "20") size: Int,
+    ): ResponseDTO<OwnerOrderListResponse> =
+        ResponseDTO.success(ownerOrderService.getOrders(status, page, size))
 
     @GetMapping("/{orderNumber}")
     fun getOrderDetail(@PathVariable orderNumber: String): ResponseDTO<OwnerOrderDetailResponse> =

--- a/deal-api-owner/src/main/kotlin/com/chaltteok/owner/order/controller/OwnerOrderController.kt
+++ b/deal-api-owner/src/main/kotlin/com/chaltteok/owner/order/controller/OwnerOrderController.kt
@@ -1,6 +1,7 @@
 package com.chaltteok.owner.order.controller
 
 import com.chaltteok.common.dto.ResponseDTO
+import com.chaltteok.core.domain.enums.OrderStatus
 import com.chaltteok.owner.order.dto.OwnerOrderDetailResponse
 import com.chaltteok.owner.order.dto.OwnerOrderListResponse
 import com.chaltteok.owner.order.service.OwnerOrderService
@@ -16,7 +17,7 @@ class OwnerOrderController(private val ownerOrderService: OwnerOrderService) {
 
     @GetMapping
     fun getOrders(
-        @RequestParam(required = false) status: String?,
+        @RequestParam(required = false) status: OrderStatus?,
         @RequestParam(defaultValue = "0") page: Int,
         @RequestParam(defaultValue = "20") size: Int,
     ): ResponseDTO<OwnerOrderListResponse> =

--- a/deal-api-owner/src/main/kotlin/com/chaltteok/owner/order/dto/OwnerOrderListResponse.kt
+++ b/deal-api-owner/src/main/kotlin/com/chaltteok/owner/order/dto/OwnerOrderListResponse.kt
@@ -1,0 +1,9 @@
+package com.chaltteok.owner.order.dto
+
+class OwnerOrderListResponse(
+    val content: List<OwnerOrderSummaryResponse>,
+    val totalElements: Long,
+    val totalPages: Int,
+    val currentPage: Int,
+    val pageSize: Int,
+)

--- a/deal-api-owner/src/main/kotlin/com/chaltteok/owner/order/dto/OwnerOrderSummaryResponse.kt
+++ b/deal-api-owner/src/main/kotlin/com/chaltteok/owner/order/dto/OwnerOrderSummaryResponse.kt
@@ -1,0 +1,12 @@
+package com.chaltteok.owner.order.dto
+
+import java.time.LocalDateTime
+
+class OwnerOrderSummaryResponse(
+    val orderNumber: String,
+    val productName: String,
+    val totalPrice: Int,
+    val status: String,
+    val orderedAt: LocalDateTime,
+    val itemCount: Int,
+)

--- a/deal-api-owner/src/main/kotlin/com/chaltteok/owner/order/service/OwnerOrderService.kt
+++ b/deal-api-owner/src/main/kotlin/com/chaltteok/owner/order/service/OwnerOrderService.kt
@@ -1,9 +1,10 @@
 package com.chaltteok.owner.order.service
 
+import com.chaltteok.core.domain.enums.OrderStatus
 import com.chaltteok.owner.order.dto.OwnerOrderDetailResponse
 import com.chaltteok.owner.order.dto.OwnerOrderListResponse
 
 interface OwnerOrderService {
     fun getOrderDetail(orderNumber: String): OwnerOrderDetailResponse
-    fun getOrders(status: String?, page: Int, size: Int): OwnerOrderListResponse
+    fun getOrders(status: OrderStatus?, page: Int, size: Int): OwnerOrderListResponse
 }

--- a/deal-api-owner/src/main/kotlin/com/chaltteok/owner/order/service/OwnerOrderService.kt
+++ b/deal-api-owner/src/main/kotlin/com/chaltteok/owner/order/service/OwnerOrderService.kt
@@ -1,7 +1,9 @@
 package com.chaltteok.owner.order.service
 
 import com.chaltteok.owner.order.dto.OwnerOrderDetailResponse
+import com.chaltteok.owner.order.dto.OwnerOrderListResponse
 
 interface OwnerOrderService {
     fun getOrderDetail(orderNumber: String): OwnerOrderDetailResponse
+    fun getOrders(status: String?, page: Int, size: Int): OwnerOrderListResponse
 }

--- a/deal-api-owner/src/main/kotlin/com/chaltteok/owner/order/service/OwnerOrderServiceImpl.kt
+++ b/deal-api-owner/src/main/kotlin/com/chaltteok/owner/order/service/OwnerOrderServiceImpl.kt
@@ -1,9 +1,13 @@
 package com.chaltteok.owner.order.service
 
+import com.chaltteok.core.domain.enums.OrderStatus
 import com.chaltteok.core.repository.order.OrderRepository
 import com.chaltteok.core.repository.orderitem.OrderItemRepository
 import com.chaltteok.core.repository.payment.PaymentRepository
 import com.chaltteok.owner.order.dto.OwnerOrderDetailResponse
+import com.chaltteok.owner.order.dto.OwnerOrderListResponse
+import com.chaltteok.owner.order.dto.OwnerOrderSummaryResponse
+import org.springframework.data.domain.PageRequest
 import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -23,5 +27,43 @@ class OwnerOrderServiceImpl(
         val items = orderItemRepository.findByOrderIdWithProduct(order.id!!)
         val payment = paymentRepository.findByOrderId(order.id!!)
         return OwnerOrderDetailResponse.from(order, items, payment)
+    }
+
+    @Transactional(readOnly = true)
+    override fun getOrders(status: String?, page: Int, size: Int): OwnerOrderListResponse {
+        val pageable = PageRequest.of(page, size)
+        val orderPage = if (status != null) {
+            val orderStatus = runCatching { OrderStatus.valueOf(status) }
+                .getOrElse { throw ResponseStatusException(HttpStatus.BAD_REQUEST, "유효하지 않은 주문 상태: $status") }
+            orderRepository.findAllByStatusOrderByOrderedAtDesc(orderStatus, pageable)
+        } else {
+            orderRepository.findAllByOrderByOrderedAtDesc(pageable)
+        }
+
+        val orderIds = orderPage.content.mapNotNull { it.id }
+        val itemsByOrderId = orderItemRepository.findByOrderIdsWithProduct(orderIds)
+            .groupBy { it.order?.id }
+
+        val content = orderPage.content.map { order ->
+            val items = itemsByOrderId[order.id] ?: emptyList()
+            val firstName = items.firstOrNull()?.product?.name ?: "-"
+            val productName = if (items.size > 1) "$firstName 외 ${items.size - 1}건" else firstName
+            OwnerOrderSummaryResponse(
+                orderNumber = order.orderNumber,
+                productName = productName,
+                totalPrice = order.totalPrice,
+                status = order.status.name,
+                orderedAt = order.orderedAt,
+                itemCount = items.size,
+            )
+        }
+
+        return OwnerOrderListResponse(
+            content = content,
+            totalElements = orderPage.totalElements,
+            totalPages = orderPage.totalPages,
+            currentPage = orderPage.number,
+            pageSize = orderPage.size,
+        )
     }
 }

--- a/deal-api-owner/src/main/kotlin/com/chaltteok/owner/order/service/OwnerOrderServiceImpl.kt
+++ b/deal-api-owner/src/main/kotlin/com/chaltteok/owner/order/service/OwnerOrderServiceImpl.kt
@@ -1,5 +1,6 @@
 package com.chaltteok.owner.order.service
 
+import com.chaltteok.core.domain.OrderItem
 import com.chaltteok.core.domain.enums.OrderStatus
 import com.chaltteok.core.repository.order.OrderRepository
 import com.chaltteok.core.repository.orderitem.OrderItemRepository
@@ -30,27 +31,25 @@ class OwnerOrderServiceImpl(
     }
 
     @Transactional(readOnly = true)
-    override fun getOrders(status: String?, page: Int, size: Int): OwnerOrderListResponse {
-        val pageable = PageRequest.of(page, size)
+    override fun getOrders(status: OrderStatus?, page: Int, size: Int): OwnerOrderListResponse {
+        val safePage = page.coerceAtLeast(0)
+        val safeSize = size.coerceIn(1, 100)
+        val pageable = PageRequest.of(safePage, safeSize)
+
         val orderPage = if (status != null) {
-            val orderStatus = runCatching { OrderStatus.valueOf(status) }
-                .getOrElse { throw ResponseStatusException(HttpStatus.BAD_REQUEST, "유효하지 않은 주문 상태: $status") }
-            orderRepository.findAllByStatusOrderByOrderedAtDesc(orderStatus, pageable)
+            orderRepository.findAllByStatusOrderByOrderedAtDesc(status, pageable)
         } else {
             orderRepository.findAllByOrderByOrderedAtDesc(pageable)
         }
 
         val orderIds = orderPage.content.mapNotNull { it.id }
-        val itemsByOrderId = orderItemRepository.findByOrderIdsWithProduct(orderIds)
-            .groupBy { it.order?.id }
+        val itemsByOrderId = fetchItemsByOrderId(orderIds)
 
         val content = orderPage.content.map { order ->
             val items = itemsByOrderId[order.id] ?: emptyList()
-            val firstName = items.firstOrNull()?.product?.name ?: "-"
-            val productName = if (items.size > 1) "$firstName 외 ${items.size - 1}건" else firstName
             OwnerOrderSummaryResponse(
                 orderNumber = order.orderNumber,
-                productName = productName,
+                productName = buildProductName(items),
                 totalPrice = order.totalPrice,
                 status = order.status.name,
                 orderedAt = order.orderedAt,
@@ -65,5 +64,13 @@ class OwnerOrderServiceImpl(
             currentPage = orderPage.number,
             pageSize = orderPage.size,
         )
+    }
+
+    private fun fetchItemsByOrderId(orderIds: List<Long>): Map<Long?, List<OrderItem>> =
+        orderItemRepository.findByOrderIdsWithProduct(orderIds).groupBy { it.order?.id }
+
+    private fun buildProductName(items: List<OrderItem>): String {
+        val firstName = items.firstOrNull()?.product?.name ?: "-"
+        return if (items.size > 1) "$firstName 외 ${items.size - 1}건" else firstName
     }
 }

--- a/deal-core/src/main/kotlin/com/chaltteok/core/repository/order/OrderRepository.kt
+++ b/deal-core/src/main/kotlin/com/chaltteok/core/repository/order/OrderRepository.kt
@@ -1,6 +1,9 @@
 package com.chaltteok.core.repository.order
 
 import com.chaltteok.core.domain.Order
+import com.chaltteok.core.domain.enums.OrderStatus
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.JpaRepository
 import java.util.Optional
 
@@ -8,4 +11,6 @@ interface OrderRepository : JpaRepository<Order, Long>, OrderRepositoryCustom {
     fun findByUser_IdOrderByOrderedAtDesc(userId: Long): List<Order>
     fun findByOrderNumber(orderNumber: String): Order?
     fun findByOrderNumberAndUser_Id(orderNumber: String, userId: Long): Optional<Order>
+    fun findAllByOrderByOrderedAtDesc(pageable: Pageable): Page<Order>
+    fun findAllByStatusOrderByOrderedAtDesc(status: OrderStatus, pageable: Pageable): Page<Order>
 }


### PR DESCRIPTION
## Summary
- 점주 앱 주문관리 페이지에서 호출할 주문 목록 조회 API 신설
- status 필터(COMPLETED/PENDING/CANCELLED) + 페이지네이션 지원

## Changes
| 파일 | 변경 내용 |
|------|----------|
| `OrderRepository.kt` | `findAllByOrderByOrderedAtDesc`, `findAllByStatusOrderByOrderedAtDesc` 추가 |
| `OwnerOrderSummaryResponse.kt` | 신규 DTO |
| `OwnerOrderListResponse.kt` | 신규 페이지 DTO |
| `OwnerOrderService.kt` | `getOrders()` 메서드 추가 |
| `OwnerOrderServiceImpl.kt` | `findByOrderIdsWithProduct` 배치 조회 활용 구현 |
| `OwnerOrderController.kt` | `GET /api/v1/owner/orders` 엔드포인트 추가 |

## Test plan
- [ ] 전체 목록 조회 확인
- [ ] status=COMPLETED 필터 확인
- [ ] 페이지네이션 동작 확인

Resolves #133
🤖 Generated with Claude Code