### PR TITLE
[FEAT] 쿠폰 발행/관리 API 및 결제 시 쿠폰 할인 적용

### DIFF
--- a/db/migration/add_coupon_table.sql
+++ b/db/migration/add_coupon_table.sql
@@ -1,0 +1,18 @@
+CREATE TABLE tb_coupons (
+    coupon_id     BIGINT AUTO_INCREMENT PRIMARY KEY,
+    coupon_uuid   VARCHAR(36)  NOT NULL UNIQUE,
+    code          VARCHAR(50)  NOT NULL UNIQUE COMMENT '쿠폰 코드',
+    name          VARCHAR(100) NOT NULL COMMENT '쿠폰 이름',
+    discount_type VARCHAR(10)  NOT NULL COMMENT 'RATE(정률) 또는 AMOUNT(정액)',
+    discount_value INT          NOT NULL COMMENT '할인율(%) 또는 할인금액(원)',
+    min_order_amount INT        NULL COMMENT '최소 주문금액',
+    max_discount_amount INT     NULL COMMENT '최대 할인 한도(정률 쿠폰)',
+    total_quantity INT          NULL COMMENT '총 발행 수량 (NULL=무제한)',
+    used_quantity  INT          NOT NULL DEFAULT 0 COMMENT '사용된 수량',
+    start_date    DATE          NOT NULL,
+    end_date      DATE          NOT NULL,
+    is_active     TINYINT(1)   NOT NULL DEFAULT 1,
+    version       BIGINT       NOT NULL DEFAULT 0 COMMENT '낙관적 락',
+    created_at    DATETIME     NOT NULL,
+    updated_at    DATETIME     NOT NULL
+);

--- a/deal-api-owner/src/main/kotlin/com/chaltteok/owner/coupon/controller/OwnerCouponController.kt
+++ b/deal-api-owner/src/main/kotlin/com/chaltteok/owner/coupon/controller/OwnerCouponController.kt
@@ -1,0 +1,41 @@
+package com.chaltteok.owner.coupon.controller
+
+import com.chaltteok.common.dto.ResponseDTO
+import com.chaltteok.owner.coupon.dto.CouponRequest
+import com.chaltteok.owner.coupon.dto.CouponResponse
+import com.chaltteok.owner.coupon.service.OwnerCouponService
+import jakarta.validation.Valid
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.*
+
+@RestController
+@RequestMapping("/api/v1/owner/coupons")
+class OwnerCouponController(
+    private val couponService: OwnerCouponService,
+) {
+    @GetMapping
+    fun getCoupons(): ResponseEntity<ResponseDTO<List<CouponResponse>>> =
+        ResponseEntity.ok(ResponseDTO.success(couponService.getCoupons()))
+
+    @PostMapping
+    fun createCoupon(@Valid @RequestBody request: CouponRequest): ResponseEntity<ResponseDTO<CouponResponse>> =
+        ResponseEntity.status(HttpStatus.CREATED).body(ResponseDTO.success(couponService.createCoupon(request)))
+
+    @PutMapping("/{couponUuid}")
+    fun updateCoupon(
+        @PathVariable couponUuid: String,
+        @Valid @RequestBody request: CouponRequest,
+    ): ResponseEntity<ResponseDTO<CouponResponse>> =
+        ResponseEntity.ok(ResponseDTO.success(couponService.updateCoupon(couponUuid, request)))
+
+    @DeleteMapping("/{couponUuid}")
+    fun deleteCoupon(@PathVariable couponUuid: String): ResponseEntity<Void> {
+        couponService.deleteCoupon(couponUuid)
+        return ResponseEntity.noContent().build()
+    }
+
+    @PatchMapping("/{couponUuid}/toggle")
+    fun toggleActive(@PathVariable couponUuid: String): ResponseEntity<ResponseDTO<CouponResponse>> =
+        ResponseEntity.ok(ResponseDTO.success(couponService.toggleActive(couponUuid)))
+}

