### PR TITLE
[FEAT] 점주 주문관리 기간별 필터링 추가

### DIFF
--- a/deal-api-owner/src/main/kotlin/com/chaltteok/owner/order/controller/OwnerOrderController.kt
+++ b/deal-api-owner/src/main/kotlin/com/chaltteok/owner/order/controller/OwnerOrderController.kt
@@ -10,6 +10,7 @@ import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
+import java.time.LocalDate
 
 @RestController
 @RequestMapping("/api/v1/owner/orders")
@@ -18,10 +19,12 @@ class OwnerOrderController(private val ownerOrderService: OwnerOrderService) {
     @GetMapping
     fun getOrders(
         @RequestParam(required = false) status: OrderStatus?,
+        @RequestParam(required = false) startDate: LocalDate?,
+        @RequestParam(required = false) endDate: LocalDate?,
         @RequestParam(defaultValue = "0") page: Int,
         @RequestParam(defaultValue = "20") size: Int,
     ): ResponseDTO<OwnerOrderListResponse> =
-        ResponseDTO.success(ownerOrderService.getOrders(status, page, size))
+        ResponseDTO.success(ownerOrderService.getOrders(status, startDate, endDate, page, size))
 
     @GetMapping("/{orderNumber}")
     fun getOrderDetail(@PathVariable orderNumber: String): ResponseDTO<OwnerOrderDetailResponse> =

--- a/deal-api-owner/src/main/kotlin/com/chaltteok/owner/order/service/OwnerOrderService.kt
+++ b/deal-api-owner/src/main/kotlin/com/chaltteok/owner/order/service/OwnerOrderService.kt
@@ -3,8 +3,9 @@ package com.chaltteok.owner.order.service
 import com.chaltteok.core.domain.enums.OrderStatus
 import com.chaltteok.owner.order.dto.OwnerOrderDetailResponse
 import com.chaltteok.owner.order.dto.OwnerOrderListResponse
+import java.time.LocalDate
 
 interface OwnerOrderService {
     fun getOrderDetail(orderNumber: String): OwnerOrderDetailResponse
-    fun getOrders(status: OrderStatus?, page: Int, size: Int): OwnerOrderListResponse
+    fun getOrders(status: OrderStatus?, startDate: LocalDate?, endDate: LocalDate?, page: Int, size: Int): OwnerOrderListResponse
 }

--- a/deal-api-owner/src/main/kotlin/com/chaltteok/owner/order/service/OwnerOrderServiceImpl.kt
+++ b/deal-api-owner/src/main/kotlin/com/chaltteok/owner/order/service/OwnerOrderServiceImpl.kt
@@ -14,6 +14,7 @@ import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import org.springframework.web.server.ResponseStatusException
 import java.time.LocalDate
+import java.time.temporal.ChronoUnit
 
 @Service
 class OwnerOrderServiceImpl(
@@ -33,6 +34,14 @@ class OwnerOrderServiceImpl(
 
     @Transactional(readOnly = true)
     override fun getOrders(status: OrderStatus?, startDate: LocalDate?, endDate: LocalDate?, page: Int, size: Int): OwnerOrderListResponse {
+        if (startDate != null && endDate != null) {
+            if (startDate.isAfter(endDate)) {
+                throw ResponseStatusException(HttpStatus.BAD_REQUEST, "startDate must not be after endDate")
+            }
+            if (ChronoUnit.DAYS.between(startDate, endDate) > 365) {
+                throw ResponseStatusException(HttpStatus.BAD_REQUEST, "Date range must not exceed 365 days")
+            }
+        }
         val safePage = page.coerceAtLeast(0)
         val safeSize = size.coerceIn(1, 100)
         val pageable = PageRequest.of(safePage, safeSize)

--- a/deal-api-owner/src/main/kotlin/com/chaltteok/owner/order/service/OwnerOrderServiceImpl.kt
+++ b/deal-api-owner/src/main/kotlin/com/chaltteok/owner/order/service/OwnerOrderServiceImpl.kt
@@ -13,6 +13,7 @@ import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import org.springframework.web.server.ResponseStatusException
+import java.time.LocalDate
 
 @Service
 class OwnerOrderServiceImpl(
@@ -31,16 +32,12 @@ class OwnerOrderServiceImpl(
     }
 
     @Transactional(readOnly = true)
-    override fun getOrders(status: OrderStatus?, page: Int, size: Int): OwnerOrderListResponse {
+    override fun getOrders(status: OrderStatus?, startDate: LocalDate?, endDate: LocalDate?, page: Int, size: Int): OwnerOrderListResponse {
         val safePage = page.coerceAtLeast(0)
         val safeSize = size.coerceIn(1, 100)
         val pageable = PageRequest.of(safePage, safeSize)
 
-        val orderPage = if (status != null) {
-            orderRepository.findAllByStatusOrderByOrderedAtDesc(status, pageable)
-        } else {
-            orderRepository.findAllByOrderByOrderedAtDesc(pageable)
-        }
+        val orderPage = orderRepository.findAllByOwnerFilter(status, startDate, endDate, pageable)
 
         val orderIds = orderPage.content.mapNotNull { it.id }
         val itemsByOrderId = fetchItemsByOrderId(orderIds)

--- a/deal-core/src/main/kotlin/com/chaltteok/core/repository/order/OrderRepositoryCustom.kt
+++ b/deal-core/src/main/kotlin/com/chaltteok/core/repository/order/OrderRepositoryCustom.kt
@@ -23,4 +23,11 @@ interface OrderRepositoryCustom {
         paymentStatus: String?,
         pageable: Pageable,
     ): Page<Order>
+
+    fun findAllByOwnerFilter(
+        status: OrderStatus?,
+        startDate: LocalDate?,
+        endDate: LocalDate?,
+        pageable: Pageable,
+    ): Page<Order>
 }

--- a/deal-core/src/main/kotlin/com/chaltteok/core/repository/order/OrderRepositoryImpl.kt
+++ b/deal-core/src/main/kotlin/com/chaltteok/core/repository/order/OrderRepositoryImpl.kt
@@ -155,4 +155,38 @@ class OrderRepositoryImpl(private val jpaQueryFactory: JPAQueryFactory) : OrderR
 
         return PageImpl(content, pageable, total)
     }
+
+    override fun findAllByOwnerFilter(
+        status: OrderStatus?,
+        startDate: LocalDate?,
+        endDate: LocalDate?,
+        pageable: Pageable,
+    ): Page<Order> {
+        var predicate = qOrder.isNotNull
+        if (status != null) {
+            predicate = predicate.and(qOrder.status.eq(status))
+        }
+        if (startDate != null) {
+            predicate = predicate.and(qOrder.orderedAt.goe(startDate.atStartOfDay()))
+        }
+        if (endDate != null) {
+            predicate = predicate.and(qOrder.orderedAt.loe(endDate.atTime(23, 59, 59)))
+        }
+
+        val content = jpaQueryFactory
+            .selectFrom(qOrder)
+            .where(predicate)
+            .orderBy(qOrder.orderedAt.desc())
+            .offset(pageable.offset)
+            .limit(pageable.pageSize.toLong())
+            .fetch()
+
+        val total = jpaQueryFactory
+            .select(qOrder.count())
+            .from(qOrder)
+            .where(predicate)
+            .fetchOne() ?: 0L
+
+        return PageImpl(content, pageable, total)
+    }
 }

--- a/deal-core/src/main/kotlin/com/chaltteok/core/repository/order/OrderRepositoryImpl.kt
+++ b/deal-core/src/main/kotlin/com/chaltteok/core/repository/order/OrderRepositoryImpl.kt
@@ -15,6 +15,7 @@ import org.springframework.data.domain.Pageable
 import org.springframework.stereotype.Repository
 import java.time.LocalDate
 import java.time.LocalDateTime
+import java.time.LocalTime
 
 @Repository
 class OrderRepositoryImpl(private val jpaQueryFactory: JPAQueryFactory) : OrderRepositoryCustom {
@@ -170,7 +171,7 @@ class OrderRepositoryImpl(private val jpaQueryFactory: JPAQueryFactory) : OrderR
             predicate = predicate.and(qOrder.orderedAt.goe(startDate.atStartOfDay()))
         }
         if (endDate != null) {
-            predicate = predicate.and(qOrder.orderedAt.loe(endDate.atTime(23, 59, 59)))
+            predicate = predicate.and(qOrder.orderedAt.loe(endDate.atTime(LocalTime.MAX)))
         }
 
         val content = jpaQueryFactory


### PR DESCRIPTION
## Summary
점주 주문 목록 API에 기간별 필터링 기능을 추가합니다.

## Changes

| 파일 | 변경 내용 |
|------|----------|
| `deal-core/.../OrderRepositoryCustom.kt` | `findAllByOwnerFilter` 인터페이스 추가 |
| `deal-core/.../OrderRepositoryImpl.kt` | QueryDSL 동적 조건 구현 (status/startDate/endDate) |
| `deal-api-owner/.../OwnerOrderService.kt` | `getOrders` 시그니처 파라미터 추가 |
| `deal-api-owner/.../OwnerOrderServiceImpl.kt` | 단일 `findAllByOwnerFilter` 호출로 리팩토링 |
| `deal-api-owner/.../OwnerOrderController.kt` | `startDate`, `endDate` 쿼리 파라미터 추가 |

## API 변경
```
GET /api/v1/owner/orders?status=COMPLETED&startDate=2026-06-01&endDate=2026-06-17&page=0&size=20
```
- `startDate` / `endDate`: `yyyy-MM-dd` 형식, 선택 사항
- 기존 `status` 필터와 조합 가능

## Test plan
- [ ] 날짜 파라미터 없이 기존 호출 정상 동작
- [ ] startDate만 지정 시 해당 날짜 이후 주문만 반환
- [ ] endDate만 지정 시 해당 날짜 이전 주문만 반환
- [ ] startDate + endDate 범위 필터링 정상 동작
- [ ] status + 날짜 복합 필터 정상 동작

Resolves #143

🤖 Generated with Claude Code