### PR TITLE
[FEAT] 주문 확정 시 점주 실시간 알림 SSE 구현

### DIFF
--- a/deal-api-owner/src/main/kotlin/com/chaltteok/owner/config/SseKafkaConfig.kt
+++ b/deal-api-owner/src/main/kotlin/com/chaltteok/owner/config/SseKafkaConfig.kt
@@ -1,0 +1,32 @@
+package com.chaltteok.owner.config
+
+import org.apache.kafka.clients.consumer.ConsumerRecord
+import org.apache.kafka.common.TopicPartition
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.kafka.annotation.EnableKafka
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory
+import org.springframework.kafka.core.ConsumerFactory
+import org.springframework.kafka.core.KafkaTemplate
+import org.springframework.kafka.listener.DeadLetterPublishingRecoverer
+import org.springframework.kafka.listener.DefaultErrorHandler
+import org.springframework.util.backoff.FixedBackOff
+
+@EnableKafka
+@Configuration
+class SseKafkaConfig(private val kafkaTemplate: KafkaTemplate<String, String>) {
+
+    @Bean
+    fun sseKafkaListenerContainerFactory(
+        consumerFactory: ConsumerFactory<String, String>,
+    ): ConcurrentKafkaListenerContainerFactory<String, String> {
+        val recoverer = DeadLetterPublishingRecoverer(kafkaTemplate) { record: ConsumerRecord<*, *>, _: Exception ->
+            TopicPartition("${record.topic()}.DLT", record.partition())
+        }
+        val errorHandler = DefaultErrorHandler(recoverer, FixedBackOff(1000L, 3L))
+        return ConcurrentKafkaListenerContainerFactory<String, String>().apply {
+            this.consumerFactory = consumerFactory
+            setCommonErrorHandler(errorHandler)
+        }
+    }
+}

--- a/deal-api-owner/src/main/kotlin/com/chaltteok/owner/sse/OrderNotificationKafkaListener.kt
+++ b/deal-api-owner/src/main/kotlin/com/chaltteok/owner/sse/OrderNotificationKafkaListener.kt
@@ -1,0 +1,35 @@
+package com.chaltteok.owner.sse
+
+import com.chaltteok.core.common.KafkaTopics
+import com.chaltteok.core.event.OrderCompletedEvent
+import com.fasterxml.jackson.databind.ObjectMapper
+import io.github.oshai.kotlinlogging.KotlinLogging
+import org.springframework.kafka.annotation.KafkaListener
+import org.springframework.stereotype.Component
+
+private val log = KotlinLogging.logger {}
+
+@Component
+class OrderNotificationKafkaListener(
+    private val sseService: OrderNotificationSseService,
+    private val objectMapper: ObjectMapper,
+) {
+    @KafkaListener(
+        topics = [KafkaTopics.ORDER_COMPLETED],
+        groupId = "deal-owner-sse-group",
+        containerFactory = "sseKafkaListenerContainerFactory",
+    )
+    fun consume(message: String) {
+        val event = objectMapper.readValue(message, OrderCompletedEvent::class.java)
+        log.info { "주문 완료 이벤트 수신 → SSE 브로드캐스트 — orderNumber=${event.orderNumber}" }
+        sseService.broadcast(
+            eventName = "order-confirmed",
+            data = mapOf(
+                "orderNumber" to event.orderNumber,
+                "userName" to event.userName,
+                "productName" to event.productName,
+                "totalAmount" to event.totalAmount,
+            )
+        )
+    }
+}

--- a/deal-api-owner/src/main/kotlin/com/chaltteok/owner/sse/OrderNotificationSseController.kt
+++ b/deal-api-owner/src/main/kotlin/com/chaltteok/owner/sse/OrderNotificationSseController.kt
@@ -1,0 +1,20 @@
+package com.chaltteok.owner.sse
+
+import org.springframework.http.MediaType
+import org.springframework.security.core.Authentication
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter
+
+@RestController
+@RequestMapping("/api/v1/owner/notifications")
+class OrderNotificationSseController(
+    private val sseService: OrderNotificationSseService,
+) {
+    @GetMapping("/sse", produces = [MediaType.TEXT_EVENT_STREAM_VALUE])
+    fun subscribe(authentication: Authentication): SseEmitter {
+        val userId = authentication.principal as Long
+        return sseService.subscribe(userId)
+    }
+}