--- a/deal-api-owner/src/main/kotlin/com/chaltteok/owner/coupon/dto/CouponRequest.kt
+++ b/deal-api-owner/src/main/kotlin/com/chaltteok/owner/coupon/dto/CouponRequest.kt
@@ -1,0 +1,27 @@
+package com.chaltteok.owner.coupon.dto
+
+import com.chaltteok.core.domain.enums.DiscountType
+import jakarta.validation.constraints.*
+import java.time.LocalDate
+
+data class CouponRequest(
+    @field:NotBlank @field:Size(max = 50)
+    val code: String,
+    @field:NotBlank @field:Size(max = 100)
+    val name: String,
+    @field:NotNull
+    val discountType: DiscountType,
+    @field:Min(1)
+    val discountValue: Int,
+    @field:Min(0)
+    val minOrderAmount: Int? = null,
+    @field:Min(0)
+    val maxDiscountAmount: Int? = null,
+    @field:Min(1)
+    val totalQuantity: Int? = null,
+    @field:NotNull
+    val startDate: LocalDate,
+    @field:NotNull
+    val endDate: LocalDate,
+    val isActive: Boolean = true,
+)

--- a/deal-api-owner/src/main/kotlin/com/chaltteok/owner/coupon/dto/CouponResponse.kt
+++ b/deal-api-owner/src/main/kotlin/com/chaltteok/owner/coupon/dto/CouponResponse.kt
@@ -1,0 +1,37 @@
+package com.chaltteok.owner.coupon.dto
+
+import com.chaltteok.core.domain.Coupon
+
+data class CouponResponse(
+    val couponUuid: String,
+    val code: String,
+    val name: String,
+    val discountType: String,
+    val discountValue: Int,
+    val minOrderAmount: Int?,
+    val maxDiscountAmount: Int?,
+    val totalQuantity: Int?,
+    val usedQuantity: Int,
+    val startDate: String,
+    val endDate: String,
+    val isActive: Boolean,
+    val createdAt: String,
+) {
+    companion object {
+        fun from(coupon: Coupon) = CouponResponse(
+            couponUuid = coupon.couponUuid,
+            code = coupon.code,
+            name = coupon.name,
+            discountType = coupon.discountType.name,
+            discountValue = coupon.discountValue,
+            minOrderAmount = coupon.minOrderAmount,
+            maxDiscountAmount = coupon.maxDiscountAmount,
+            totalQuantity = coupon.totalQuantity,
+            usedQuantity = coupon.usedQuantity,
+            startDate = coupon.startDate.toString(),
+            endDate = coupon.endDate.toString(),
+            isActive = coupon.isActive,
+            createdAt = coupon.createdAt.toString(),
+        )
+    }
+}

--- a/deal-api-owner/src/main/kotlin/com/chaltteok/owner/coupon/enums/CouponErrorCode.kt
+++ b/deal-api-owner/src/main/kotlin/com/chaltteok/owner/coupon/enums/CouponErrorCode.kt
@@ -1,0 +1,12 @@
+package com.chaltteok.owner.coupon.enums
+
+import com.chaltteok.common.enums.ErrorCode
+import org.springframework.http.HttpStatus
+
+enum class CouponErrorCode(
+    override val status: HttpStatus,
+    override val message: String,
+) : ErrorCode {
+    COUPON_NOT_FOUND(HttpStatus.NOT_FOUND, "쿠폰을 찾을 수 없습니다."),
+    COUPON_CODE_DUPLICATE(HttpStatus.CONFLICT, "이미 사용 중인 쿠폰 코드입니다."),
+}

--- a/deal-api-owner/src/main/kotlin/com/chaltteok/owner/coupon/service/OwnerCouponService.kt
+++ b/deal-api-owner/src/main/kotlin/com/chaltteok/owner/coupon/service/OwnerCouponService.kt
@@ -1,0 +1,12 @@
+package com.chaltteok.owner.coupon.service
+
+import com.chaltteok.owner.coupon.dto.CouponRequest
+import com.chaltteok.owner.coupon.dto.CouponResponse
+
+interface OwnerCouponService {
+    fun getCoupons(): List<CouponResponse>
+    fun createCoupon(request: CouponRequest): CouponResponse
+    fun updateCoupon(couponUuid: String, request: CouponRequest): CouponResponse
+    fun deleteCoupon(couponUuid: String)
+    fun toggleActive(couponUuid: String): CouponResponse
+}

--- a/deal-api-owner/src/main/kotlin/com/chaltteok/owner/coupon/service/OwnerCouponServiceImpl.kt
+++ b/deal-api-owner/src/main/kotlin/com/chaltteok/owner/coupon/service/OwnerCouponServiceImpl.kt
@@ -1,0 +1,86 @@
+package com.chaltteok.owner.coupon.service
+
+import com.chaltteok.common.exception.BusinessException
+import com.chaltteok.core.domain.Coupon
+import com.chaltteok.core.repository.coupon.CouponRepository
+import com.chaltteok.owner.coupon.dto.CouponRequest
+import com.chaltteok.owner.coupon.dto.CouponResponse
+import com.chaltteok.owner.coupon.enums.CouponErrorCode
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class OwnerCouponServiceImpl(
+    private val couponRepository: CouponRepository,
+) : OwnerCouponService {
+
+    @Transactional(readOnly = true)
+    override fun getCoupons(): List<CouponResponse> =
+        couponRepository.findAllByOrderByCreatedAtDesc().map { CouponResponse.from(it) }
+
+    @Transactional
+    override fun createCoupon(request: CouponRequest): CouponResponse {
+        if (couponRepository.findByCode(request.code.uppercase().trim()).isPresent) {
+            throw BusinessException(CouponErrorCode.COUPON_CODE_DUPLICATE)
+        }
+        val coupon = couponRepository.save(
+            Coupon(
+                code = request.code.uppercase().trim(),
+                name = request.name,
+                discountType = request.discountType,
+                discountValue = request.discountValue,
+                minOrderAmount = request.minOrderAmount,
+                maxDiscountAmount = request.maxDiscountAmount,
+                totalQuantity = request.totalQuantity,
+                startDate = request.startDate,
+                endDate = request.endDate,
+                isActive = request.isActive,
+            )
+        )
+        return CouponResponse.from(coupon)
+    }
+
+    @Transactional
+    override fun updateCoupon(couponUuid: String, request: CouponRequest): CouponResponse {
+        val coupon = couponRepository.findByCouponUuid(couponUuid)
+            .orElseThrow { BusinessException(CouponErrorCode.COUPON_NOT_FOUND) }
+        // code 중복 체크 (자기 자신 제외)
+        couponRepository.findByCode(request.code.uppercase().trim())
+            .ifPresent { existing ->
+                if (existing.couponUuid != couponUuid) throw BusinessException(CouponErrorCode.COUPON_CODE_DUPLICATE)
+            }
+        // Coupon은 불변 설계이므로 삭제 후 재생성 방식 채택
+        couponRepository.delete(coupon)
+        val newCoupon = couponRepository.save(
+            Coupon(
+                code = request.code.uppercase().trim(),
+                name = request.name,
+                discountType = request.discountType,
+                discountValue = request.discountValue,
+                minOrderAmount = request.minOrderAmount,
+                maxDiscountAmount = request.maxDiscountAmount,
+                totalQuantity = request.totalQuantity,
+                usedQuantity = coupon.usedQuantity, // 사용 이력 유지
+                startDate = request.startDate,
+                endDate = request.endDate,
+                isActive = request.isActive,
+            )
+        )
+        return CouponResponse.from(newCoupon)
+    }
+
+    @Transactional
+    override fun deleteCoupon(couponUuid: String) {
+        val coupon = couponRepository.findByCouponUuid(couponUuid)
+            .orElseThrow { BusinessException(CouponErrorCode.COUPON_NOT_FOUND) }
+        couponRepository.delete(coupon)
+    }
+
+    @Transactional
+    override fun toggleActive(couponUuid: String): CouponResponse {
+        val coupon = couponRepository.findByCouponUuid(couponUuid)
+            .orElseThrow { BusinessException(CouponErrorCode.COUPON_NOT_FOUND) }
+        coupon.toggleActive()
+        return CouponResponse.from(coupon)
+    }
+}

--- a/deal-api-user/src/main/kotlin/com/chaltteok/user/coupon/controller/CouponController.kt
+++ b/deal-api-user/src/main/kotlin/com/chaltteok/user/coupon/controller/CouponController.kt
@@ -1,0 +1,20 @@
+package com.chaltteok.user.coupon.controller
+
+import com.chaltteok.common.dto.ResponseDTO
+import com.chaltteok.user.coupon.dto.CouponValidateResponse
+import com.chaltteok.user.coupon.service.CouponService
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.*
+
+@RestController
+@RequestMapping("/api/v1/user/coupons")
+class CouponController(
+    private val couponService: CouponService,
+) {
+    @GetMapping("/validate")
+    fun validate(
+        @RequestParam code: String,
+        @RequestParam amount: Int,
+    ): ResponseEntity<ResponseDTO<CouponValidateResponse>> =
+        ResponseEntity.ok(ResponseDTO.success(couponService.validate(code, amount)))
+}