--- a/deal-api-owner/src/main/kotlin/com/chaltteok/owner/sse/OrderNotificationSseService.kt
+++ b/deal-api-owner/src/main/kotlin/com/chaltteok/owner/sse/OrderNotificationSseService.kt
@@ -1,0 +1,40 @@
+package com.chaltteok.owner.sse
+
+import io.github.oshai.kotlinlogging.KotlinLogging
+import org.springframework.stereotype.Service
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter
+import java.util.concurrent.ConcurrentHashMap
+
+private val log = KotlinLogging.logger {}
+
+@Service
+class OrderNotificationSseService {
+
+    private val emitters = ConcurrentHashMap<Long, SseEmitter>()
+
+    fun subscribe(userId: Long): SseEmitter {
+        val emitter = SseEmitter(Long.MAX_VALUE)
+        emitters[userId] = emitter
+        emitter.onCompletion { emitters.remove(userId) }
+        emitter.onTimeout { emitters.remove(userId) }
+        emitter.onError { emitters.remove(userId) }
+        runCatching {
+            emitter.send(SseEmitter.event().name("connected").data("ok"))
+        }
+        log.info { "SSE 구독 등록 — userId=$userId, 연결 수=${emitters.size}" }
+        return emitter
+    }
+
+    fun broadcast(eventName: String, data: Any) {
+        val deadKeys = mutableListOf<Long>()
+        emitters.forEach { (userId, emitter) ->
+            runCatching {
+                emitter.send(SseEmitter.event().name(eventName).data(data))
+            }.onFailure {
+                log.warn { "SSE 전송 실패 — userId=$userId" }
+                deadKeys += userId
+            }
+        }
+        deadKeys.forEach { emitters.remove(it) }
+    }
+}

--- a/deal-common-api/src/main/kotlin/com/chaltteok/common/security/jwt/JwtAuthenticationFilter.kt
+++ b/deal-common-api/src/main/kotlin/com/chaltteok/common/security/jwt/JwtAuthenticationFilter.kt
@@ -35,6 +35,8 @@ class JwtAuthenticationFilter(
     private fun resolveToken(request: HttpServletRequest): String? {
         val bearer = request.getHeader("Authorization")
         if (bearer != null && bearer.startsWith("Bearer ")) return bearer.substring(7)
-        return request.getParameter("token")
+        // EventSource는 커스텀 헤더를 지원하지 않으므로 SSE 엔드포인트에 한해 쿼리 파라미터 토큰 허용
+        if (request.requestURI.endsWith("/notifications/sse")) return request.getParameter("token")
+        return null
     }
 }

--- a/deal-common-api/src/main/kotlin/com/chaltteok/common/security/jwt/JwtAuthenticationFilter.kt
+++ b/deal-common-api/src/main/kotlin/com/chaltteok/common/security/jwt/JwtAuthenticationFilter.kt
@@ -33,7 +33,8 @@ class JwtAuthenticationFilter(
     }
 
     private fun resolveToken(request: HttpServletRequest): String? {
-        val bearer = request.getHeader("Authorization") ?: return null
-        return if (bearer.startsWith("Bearer ")) bearer.substring(7) else null
+        val bearer = request.getHeader("Authorization")
+        if (bearer != null && bearer.startsWith("Bearer ")) return bearer.substring(7)
+        return request.getParameter("token")
     }
 }


### PR DESCRIPTION
## Summary
- Kafka `order-completed-events` 토픽을 새 consumer group(`deal-owner-sse-group`)으로 구독하여 deal-consumer 변경 없이 실시간 알림 파이프라인 구성
- `JwtAuthenticationFilter`에 `?token=` 쿼리 파라미터 인증 추가 (EventSource 헤더 미지원 대응)
- `GET /api/v1/owner/notifications/sse` 엔드포인트로 점주 브라우저에 SSE 스트림 제공

## Changes

| 파일 | 변경 |
|------|------|
| `deal-common-api/.../JwtAuthenticationFilter.kt` | `resolveToken()`: `?token=` 쿼리 파라미터 fallback 추가 |
| `deal-api-owner/.../config/SseKafkaConfig.kt` | `sseKafkaListenerContainerFactory` 빈 (DLT + FixedBackOff 3회) |
| `deal-api-owner/.../sse/OrderNotificationSseService.kt` | `ConcurrentHashMap<Long, SseEmitter>` 풀, `broadcast()` |
| `deal-api-owner/.../sse/OrderNotificationKafkaListener.kt` | `@KafkaListener(topics=["order-completed-events"], groupId="deal-owner-sse-group")` |
| `deal-api-owner/.../sse/OrderNotificationSseController.kt` | `GET /api/v1/owner/notifications/sse` (`text/event-stream`) |

## Test plan
- [ ] 점주 로그인 후 `/api/v1/owner/notifications/sse?token={jwt}` 구독 확인
- [ ] 유저 앱에서 주문 완료 시 점주 브라우저에 `order-confirmed` 이벤트 수신 확인
- [ ] 점주 앱 `NotificationBell` 즉시 갱신 확인
- [ ] 점주 재접속(브라우저 새로고침) 시 SSE 재연결 확인
- [ ] 기존 이메일 consumer(`deal-email-group`) 영향 없음 확인

Resolves #147

🤖 Generated with Claude Code