--- a/deal-api-user/src/main/kotlin/com/chaltteok/user/coupon/dto/CouponValidateResponse.kt
+++ b/deal-api-user/src/main/kotlin/com/chaltteok/user/coupon/dto/CouponValidateResponse.kt
@@ -1,0 +1,9 @@
+package com.chaltteok.user.coupon.dto
+
+data class CouponValidateResponse(
+    val couponName: String,
+    val discountType: String,
+    val discountValue: Int,
+    val discountAmount: Int,
+    val finalAmount: Int,
+)

--- a/deal-api-user/src/main/kotlin/com/chaltteok/user/coupon/enums/CouponErrorCode.kt
+++ b/deal-api-user/src/main/kotlin/com/chaltteok/user/coupon/enums/CouponErrorCode.kt
@@ -1,0 +1,15 @@
+package com.chaltteok.user.coupon.enums
+
+import com.chaltteok.common.enums.ErrorCode
+import org.springframework.http.HttpStatus
+
+enum class CouponErrorCode(
+    override val status: HttpStatus,
+    override val message: String,
+) : ErrorCode {
+    COUPON_NOT_FOUND(HttpStatus.NOT_FOUND, "쿠폰을 찾을 수 없습니다."),
+    COUPON_INVALID(HttpStatus.BAD_REQUEST, "유효하지 않은 쿠폰입니다."),
+    COUPON_EXPIRED(HttpStatus.BAD_REQUEST, "만료된 쿠폰입니다."),
+    COUPON_EXHAUSTED(HttpStatus.BAD_REQUEST, "쿠폰 수량이 소진되었습니다."),
+    COUPON_MIN_ORDER_NOT_MET(HttpStatus.BAD_REQUEST, "최소 주문금액을 충족하지 않습니다."),
+}

--- a/deal-api-user/src/main/kotlin/com/chaltteok/user/coupon/service/CouponService.kt
+++ b/deal-api-user/src/main/kotlin/com/chaltteok/user/coupon/service/CouponService.kt
@@ -1,0 +1,7 @@
+package com.chaltteok.user.coupon.service
+
+import com.chaltteok.user.coupon.dto.CouponValidateResponse
+
+interface CouponService {
+    fun validate(code: String, orderAmount: Int): CouponValidateResponse
+}

--- a/deal-api-user/src/main/kotlin/com/chaltteok/user/coupon/service/CouponServiceImpl.kt
+++ b/deal-api-user/src/main/kotlin/com/chaltteok/user/coupon/service/CouponServiceImpl.kt
@@ -1,0 +1,38 @@
+package com.chaltteok.user.coupon.service
+
+import com.chaltteok.common.exception.BusinessException
+import com.chaltteok.core.repository.coupon.CouponRepository
+import com.chaltteok.user.coupon.dto.CouponValidateResponse
+import com.chaltteok.user.coupon.enums.CouponErrorCode
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDate
+
+@Service
+class CouponServiceImpl(
+    private val couponRepository: CouponRepository,
+) : CouponService {
+
+    @Transactional(readOnly = true)
+    override fun validate(code: String, orderAmount: Int): CouponValidateResponse {
+        val coupon = couponRepository.findByCode(code.uppercase().trim())
+            .orElseThrow { BusinessException(CouponErrorCode.COUPON_NOT_FOUND) }
+
+        val today = LocalDate.now()
+        if (!coupon.isActive) throw BusinessException(CouponErrorCode.COUPON_INVALID)
+        if (today < coupon.startDate || today > coupon.endDate) throw BusinessException(CouponErrorCode.COUPON_EXPIRED)
+        val totalQuantity = coupon.totalQuantity
+        if (totalQuantity != null && coupon.usedQuantity >= totalQuantity) throw BusinessException(CouponErrorCode.COUPON_EXHAUSTED)
+        val minOrderAmount = coupon.minOrderAmount
+        if (minOrderAmount != null && orderAmount < minOrderAmount) throw BusinessException(CouponErrorCode.COUPON_MIN_ORDER_NOT_MET)
+
+        val discountAmount = coupon.calculateDiscount(orderAmount)
+        return CouponValidateResponse(
+            couponName = coupon.name,
+            discountType = coupon.discountType.name,
+            discountValue = coupon.discountValue,
+            discountAmount = discountAmount,
+            finalAmount = orderAmount - discountAmount,
+        )
+    }
+}

--- a/deal-api-user/src/main/kotlin/com/chaltteok/user/infrastructure/kafka/OrderEventProducer.kt
+++ b/deal-api-user/src/main/kotlin/com/chaltteok/user/infrastructure/kafka/OrderEventProducer.kt
@@ -16,9 +16,9 @@ class OrderEventProducer(
     private val kafkaTemplate: KafkaTemplate<String, String>,
     private val objectMapper: ObjectMapper,
 ) {
-    fun sendOrderEvent(userId: Long, timeSaleStockId: Long, quantity: Int, paymentMethod: PaymentMethod) {
+    fun sendOrderEvent(userId: Long, timeSaleStockId: Long, quantity: Int, paymentMethod: PaymentMethod, couponCode: String? = null) {
         val payload = objectMapper.writeValueAsString(
-            OrderPlacedEvent(userId = userId, timeSaleStockId = timeSaleStockId, paymentMethod = paymentMethod, quantity = quantity)
+            OrderPlacedEvent(userId = userId, timeSaleStockId = timeSaleStockId, paymentMethod = paymentMethod, quantity = quantity, couponCode = couponCode)
         )
         kafkaTemplate.send(TOPIC, userId.toString(), payload)
             .whenComplete { result, ex ->

--- a/deal-api-user/src/main/kotlin/com/chaltteok/user/order/dto/OrderRequest.kt
+++ b/deal-api-user/src/main/kotlin/com/chaltteok/user/order/dto/OrderRequest.kt
@@ -12,4 +12,5 @@ data class OrderRequest(
     @field:Max(value = 100, message = "1회 최대 구매 수량은 100개입니다")
     val quantity: Int = 1,
     val paymentMethod: PaymentMethod,
+    val couponCode: String? = null,
 )

--- a/deal-api-user/src/main/kotlin/com/chaltteok/user/order/service/OrderServiceImpl.kt
+++ b/deal-api-user/src/main/kotlin/com/chaltteok/user/order/service/OrderServiceImpl.kt
@@ -62,7 +62,7 @@ class OrderServiceImpl(
         }
 
         val timeSaleStockId = timeSaleStock.id ?: error("TimeSaleStock ID가 null입니다")
-        orderEventProducer.sendOrderEvent(userId, timeSaleStockId, request.quantity, request.paymentMethod)
+        orderEventProducer.sendOrderEvent(userId, timeSaleStockId, request.quantity, request.paymentMethod, request.couponCode)
         logger.info { "타임세일 주문 이벤트 발행 — stockUuid=${request.stockUuid}, userId=$userId, timeSaleStockId=$timeSaleStockId" }
 
         return OrderResponse.pending()

--- a/deal-consumer/src/main/kotlin/com/chaltteok/consumer/order/consumer/OrderEventConsumer.kt
+++ b/deal-consumer/src/main/kotlin/com/chaltteok/consumer/order/consumer/OrderEventConsumer.kt
@@ -26,6 +26,7 @@ class OrderEventConsumer(
                 timeSaleStockId = event.timeSaleStockId,
                 quantity = event.quantity,
                 paymentMethod = event.paymentMethod,
+                couponCode = event.couponCode,
             )
         )
     }

--- a/deal-consumer/src/main/kotlin/com/chaltteok/consumer/order/service/OrderConfirmService.kt
+++ b/deal-consumer/src/main/kotlin/com/chaltteok/consumer/order/service/OrderConfirmService.kt
@@ -11,6 +11,7 @@ import com.chaltteok.core.domain.enums.PaymentMethod
 import com.chaltteok.core.domain.enums.PaymentStatus
 import com.chaltteok.core.event.OrderCompletedEvent
 import com.chaltteok.core.infrastructure.outbox.OutboxEventWriter
+import com.chaltteok.core.repository.coupon.CouponRepository
 import com.chaltteok.core.repository.eventhistory.EventHistoryRepository
 import com.chaltteok.core.repository.order.OrderRepository
 import com.chaltteok.core.repository.orderitem.OrderItemRepository
@@ -29,10 +30,21 @@ class OrderConfirmService(
     private val paymentRepository: PaymentRepository,
     private val eventHistoryRepository: EventHistoryRepository,
     private val outboxEventWriter: OutboxEventWriter,
+    private val couponRepository: CouponRepository,
 ) {
     @Transactional
-    fun confirmOrder(user: User, timeSaleStock: TimeSaleStock, quantity: Int, paymentMethod: PaymentMethod) {
-        val totalPrice = timeSaleStock.salePrice.toLong() * quantity
+    fun confirmOrder(user: User, timeSaleStock: TimeSaleStock, quantity: Int, paymentMethod: PaymentMethod, couponCode: String? = null) {
+        var totalPrice = timeSaleStock.salePrice.toLong() * quantity
+
+        if (couponCode != null) {
+            couponRepository.findByCode(couponCode.uppercase().trim()).ifPresent { coupon ->
+                if (coupon.isValid(totalPrice.toInt())) {
+                    val discountAmount = coupon.calculateDiscount(totalPrice.toInt())
+                    totalPrice = maxOf(0L, totalPrice - discountAmount)
+                    coupon.use()
+                }
+            }
+        }
 
         val order = orderRepository.save(
             Order(user = user, totalPrice = totalPrice.toInt(), status = OrderStatus.COMPLETED)

--- a/deal-consumer/src/main/kotlin/com/chaltteok/consumer/order/service/OrderConfirmService.kt
+++ b/deal-consumer/src/main/kotlin/com/chaltteok/consumer/order/service/OrderConfirmService.kt
@@ -37,7 +37,8 @@ class OrderConfirmService(
         var totalPrice = timeSaleStock.salePrice.toLong() * quantity
 
         if (couponCode != null) {
-            couponRepository.findByCode(couponCode.uppercase().trim()).ifPresent { coupon ->
+            // PESSIMISTIC_WRITE: 동시 Kafka 메시지에서 수량 초과 사용 방지
+            couponRepository.findByCodeForUpdate(couponCode.uppercase().trim()).ifPresent { coupon ->
                 if (coupon.isValid(totalPrice.toInt())) {
                     val discountAmount = coupon.calculateDiscount(totalPrice.toInt())
                     totalPrice = maxOf(0L, totalPrice - discountAmount)

--- a/deal-consumer/src/main/kotlin/com/chaltteok/consumer/order/service/OrderProcessCommand.kt
+++ b/deal-consumer/src/main/kotlin/com/chaltteok/consumer/order/service/OrderProcessCommand.kt
@@ -7,4 +7,5 @@ data class OrderProcessCommand(
     val timeSaleStockId: Long,
     val quantity: Int,
     val paymentMethod: PaymentMethod,
+    val couponCode: String? = null,
 )

--- a/deal-consumer/src/main/kotlin/com/chaltteok/consumer/order/service/OrderProcessServiceImpl.kt
+++ b/deal-consumer/src/main/kotlin/com/chaltteok/consumer/order/service/OrderProcessServiceImpl.kt
@@ -70,7 +70,7 @@ class OrderProcessServiceImpl(
                 }
             }
             // 별도 빈을 통해 호출 → Spring 프록시 경유 → @Transactional 적용
-            orderConfirmService.confirmOrder(user, timeSaleStock, command.quantity, command.paymentMethod)
+            orderConfirmService.confirmOrder(user, timeSaleStock, command.quantity, command.paymentMethod, command.couponCode)
         }
     }
 }

--- a/deal-core/src/main/kotlin/com/chaltteok/core/domain/Coupon.kt
+++ b/deal-core/src/main/kotlin/com/chaltteok/core/domain/Coupon.kt
@@ -1,0 +1,98 @@
+package com.chaltteok.core.domain
+
+import com.chaltteok.core.domain.enums.DiscountType
+import jakarta.persistence.*
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.util.*
+
+@Entity
+@Table(
+    name = "tb_coupons",
+    uniqueConstraints = [
+        UniqueConstraint(name = "uk_coupon_uuid", columnNames = ["coupon_uuid"]),
+        UniqueConstraint(name = "uk_coupon_code", columnNames = ["code"]),
+    ]
+)
+class Coupon(
+    @Column(name = "code", nullable = false, unique = true, length = 50)
+    val code: String,
+
+    @Column(name = "name", nullable = false, length = 100)
+    val name: String,
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "discount_type", nullable = false, length = 10)
+    val discountType: DiscountType,
+
+    @Column(name = "discount_value", nullable = false)
+    val discountValue: Int,
+
+    @Column(name = "min_order_amount")
+    val minOrderAmount: Int? = null,
+
+    @Column(name = "max_discount_amount")
+    val maxDiscountAmount: Int? = null,
+
+    @Column(name = "total_quantity")
+    val totalQuantity: Int? = null,
+
+    @Column(name = "used_quantity", nullable = false)
+    var usedQuantity: Int = 0,
+
+    @Column(name = "start_date", nullable = false)
+    val startDate: LocalDate,
+
+    @Column(name = "end_date", nullable = false)
+    val endDate: LocalDate,
+
+    @Column(name = "is_active", nullable = false)
+    var isActive: Boolean = true,
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    val createdAt: LocalDateTime = LocalDateTime.now(),
+
+    @Column(name = "updated_at", nullable = false)
+    var updatedAt: LocalDateTime = LocalDateTime.now(),
+) {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "coupon_id")
+    var id: Long? = null
+
+    @Column(name = "coupon_uuid", nullable = false, unique = true, length = 36)
+    val couponUuid: String = UUID.randomUUID().toString()
+
+    @Version
+    @Column(name = "version")
+    var version: Long = 0
+
+    fun isValid(orderAmount: Int): Boolean {
+        val today = LocalDate.now()
+        if (!isActive) return false
+        if (today < startDate || today > endDate) return false
+        if (totalQuantity != null && usedQuantity >= totalQuantity) return false
+        if (minOrderAmount != null && orderAmount < minOrderAmount) return false
+        return true
+    }
+
+    fun calculateDiscount(orderAmount: Int): Int {
+        return when (discountType) {
+            DiscountType.AMOUNT -> minOf(discountValue, orderAmount)
+            DiscountType.RATE -> {
+                val discount = orderAmount * discountValue / 100
+                if (maxDiscountAmount != null) minOf(discount, maxDiscountAmount) else discount
+            }
+        }
+    }
+
+    fun use() {
+        usedQuantity++
+        updatedAt = LocalDateTime.now()
+    }
+
+    fun toggleActive() {
+        isActive = !isActive
+        updatedAt = LocalDateTime.now()
+    }
+}

--- a/deal-core/src/main/kotlin/com/chaltteok/core/domain/enums/DiscountType.kt
+++ b/deal-core/src/main/kotlin/com/chaltteok/core/domain/enums/DiscountType.kt
@@ -1,0 +1,6 @@
+package com.chaltteok.core.domain.enums
+
+enum class DiscountType {
+    RATE,    // 정률 할인 (%)
+    AMOUNT,  // 정액 할인 (원)
+}

--- a/deal-core/src/main/kotlin/com/chaltteok/core/event/OrderPlacedEvent.kt
+++ b/deal-core/src/main/kotlin/com/chaltteok/core/event/OrderPlacedEvent.kt
@@ -9,4 +9,5 @@ data class OrderPlacedEvent(
     val paymentMethod: PaymentMethod,
     @JsonProperty(defaultValue = "1")
     val quantity: Int = 1,
+    val couponCode: String? = null,
 )

--- a/deal-core/src/main/kotlin/com/chaltteok/core/repository/coupon/CouponRepository.kt
+++ b/deal-core/src/main/kotlin/com/chaltteok/core/repository/coupon/CouponRepository.kt
@@ -1,11 +1,19 @@
 package com.chaltteok.core.repository.coupon
 
 import com.chaltteok.core.domain.Coupon
+import jakarta.persistence.LockModeType
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Lock
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
 import java.util.Optional
 
 interface CouponRepository : JpaRepository<Coupon, Long> {
     fun findByCouponUuid(uuid: String): Optional<Coupon>
     fun findByCode(code: String): Optional<Coupon>
     fun findAllByOrderByCreatedAtDesc(): List<Coupon>
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT c FROM Coupon c WHERE c.code = :code")
+    fun findByCodeForUpdate(@Param("code") code: String): Optional<Coupon>
 }

--- a/deal-core/src/main/kotlin/com/chaltteok/core/repository/coupon/CouponRepository.kt
+++ b/deal-core/src/main/kotlin/com/chaltteok/core/repository/coupon/CouponRepository.kt
@@ -1,0 +1,11 @@
+package com.chaltteok.core.repository.coupon
+
+import com.chaltteok.core.domain.Coupon
+import org.springframework.data.jpa.repository.JpaRepository
+import java.util.Optional
+
+interface CouponRepository : JpaRepository<Coupon, Long> {
+    fun findByCouponUuid(uuid: String): Optional<Coupon>
+    fun findByCode(code: String): Optional<Coupon>
+    fun findAllByOrderByCreatedAtDesc(): List<Coupon>
+}


### PR DESCRIPTION
## Summary
- 점주가 쿠폰을 생성/관리할 수 있는 Owner API 구현
- 유저 결제 시 쿠폰 코드를 입력하여 할인을 받을 수 있는 기능 구현
- Kafka 주문 이벤트에 쿠폰 코드 포함 → 컨슈머에서 할인 적용 후 최종 금액으로 주문 확정

## Changes

| 파일 | 변경 내용 |
|------|----------|
| `db/migration/add_coupon_table.sql` | tb_coupons 테이블 DDL (낙관적 락 version 컬럼 포함) |
| `deal-core/.../domain/enums/DiscountType.kt` | RATE(정률)/AMOUNT(정액) 열거형 신규 |
| `deal-core/.../domain/Coupon.kt` | Coupon 엔티티 (isValid/calculateDiscount/use/toggleActive 메서드) |
| `deal-core/.../repository/coupon/CouponRepository.kt` | CouponRepository 인터페이스 |
| `deal-core/.../event/OrderPlacedEvent.kt` | couponCode 필드 추가 |
| `deal-api-owner/.../coupon/**` | CouponController/Service/DTO/ErrorCode (CRUD + toggle) |
| `deal-api-user/.../coupon/**` | CouponController/Service/DTO/ErrorCode (쿠폰 검증 엔드포인트) |
| `deal-api-user/.../order/dto/OrderRequest.kt` | couponCode 필드 추가 |
| `deal-api-user/.../kafka/OrderEventProducer.kt` | couponCode 포함하여 Kafka 발행 |
| `deal-api-user/.../order/service/OrderServiceImpl.kt` | couponCode 전달 |
| `deal-consumer/.../order/service/OrderProcessCommand.kt` | couponCode 필드 추가 |
| `deal-consumer/.../order/consumer/OrderEventConsumer.kt` | couponCode 추출 및 전달 |
| `deal-consumer/.../order/service/OrderProcessServiceImpl.kt` | couponCode 전달 |
| `deal-consumer/.../order/service/OrderConfirmService.kt` | 쿠폰 검증 → 할인 적용 → use() → 최종금액으로 주문 확정 |

## API Spec

**Owner:**
- `GET /api/v1/owner/coupons` — 쿠폰 목록
- `POST /api/v1/owner/coupons` — 쿠폰 생성
- `PUT /api/v1/owner/coupons/{uuid}` — 쿠폰 수정
- `DELETE /api/v1/owner/coupons/{uuid}` — 쿠폰 삭제
- `PATCH /api/v1/owner/coupons/{uuid}/toggle` — 활성화/비활성화

**User:**
- `GET /api/v1/user/coupons/validate?code=XXX&amount=N` — 쿠폰 검증 및 할인금액 미리보기
- `POST /api/v1/user/orders` — 기존 API, couponCode 필드 추가

## Test plan
- [ ] 쿠폰 생성 (정률/정액 각각)
- [ ] 쿠폰 수정/삭제/활성화 토글
- [ ] 코드 중복 발행 시 COUPON_CODE_DUPLICATE 에러 반환
- [ ] 쿠폰 검증 — 유효/만료/소진/최소주문 미충족 각 케이스
- [ ] 결제 시 couponCode 포함 → 할인 적용된 금액으로 Payment 저장

Resolves #149

🤖 Generated with Claude Code